### PR TITLE
feat: agent activity log + endpoints (refs #27)

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -74,8 +74,35 @@ export function getOutboundDb(): Database {
         updated_at               TEXT NOT NULL
       );
     `);
+    // activity: append-only ledger of tool invocations, drained by the host's
+    // delivery loop into central agent_activity. seq is monotonic and serves
+    // as the host's merge cursor (sessions.activity_synced_seq). Forward-
+    // compat for older outbound.db files. Privacy: never write secret values
+    // or full Bash command strings into `summary` — env-injected creds can
+    // leak via argv. Caller (PreToolUse hook) is responsible.
+    _outbound.exec(`
+      CREATE TABLE IF NOT EXISTS activity (
+        seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts         TEXT NOT NULL,
+        kind       TEXT NOT NULL,
+        target     TEXT,
+        summary    TEXT
+      );
+    `);
   }
   return _outbound;
+}
+
+/**
+ * Append a tool-invocation row to the outbound activity ledger. Called from
+ * the provider's PreToolUse hook. Sanitization is the caller's job — pass
+ * `summary = null` for kinds that may carry secrets (e.g. Bash argv).
+ */
+export function appendActivity(kind: string, target: string | null, summary: string | null): void {
+  const ts = new Date().toISOString();
+  getOutboundDb()
+    .prepare(`INSERT INTO activity (ts, kind, target, summary) VALUES (?, ?, ?, ?)`)
+    .run(ts, kind, target, summary);
 }
 
 /**
@@ -211,6 +238,13 @@ export function initTestSessionDb(): { inbound: Database; outbound: Database } {
       tool_declared_timeout_ms INTEGER,
       tool_started_at          TEXT,
       updated_at               TEXT NOT NULL
+    );
+    CREATE TABLE activity (
+      seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts         TEXT NOT NULL,
+      kind       TEXT NOT NULL,
+      target     TEXT,
+      summary    TEXT
     );
   `);
 

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
 
-import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { appendActivity, clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
 import { registerProvider } from './provider-registry.js';
 import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
 
@@ -164,6 +164,20 @@ const preToolUseHook: HookCallback = async (input) => {
     setContainerToolInFlight(toolName, declaredTimeoutMs);
   } catch (err) {
     log(`PreToolUse: failed to record container_state: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  // Activity ledger — append-only per-invocation row. Kind classifies; target
+  // names the tool. summary is left null for Bash because tool_input.command
+  // can carry env-injected secrets via argv. Other tools' inputs may also
+  // contain secrets, so we keep summary null across the board for now and
+  // tighten case-by-case as the surface stabilizes.
+  try {
+    let kind: string;
+    if (toolName === 'Bash') kind = 'cmd_exec';
+    else if (toolName.startsWith('mcp__')) kind = 'mcp_call';
+    else kind = 'tool_call';
+    appendActivity(kind, toolName || null, null);
+  } catch (err) {
+    log(`PreToolUse: failed to append activity: ${err instanceof Error ? err.message : String(err)}`);
   }
   return { continue: true };
 };

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -5,7 +5,14 @@ import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '
 
 import { appendActivity, clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
 import { registerProvider } from './provider-registry.js';
-import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import type {
+  AgentProvider,
+  AgentQuery,
+  McpServerConfig,
+  ProviderEvent,
+  ProviderOptions,
+  QueryInput,
+} from './types.js';
 
 function log(msg: string): void {
   console.error(`[claude-provider] ${msg}`);
@@ -115,10 +122,15 @@ function parseTranscript(content: string): ParsedMessage[] {
     try {
       const entry = JSON.parse(line);
       if (entry.type === 'user' && entry.message?.content) {
-        const text = typeof entry.message.content === 'string' ? entry.message.content : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        const text =
+          typeof entry.message.content === 'string'
+            ? entry.message.content
+            : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
         if (text) messages.push({ role: 'user', content: text });
       } else if (entry.type === 'assistant' && entry.message?.content) {
-        const textParts = entry.message.content.filter((c: { type: string }) => c.type === 'text').map((c: { text: string }) => c.text);
+        const textParts = entry.message.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { text: string }) => c.text);
         const text = textParts.join('');
         if (text) messages.push({ role: 'assistant', content: text });
       }
@@ -131,7 +143,13 @@ function parseTranscript(content: string): ParsedMessage[] {
 
 function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
   const now = new Date();
-  const dateStr = now.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
+  const dateStr = now.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
   const lines = [`# ${title || 'Conversation'}`, '', `Archived: ${dateStr}`, '', '---', ''];
   for (const msg of messages) {
     const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
@@ -213,20 +231,29 @@ function createPreCompactHook(assistantName?: string): HookCallback {
       if (fs.existsSync(indexPath)) {
         try {
           const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
-          summary = index.entries?.find((e: { sessionId: string; summary?: string }) => e.sessionId === sessionId)?.summary;
+          summary = index.entries?.find(
+            (e: { sessionId: string; summary?: string }) => e.sessionId === sessionId,
+          )?.summary;
         } catch {
           /* ignore */
         }
       }
 
       const name = summary
-        ? summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 50)
+        ? summary
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 50)
         : `conversation-${new Date().getHours().toString().padStart(2, '0')}${new Date().getMinutes().toString().padStart(2, '0')}`;
 
       const conversationsDir = '/workspace/agent/conversations';
       fs.mkdirSync(conversationsDir, { recursive: true });
       const filename = `${new Date().toISOString().split('T')[0]}-${name}.md`;
-      fs.writeFileSync(path.join(conversationsDir, filename), formatTranscriptMarkdown(messages, summary, assistantName));
+      fs.writeFileSync(
+        path.join(conversationsDir, filename),
+        formatTranscriptMarkdown(messages, summary, assistantName),
+      );
       log(`Archived conversation to ${filename}`);
     } catch (err) {
       log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
@@ -286,7 +313,9 @@ export class ClaudeProvider implements AgentProvider {
         additionalDirectories: this.additionalDirectories,
         resume: input.continuation,
         pathToClaudeCodeExecutable: '/pnpm/claude',
-        systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
+        systemPrompt: instructions
+          ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions }
+          : undefined,
         allowedTools: TOOL_ALLOWLIST,
         disallowedTools: SDK_DISALLOWED_TOOLS,
         env: this.env,
@@ -317,7 +346,7 @@ export class ClaudeProvider implements AgentProvider {
         if (message.type === 'system' && message.subtype === 'init') {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
-          const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
+          const text = 'result' in message ? ((message as { result?: string }).result ?? null) : null;
           yield { type: 'result', text };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.3",
+  "version": "0.0.14-rc.4",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/agent-activity.test.ts
+++ b/src/db/agent-activity.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createAgentGroup,
+  createSession,
+  closeDb,
+  getDb,
+  initTestDb,
+  runMigrations,
+} from './index.js';
+import {
+  getActivitySyncedSeq,
+  listActivityByAgentGroup,
+  listActivityBySession,
+  mergeActivityBatch,
+} from './agent-activity.js';
+import type { OutboundActivityRow } from './session-db.js';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function seedAgentAndSession(): { agentGroupId: string; sessionId: string } {
+  createAgentGroup({
+    id: 'ag-1',
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: now(),
+  });
+  createSession({
+    id: 'sess-1',
+    agent_group_id: 'ag-1',
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active',
+    container_status: 'running',
+    last_active: now(),
+    created_at: now(),
+  });
+  return { agentGroupId: 'ag-1', sessionId: 'sess-1' };
+}
+
+function row(seq: number, kind: string, target: string | null, summary: string | null = null): OutboundActivityRow {
+  return { seq, ts: new Date(2026, 0, seq).toISOString(), kind, target, summary };
+}
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('agent_activity merge', () => {
+  it('initial cursor is 0 and merging a batch advances it', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    expect(getActivitySyncedSeq(sessionId)).toBe(0);
+
+    const newCursor = mergeActivityBatch(agentGroupId, sessionId, [
+      row(1, 'tool_call', 'Read'),
+      row(2, 'cmd_exec', 'Bash'),
+      row(3, 'mcp_call', 'mcp__paraclaw__schedule_task'),
+    ]);
+    expect(newCursor).toBe(3);
+    expect(getActivitySyncedSeq(sessionId)).toBe(3);
+
+    const rows = listActivityBySession(sessionId);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.kind).sort()).toEqual(['cmd_exec', 'mcp_call', 'tool_call']);
+  });
+
+  it('empty batch is a no-op and returns the existing cursor', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    mergeActivityBatch(agentGroupId, sessionId, [row(1, 'tool_call', 'Read')]);
+    expect(getActivitySyncedSeq(sessionId)).toBe(1);
+
+    const c = mergeActivityBatch(agentGroupId, sessionId, []);
+    expect(c).toBe(1);
+    expect(listActivityBySession(sessionId)).toHaveLength(1);
+  });
+
+  it('cursor advance is monotonic — re-merging an older batch leaves it unchanged', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    mergeActivityBatch(agentGroupId, sessionId, [row(5, 'tool_call', 'Read'), row(6, 'tool_call', 'Glob')]);
+    expect(getActivitySyncedSeq(sessionId)).toBe(6);
+
+    // The delivery loop guards against this with `seq > cursor`, but if a
+    // caller passes older rows, the cursor should NOT regress.
+    mergeActivityBatch(agentGroupId, sessionId, [row(2, 'tool_call', 'Read')]);
+    expect(getActivitySyncedSeq(sessionId)).toBe(6);
+  });
+
+  it('listActivityByAgentGroup returns rows for a single group, newest first', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    createAgentGroup({
+      id: 'ag-2',
+      name: 'Other',
+      folder: 'other',
+      agent_provider: null,
+      created_at: now(),
+    });
+    createSession({
+      id: 'sess-2',
+      agent_group_id: 'ag-2',
+      messaging_group_id: null,
+      thread_id: null,
+      agent_provider: null,
+      status: 'active',
+      container_status: 'running',
+      last_active: now(),
+      created_at: now(),
+    });
+
+    mergeActivityBatch(agentGroupId, sessionId, [row(1, 'tool_call', 'Read'), row(2, 'cmd_exec', 'Bash')]);
+    mergeActivityBatch('ag-2', 'sess-2', [row(1, 'tool_call', 'Glob')]);
+
+    const ag1 = listActivityByAgentGroup(agentGroupId);
+    expect(ag1).toHaveLength(2);
+    expect(ag1.every((r) => r.agent_group_id === agentGroupId)).toBe(true);
+    // DESC by created_at — row(2) was minted later (Jan 2 > Jan 1).
+    expect(ag1[0].target).toBe('Bash');
+    expect(ag1[1].target).toBe('Read');
+
+    const ag2 = listActivityByAgentGroup('ag-2');
+    expect(ag2).toHaveLength(1);
+    expect(ag2[0].target).toBe('Glob');
+  });
+
+  it('honors `since` and `limit`', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    mergeActivityBatch(agentGroupId, sessionId, [
+      row(1, 'tool_call', 'A'),
+      row(2, 'tool_call', 'B'),
+      row(3, 'tool_call', 'C'),
+      row(4, 'tool_call', 'D'),
+    ]);
+
+    const limited = listActivityBySession(sessionId, { limit: 2 });
+    expect(limited).toHaveLength(2);
+    expect(limited[0].target).toBe('D'); // newest first
+    expect(limited[1].target).toBe('C');
+
+    // since = ts of seq=2 (Jan 2). Should include C (Jan 3) and D (Jan 4).
+    const since = new Date(2026, 0, 2).toISOString();
+    const sinceRows = listActivityBySession(sessionId, { since });
+    expect(sinceRows.map((r) => r.target)).toEqual(['D', 'C']);
+  });
+
+  it('cascades on session delete', () => {
+    const { agentGroupId, sessionId } = seedAgentAndSession();
+    mergeActivityBatch(agentGroupId, sessionId, [row(1, 'tool_call', 'Read')]);
+    expect(listActivityBySession(sessionId)).toHaveLength(1);
+
+    getDb().prepare('DELETE FROM sessions WHERE id = ?').run(sessionId);
+    expect(listActivityBySession(sessionId)).toHaveLength(0);
+    expect(listActivityByAgentGroup(agentGroupId)).toHaveLength(0);
+  });
+});

--- a/src/db/agent-activity.test.ts
+++ b/src/db/agent-activity.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import {
-  createAgentGroup,
-  createSession,
-  closeDb,
-  getDb,
-  initTestDb,
-  runMigrations,
-} from './index.js';
+import { createAgentGroup, createSession, closeDb, getDb, initTestDb, runMigrations } from './index.js';
 import {
   getActivitySyncedSeq,
   listActivityByAgentGroup,

--- a/src/db/agent-activity.ts
+++ b/src/db/agent-activity.ts
@@ -29,9 +29,9 @@ export interface ActivityRow {
 }
 
 export function getActivitySyncedSeq(sessionId: string): number {
-  const row = getDb()
-    .prepare('SELECT activity_synced_seq AS seq FROM sessions WHERE id = ?')
-    .get(sessionId) as { seq: number } | undefined;
+  const row = getDb().prepare('SELECT activity_synced_seq AS seq FROM sessions WHERE id = ?').get(sessionId) as
+    | { seq: number }
+    | undefined;
   return row?.seq ?? 0;
 }
 
@@ -41,11 +41,7 @@ export function getActivitySyncedSeq(sessionId: string): number {
  * input is empty so callers don't have to short-circuit. Returns the new
  * cursor value (max input seq, or the unchanged prior cursor).
  */
-export function mergeActivityBatch(
-  agentGroupId: string,
-  sessionId: string,
-  rows: OutboundActivityRow[],
-): number {
+export function mergeActivityBatch(agentGroupId: string, sessionId: string, rows: OutboundActivityRow[]): number {
   if (rows.length === 0) return getActivitySyncedSeq(sessionId);
 
   const db = getDb();

--- a/src/db/agent-activity.ts
+++ b/src/db/agent-activity.ts
@@ -1,0 +1,125 @@
+/**
+ * Central `agent_activity` ledger — append-only, drained from each session's
+ * outbound.db `activity` table during delivery. Read paths feed the web UI's
+ * "what is this agent doing" surface; the table is intended to be
+ * inexpensively scannable per-agent-group and per-session, hence the two
+ * descending indexes added in migration 017.
+ *
+ * Cursor: `sessions.activity_synced_seq` is the per-session high-water mark
+ * — every row from outbound.db with `seq <= cursor` has either been merged
+ * here or was emitted by a session whose container has since stopped (we
+ * still drained it on the way out). The merge is single-writer because the
+ * delivery loop already serializes per-session via `inflightDeliveries`.
+ */
+import crypto from 'node:crypto';
+
+import { getDb } from './connection.js';
+import type { OutboundActivityRow } from './session-db.js';
+
+export type ActivityKind = 'tool_call' | 'mcp_call' | 'cmd_exec' | 'secret_use';
+
+export interface ActivityRow {
+  id: string;
+  agent_group_id: string;
+  session_id: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  created_at: string;
+}
+
+export function getActivitySyncedSeq(sessionId: string): number {
+  const row = getDb()
+    .prepare('SELECT activity_synced_seq AS seq FROM sessions WHERE id = ?')
+    .get(sessionId) as { seq: number } | undefined;
+  return row?.seq ?? 0;
+}
+
+/**
+ * Insert a batch of outbound activity rows into central `agent_activity` and
+ * advance the session's merge cursor in one transaction. No-op when the
+ * input is empty so callers don't have to short-circuit. Returns the new
+ * cursor value (max input seq, or the unchanged prior cursor).
+ */
+export function mergeActivityBatch(
+  agentGroupId: string,
+  sessionId: string,
+  rows: OutboundActivityRow[],
+): number {
+  if (rows.length === 0) return getActivitySyncedSeq(sessionId);
+
+  const db = getDb();
+  const insert = db.prepare(
+    `INSERT INTO agent_activity (id, agent_group_id, session_id, kind, target, summary, created_at)
+     VALUES (@id, @agent_group_id, @session_id, @kind, @target, @summary, @created_at)`,
+  );
+  const updateCursor = db.prepare(
+    `UPDATE sessions SET activity_synced_seq = ? WHERE id = ? AND activity_synced_seq < ?`,
+  );
+
+  const maxSeq = rows.reduce((acc, r) => (r.seq > acc ? r.seq : acc), 0);
+
+  db.transaction(() => {
+    for (const r of rows) {
+      insert.run({
+        id: crypto.randomUUID(),
+        agent_group_id: agentGroupId,
+        session_id: sessionId,
+        kind: r.kind,
+        target: r.target,
+        summary: r.summary,
+        created_at: r.ts,
+      });
+    }
+    updateCursor.run(maxSeq, sessionId, maxSeq);
+  })();
+
+  return maxSeq;
+}
+
+export interface ListActivityOpts {
+  /** Only return rows with created_at > since (ISO 8601). */
+  since?: string;
+  /** Cap row count. Defaults to 100, hard-capped at 500 by the route layer. */
+  limit?: number;
+}
+
+export function listActivityByAgentGroup(agentGroupId: string, opts: ListActivityOpts = {}): ActivityRow[] {
+  const limit = opts.limit ?? 100;
+  if (opts.since) {
+    return getDb()
+      .prepare(
+        `SELECT * FROM agent_activity
+          WHERE agent_group_id = ? AND created_at > ?
+          ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(agentGroupId, opts.since, limit) as ActivityRow[];
+  }
+  return getDb()
+    .prepare(
+      `SELECT * FROM agent_activity
+        WHERE agent_group_id = ?
+        ORDER BY created_at DESC LIMIT ?`,
+    )
+    .all(agentGroupId, limit) as ActivityRow[];
+}
+
+export function listActivityBySession(sessionId: string, opts: ListActivityOpts = {}): ActivityRow[] {
+  const limit = opts.limit ?? 100;
+  if (opts.since) {
+    return getDb()
+      .prepare(
+        `SELECT * FROM agent_activity
+          WHERE session_id = ? AND created_at > ?
+          ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(sessionId, opts.since, limit) as ActivityRow[];
+  }
+  return getDb()
+    .prepare(
+      `SELECT * FROM agent_activity
+        WHERE session_id = ?
+        ORDER BY created_at DESC LIMIT ?`,
+    )
+    .all(sessionId, limit) as ActivityRow[];
+}

--- a/src/db/migrations/017-agent-activity.ts
+++ b/src/db/migrations/017-agent-activity.ts
@@ -1,0 +1,40 @@
+/**
+ * Tool-invocation activity log.
+ *
+ * `agent_activity` is a central, append-only ledger of every tool/MCP/cmd
+ * call an agent makes. The container writes a per-session row to its own
+ * `outbound.db` `activity` table (created on demand in
+ * container/agent-runner/src/db/connection.ts); the host's delivery loop
+ * merges undrained rows here during `drainSession`. `sessions.activity_synced_seq`
+ * is the per-session merge cursor so a slow host doesn't double-import.
+ *
+ * Privacy note: `summary` MUST NOT carry secret values or full Bash command
+ * strings — env-injected secrets can leak into argv. The container side is
+ * responsible for sanitization; this layer just stores what arrives.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration017: Migration = {
+  version: 17,
+  name: 'agent-activity',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_activity (
+        id              TEXT PRIMARY KEY,
+        agent_group_id  TEXT NOT NULL REFERENCES agent_groups(id) ON DELETE CASCADE,
+        session_id      TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        kind            TEXT NOT NULL,
+        target          TEXT,
+        summary         TEXT,
+        created_at      TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_agent_activity_group_created
+        ON agent_activity(agent_group_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_agent_activity_session_created
+        ON agent_activity(session_id, created_at DESC);
+
+      ALTER TABLE sessions ADD COLUMN activity_synced_seq INTEGER NOT NULL DEFAULT 0;
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -13,6 +13,7 @@ import { migration013 } from './013-approval-render-metadata.js';
 import { migration014 } from './014-secrets.js';
 import { migration015 } from './015-secrets-drop-host-pattern.js';
 import { migration016 } from './016-secret-assignments.js';
+import { migration017 } from './017-agent-activity.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -37,6 +38,7 @@ const migrations: Migration[] = [
   migration014,
   migration015,
   migration016,
+  migration017,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -266,6 +266,35 @@ export function migrateDeliveredTable(db: Database): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// activity (read-only from host)
+// ---------------------------------------------------------------------------
+
+export interface OutboundActivityRow {
+  seq: number;
+  ts: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+}
+
+/**
+ * Read activity rows the host hasn't yet merged. Returns rows ordered by
+ * seq ascending so the merge runs in chronological order and the cursor
+ * advances monotonically. Returns [] (without throwing) if the outbound
+ * DB pre-dates the activity table — old session DBs simply won't emit
+ * activity until the next container reboot creates the table on demand.
+ */
+export function getOutboundActivity(db: Database, sinceSeq: number): OutboundActivityRow[] {
+  try {
+    return db
+      .prepare(`SELECT seq, ts, kind, target, summary FROM activity WHERE seq > ? ORDER BY seq ASC`)
+      .all(sinceSeq) as OutboundActivityRow[];
+  } catch {
+    return [];
+  }
+}
+
 // Adds columns added to messages_in after the initial v2 schema to
 // pre-existing session DBs. No-op on fresh installs where the columns are
 // in the baseline schema. Backfills existing rows so invariants hold.

--- a/src/delivery.ts
+++ b/src/delivery.ts
@@ -9,6 +9,7 @@
  */
 import type { Database } from './db/connection.js';
 
+import { getActivitySyncedSeq, mergeActivityBatch } from './db/agent-activity.js';
 import { getRunningSessions, getActiveSessions, createPendingQuestion } from './db/sessions.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -16,6 +17,7 @@ import { getMessagingGroupByPlatform } from './db/messaging-groups.js';
 import {
   getDueOutboundMessages,
   getDeliveredIds,
+  getOutboundActivity,
   markDelivered,
   markDeliveryFailed,
   migrateDeliveredTable,
@@ -175,6 +177,20 @@ async function drainSession(session: Session): Promise<void> {
   }
 
   try {
+    // Drain any new activity rows from outbound.db into central agent_activity.
+    // Independent of message delivery — activity should be visible even when
+    // there are no outbound messages. Cheap on idle sessions: a single indexed
+    // SELECT > cursor returning zero rows.
+    try {
+      const sinceSeq = getActivitySyncedSeq(session.id);
+      const activityRows = getOutboundActivity(outDb, sinceSeq);
+      if (activityRows.length > 0) {
+        mergeActivityBatch(session.agent_group_id, session.id, activityRows);
+      }
+    } catch (err) {
+      log.warn('activity merge failed', { sessionId: session.id, err });
+    }
+
     // Read all due messages from outbound.db (read-only)
     const allDue = getDueOutboundMessages(outDb);
     if (allDue.length === 0) return;

--- a/src/web/routes/activity.ts
+++ b/src/web/routes/activity.ts
@@ -1,0 +1,106 @@
+/**
+ * /api/groups/:folder/activity and /api/sessions/:id/activity — read-only
+ * tool-invocation feed. Rows are merged into central agent_activity by the
+ * delivery loop in src/delivery.ts; this route just paginates them out.
+ *
+ * Auth: claw:read. Listing tool calls leaks no plaintext (target is the
+ * tool name, summary is null today), but it does expose what the agent has
+ * been doing — operator-only by design.
+ */
+import http from 'node:http';
+
+import { listActivityByAgentGroup, listActivityBySession } from '../../db/agent-activity.js';
+import { getAgentGroupByFolder } from '../../db/agent-groups.js';
+import { getSession } from '../../db/sessions.js';
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+interface ActivityView {
+  id: string;
+  agentGroupId: string;
+  sessionId: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  createdAt: string;
+}
+
+function toView(r: {
+  id: string;
+  agent_group_id: string;
+  session_id: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  created_at: string;
+}): ActivityView {
+  return {
+    id: r.id,
+    agentGroupId: r.agent_group_id,
+    sessionId: r.session_id,
+    kind: r.kind,
+    target: r.target,
+    summary: r.summary,
+    createdAt: r.created_at,
+  };
+}
+
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+const error = (res: http.ServerResponse, status: number, message: string): void =>
+  json(res, status, { error: message });
+
+function parseLimit(raw: string | null): number {
+  if (!raw) return DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}
+
+export interface ActivityRouteContext {
+  pathname: string;
+  method: string;
+  url: URL;
+  res: http.ServerResponse;
+}
+
+export async function handleActivityRoute(ctx: ActivityRouteContext): Promise<boolean> {
+  const { pathname, method, url, res } = ctx;
+  if (method !== 'GET') return false;
+
+  const groupMatch = pathname.match(/^\/api\/groups\/([^/]+)\/activity$/);
+  if (groupMatch) {
+    const folder = decodeURIComponent(groupMatch[1]);
+    const group = getAgentGroupByFolder(folder);
+    if (!group) {
+      error(res, 404, `agent group not found: ${folder}`);
+      return true;
+    }
+    const since = url.searchParams.get('since') ?? undefined;
+    const limit = parseLimit(url.searchParams.get('limit'));
+    const rows = listActivityByAgentGroup(group.id, { since, limit });
+    json(res, 200, { activity: rows.map(toView) });
+    return true;
+  }
+
+  const sessionMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/activity$/);
+  if (sessionMatch) {
+    const id = decodeURIComponent(sessionMatch[1]);
+    const session = getSession(id);
+    if (!session) {
+      error(res, 404, `session not found: ${id}`);
+      return true;
+    }
+    const since = url.searchParams.get('since') ?? undefined;
+    const limit = parseLimit(url.searchParams.get('limit'));
+    const rows = listActivityBySession(id, { since, limit });
+    json(res, 200, { activity: rows.map(toView) });
+    return true;
+  }
+
+  return false;
+}

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -33,6 +33,7 @@ interface SecretView {
   name: string;
   kind: SecretKind;
   agentGroupId: string | null;
+  assignedMode: 'all' | 'selective';
   createdAt: string;
   updatedAt: string;
 }
@@ -43,6 +44,7 @@ function toView(r: SecretRow): SecretView {
     name: r.name,
     kind: r.kind,
     agentGroupId: r.agent_group_id,
+    assignedMode: r.assigned_mode,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -269,8 +269,7 @@ async function handleApi(
   // those handlers 405 on unknown sub-paths and would shadow /activity.
   if (
     method === 'GET' &&
-    (/^\/api\/groups\/[^/]+\/activity$/.test(pathname) ||
-      /^\/api\/sessions\/[^/]+\/activity$/.test(pathname))
+    (/^\/api\/groups\/[^/]+\/activity$/.test(pathname) || /^\/api\/sessions\/[^/]+\/activity$/.test(pathname))
   ) {
     if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
     try {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -55,6 +55,7 @@ import {
 import { fetchHubVaults } from './hub-discovery.js';
 import { handleApprovalsRoute } from './routes/approvals.js';
 import { handleChannelsRoute } from './routes/channels.js';
+import { handleActivityRoute } from './routes/activity.js';
 import { handleSecretsRoute } from './routes/secrets.js';
 import { handleSessionsRoute } from './routes/sessions.js';
 import { handleSetupStatusRoute } from './routes/setup-status.js';
@@ -75,7 +76,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // hub#83) sets this from `module.json` `paths[0]` automatically. Empty
 // string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.14-rc.3';
+const SERVICE_VERSION = '0.0.14-rc.4';
 
 interface AgentGroupRow {
   id: string;
@@ -257,6 +258,23 @@ async function handleApi(
     if (!(await gate(req, res, required))) return;
     try {
       const handled = await handleChannelsRoute({ pathname, method, req, res });
+      if (handled) return;
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+      return;
+    }
+  }
+
+  // Activity feed must dispatch BEFORE the sessions/groups blocks below —
+  // those handlers 405 on unknown sub-paths and would shadow /activity.
+  if (
+    method === 'GET' &&
+    (/^\/api\/groups\/[^/]+\/activity$/.test(pathname) ||
+      /^\/api\/sessions\/[^/]+\/activity$/.test(pathname))
+  ) {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
+    try {
+      const handled = await handleActivityRoute({ pathname, method, url, res });
       if (handled) return;
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary
- New append-only `agent_activity` table (migration 017) — kind, target, summary, created_at — indexed by group + session.
- Container writes to outbound.db's `activity` table at PreToolUse; host's delivery loop drains and merges into central `agent_activity`, advancing `sessions.activity_synced_seq` monotonically.
- GET `/api/groups/:folder/activity?since=&limit=` and GET `/api/sessions/:id/activity?since=&limit=` (claw:read), camelCased, DESC by created_at, DEFAULT_LIMIT=100, MAX_LIMIT=500.
- Privacy: `target` = tool name only; `summary` is null at capture time. Bash argv can carry env-injected secrets, so we never log it.
- Forward-compat: outbound.db `activity` table is created on demand, drainer returns `[]` on missing table — older session DBs work without container restart.

## Test plan
- [x] 6 vitest cases in `src/db/agent-activity.test.ts` — initial cursor 0, empty batch no-op, monotonic cursor, group-scoped DESC order, since+limit, cascade on session delete. All pass.
- [x] `pnpm exec tsc --noEmit` — clean.
- [ ] Smoke: spin up an agent group, send a message that triggers a tool call, GET `/api/groups/:folder/activity` and confirm a row appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from ParachuteComputer/paraclaw-archive-fork#39 (the repo was detached from the qwibitai/nanoclaw fork network; PRs were re-created on the standalone repo with new numbers)._