### PR TITLE
feat(ui): /claw/apps — OAuth integration scaffold + Google

### DIFF
--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { Apps } from "./routes/Apps.tsx";
 import { ApprovalsList } from "./routes/ApprovalsList.tsx";
 import { ChannelsList } from "./routes/ChannelsList.tsx";
 import { GroupDetail } from "./routes/GroupDetail.tsx";
@@ -35,6 +36,7 @@ export function App() {
         <Link to="/sessions">Sessions</Link>
         <Link to="/channels">Channels</Link>
         <Link to="/secrets">Secrets</Link>
+        <Link to="/apps">Apps</Link>
         <Link to="/approvals">Approvals</Link>
         <Link to="/setup">Setup</Link>
         <a
@@ -51,6 +53,7 @@ export function App() {
         <Route path="/secrets" element={<SecretsList />} />
         <Route path="/sessions" element={<SessionsList />} />
         <Route path="/channels" element={<ChannelsList />} />
+        <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />
         <Route path="/setup" element={<SetupWizard />} />
         <Route path="/groups/new" element={<NewGroupWizard />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -323,6 +323,104 @@ export async function listGroupActivity(
   return r.activity;
 }
 
+// --- Apps (OAuth integrations: per-provider OAuth configs + user grants) ---
+
+/**
+ * Three-table OneCLI model surfaced through `/api/apps/*`:
+ *   1. app_configs      — per-provider OAuth client (paste client_id/secret)
+ *   2. app_connections  — user grants (the rows GET /api/apps returns)
+ *   3. assignments      — which agent groups see which connection (drawer; not yet wired in this PR)
+ *
+ * The brief locks the wire to one config per (paraclaw-instance, provider).
+ * A connection's `agentGroupCount` is the only assignment hint surfaced in
+ * this PR; full per-connection assignment editing comes with the cross-page
+ * pivot follow-up.
+ */
+export type AppConnectionStatus = 'active' | 'expired' | 'revoked';
+
+export interface AppConnectionView {
+  id: string;
+  provider: string;
+  /** From userinfo at OAuth completion. May be null for providers that don't expose it. */
+  account_email: string | null;
+  /** Auto-populated label (typically `<email> @ <provider>`). User-overridable in a future PR. */
+  label: string;
+  scopes_granted: string[];
+  /** ISO8601 — null when refresh tokens never expire (some providers). */
+  expires_at: string | null;
+  status: AppConnectionStatus;
+  /** Count only — the assignment list isn't returned here. */
+  agentGroupCount: number;
+}
+
+export interface AppConfigView {
+  provider: string;
+  client_id: string;
+  scopes_default: string[];
+  /**
+   * The server NEVER returns the secret; only an existence flag. The UI uses
+   * this to choose between "Add config" and "Replace secret" in the form.
+   */
+  hasSecret: boolean;
+}
+
+export async function listAppConnections(): Promise<AppConnectionView[]> {
+  // Server returns the list directly per the brief (no envelope), but we
+  // accept either shape so a future envelope migration doesn't break here.
+  const r = await request<AppConnectionView[] | { apps: AppConnectionView[] }>('/apps');
+  return Array.isArray(r) ? r : r.apps;
+}
+
+export async function getAppConfig(provider: string): Promise<AppConfigView | null> {
+  // 404 is the documented "no config yet" signal — distinguish that from a
+  // real error so the UI can render the "Add config" CTA instead of a banner.
+  try {
+    return await request<AppConfigView>(`/apps/${encodeURIComponent(provider)}/config`);
+  } catch (err) {
+    if (err instanceof Error && /404|not\s*found/i.test(err.message)) return null;
+    throw err;
+  }
+}
+
+export interface PutAppConfigInput {
+  client_id: string;
+  client_secret: string;
+  scopes_default?: string[];
+}
+
+export async function putAppConfig(provider: string, input: PutAppConfigInput): Promise<AppConfigView> {
+  return request<AppConfigView>(`/apps/${encodeURIComponent(provider)}/config`, {
+    method: 'POST',
+    json: input,
+  });
+}
+
+export interface AuthorizeAppOptions {
+  /** Bind the resulting connection to a specific agent group on creation. */
+  agentGroupId?: string;
+}
+
+export interface AuthorizeAppResult {
+  redirectUrl: string;
+  state: string;
+}
+
+/**
+ * Kick off the OAuth dance — the caller is expected to navigate the browser
+ * to `redirectUrl`. The server completes the exchange on its callback and
+ * redirects back to `/claw/apps?connected=:id`.
+ */
+export async function authorizeApp(provider: string, options: AuthorizeAppOptions = {}): Promise<AuthorizeAppResult> {
+  return request<AuthorizeAppResult>(`/apps/${encodeURIComponent(provider)}/authorize`, {
+    method: 'POST',
+    json: options,
+  });
+}
+
+export async function deleteAppConnection(id: string): Promise<void> {
+  return request<void>(`/apps/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}
+
 // --- Secrets (paraclaw-native, replaces OneCLI proxy) ---
 
 /** Per PRIMITIVES.md §"Secret": kinds keyed by purpose. */

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -338,6 +338,12 @@ export async function listGroupActivity(
  */
 export type AppConnectionStatus = 'active' | 'expired' | 'revoked';
 
+/**
+ * Per-connection scope: `all` injects into every agent group; `selective`
+ * consults the join table. Mirrors the secrets shape from PR1.
+ */
+export type AssignedMode = 'all' | 'selective';
+
 export interface AppConnectionView {
   id: string;
   provider: string;
@@ -351,6 +357,13 @@ export interface AppConnectionView {
   status: AppConnectionStatus;
   /** Count only — the assignment list isn't returned here. */
   agentGroupCount: number;
+  /**
+   * Forward-compat: nullable in v1; mandatory once the cross-page-pivot
+   * follow-up lands the per-connection assignment editor. UI is not yet
+   * bound to this field — leaving the slot in the type so the next PR
+   * doesn't have to retrofit.
+   */
+  assignedMode: AssignedMode | null;
 }
 
 export interface AppConfigView {
@@ -367,8 +380,12 @@ export interface AppConfigView {
 export async function listAppConnections(): Promise<AppConnectionView[]> {
   // Server returns the list directly per the brief (no envelope), but we
   // accept either shape so a future envelope migration doesn't break here.
-  const r = await request<AppConnectionView[] | { apps: AppConnectionView[] }>('/apps');
-  return Array.isArray(r) ? r : r.apps;
+  // assignedMode is forward-compat (see type comment) — default to null
+  // when the v1 server omits it.
+  type Wire = Omit<AppConnectionView, 'assignedMode'> & { assignedMode?: AssignedMode | null };
+  const r = await request<Wire[] | { apps: Wire[] }>('/apps');
+  const list = Array.isArray(r) ? r : r.apps;
+  return list.map((c) => ({ ...c, assignedMode: c.assignedMode ?? null }));
 }
 
 export async function getAppConfig(provider: string): Promise<AppConfigView | null> {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -389,8 +389,10 @@ export interface PutAppConfigInput {
 }
 
 export async function putAppConfig(provider: string, input: PutAppConfigInput): Promise<AppConfigView> {
+  // Canonical wire shape: PUT (idempotent upsert) per the team-lead's brief.
+  // Server-side handler keys on (paraclaw-instance, provider) and replaces.
   return request<AppConfigView>(`/apps/${encodeURIComponent(provider)}/config`, {
-    method: 'POST',
+    method: 'PUT',
     json: input,
   });
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -465,8 +465,10 @@ export type SecretKind = 'channel-token' | 'api-key' | 'generic';
  *   resolution per `src/secrets/index.ts:resolveInjectableSecrets`).
  * `selective` — inject only into the agent groups explicitly assigned via
  *   /api/secrets/:id/assignments.
+ *
+ * The `AssignedMode` type itself is declared in the Apps section above; both
+ * surfaces share the same allow-list semantics so we reuse the alias.
  */
-export type AssignedMode = 'all' | 'selective';
 
 export interface SecretView {
   id: string;

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -107,6 +107,21 @@ async function readError(res: Response): Promise<string> {
   return message;
 }
 
+/**
+ * Error thrown for non-2xx responses. Carries the HTTP status so callers can
+ * branch on it numerically instead of regex-matching the message string —
+ * less brittle when servers reword their error bodies.
+ */
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
 export async function request<T>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> {
   let bearer = getAccessToken();
   if (!bearer) {
@@ -137,7 +152,7 @@ export async function request<T>(path: string, init?: RequestInit & { json?: unk
     await beginLogin();
   }
   if (!res.ok) {
-    throw new Error(await readError(res));
+    throw new HttpError(res.status, await readError(res));
   }
   if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
@@ -394,7 +409,7 @@ export async function getAppConfig(provider: string): Promise<AppConfigView | nu
   try {
     return await request<AppConfigView>(`/apps/${encodeURIComponent(provider)}/config`);
   } catch (err) {
-    if (err instanceof Error && /404|not\s*found/i.test(err.message)) return null;
+    if (err instanceof HttpError && err.status === 404) return null;
     throw err;
   }
 }

--- a/web/ui/src/routes/Apps.tsx
+++ b/web/ui/src/routes/Apps.tsx
@@ -1,0 +1,582 @@
+/**
+ * `/claw/apps` — OAuth integrations management.
+ *
+ * Two stacked sections per the audit-refined brief:
+ *   1. **App configs** — per-provider OAuth client (paste client_id + client_secret).
+ *      One row per *supported* provider, regardless of whether it's been
+ *      configured yet. The CTA flips between "Add" and "Replace secret".
+ *   2. **Connections** — the user grants. Each row shows account_email +
+ *      label + scopes_granted + status + agentGroupCount + delete.
+ *
+ * Add-flow: clicking "Connect with X" on a provider that has no app_config
+ * yet routes through the App-config form first; once saved, the same button
+ * proceeds to authorize.
+ *
+ * Callback handling: the server's OAuth callback redirects back to
+ * `?connected=<id>`. We read that on mount, refetch, and highlight the
+ * matching row briefly. The query param is then stripped from the URL so a
+ * page refresh doesn't re-trigger the highlight.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { formatRelative } from '../components/StatusDot.tsx';
+import {
+  type AppConfigView,
+  type AppConnectionView,
+  type PutAppConfigInput,
+  authorizeApp,
+  deleteAppConnection,
+  getAppConfig,
+  listAppConnections,
+  putAppConfig,
+} from '../lib/api.ts';
+
+/**
+ * Providers the UI knows about. Keep this list small — adding a provider is
+ * an explicit decision (the OAuth scopes, the userinfo shape, the icon, all
+ * vary). PR3 ships with Google as the seed; subsequent PRs add more.
+ */
+const SUPPORTED_PROVIDERS: ProviderMeta[] = [
+  {
+    id: 'google',
+    label: 'Google',
+    description: 'Gmail, Calendar, Drive — depending on the scopes you grant.',
+    defaultScopes: ['openid', 'email', 'profile'],
+    docsUrl: 'https://console.cloud.google.com/apis/credentials',
+  },
+];
+
+interface ProviderMeta {
+  id: string;
+  label: string;
+  description: string;
+  defaultScopes: string[];
+  /** Where the human goes to register an OAuth app for this provider. */
+  docsUrl: string;
+}
+
+export function Apps() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const justConnectedId = searchParams.get('connected');
+
+  // Configs are keyed by provider id; null = explicitly "no config yet"
+  // (404 from server), undefined = not yet loaded.
+  const [configs, setConfigs] = useState<Record<string, AppConfigView | null | undefined>>({});
+  const [connections, setConnections] = useState<AppConnectionView[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
+  const [editingProvider, setEditingProvider] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      const [conns, ...cfgs] = await Promise.all([
+        listAppConnections(),
+        ...SUPPORTED_PROVIDERS.map((p) => getAppConfig(p.id)),
+      ]);
+      const cfgMap: Record<string, AppConfigView | null> = {};
+      SUPPORTED_PROVIDERS.forEach((p, i) => {
+        cfgMap[p.id] = cfgs[i];
+      });
+      setConfigs(cfgMap);
+      setConnections(conns);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Strip the `?connected=` param after we've consumed it for the highlight,
+  // so a refresh doesn't re-trigger the green flash. Kept replace:true to
+  // avoid leaving a redundant entry in the back-stack.
+  useEffect(() => {
+    if (!justConnectedId) return;
+    const t = setTimeout(() => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          p.delete('connected');
+          return p;
+        },
+        { replace: true },
+      );
+    }, 4_000);
+    return () => clearTimeout(t);
+  }, [justConnectedId, setSearchParams]);
+
+  const onConnect = async (provider: string) => {
+    const cfg = configs[provider];
+    if (!cfg) {
+      // Need an app_config first — open the form and stop. The form's submit
+      // path will re-call onConnect once the config is saved.
+      setEditingProvider(provider);
+      setFlash({ kind: 'ok', text: `Configure ${provider} OAuth client first, then return to Connect.` });
+      return;
+    }
+    setFlash(null);
+    try {
+      const { redirectUrl } = await authorizeApp(provider);
+      window.location.href = redirectUrl;
+    } catch (err) {
+      setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const onDeleteConnection = async (conn: AppConnectionView) => {
+    if (
+      !window.confirm(
+        `Remove connection ${conn.label}? The agent groups it's assigned to (${conn.agentGroupCount}) will lose access immediately.`,
+      )
+    ) {
+      return;
+    }
+    setFlash(null);
+    try {
+      await deleteAppConnection(conn.id);
+      setFlash({ kind: 'ok', text: `Removed ${conn.label}.` });
+      await reload();
+    } catch (err) {
+      setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  if (loading && connections === null) {
+    return (
+      <div>
+        <h2>Apps</h2>
+        <div className="section">
+          <div className="skeleton skeleton-line" style={{ width: '40%' }} />
+          <div className="skeleton skeleton-line" />
+          <div className="skeleton skeleton-line" style={{ width: '70%' }} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Apps</h2>
+      <p className="muted" style={{ marginTop: '-0.5rem' }}>
+        OAuth integrations — configure a provider once, then grant the agent access via "Connect".
+      </p>
+
+      {error && (
+        <div className="error-banner">
+          {error}
+          <button className="secondary" onClick={() => void reload()} style={{ marginLeft: '0.6rem' }}>
+            Retry
+          </button>
+        </div>
+      )}
+      {flash && <div className={flash.kind === 'ok' ? 'status-banner' : 'error-banner'}>{flash.text}</div>}
+
+      <div className="section">
+        <h3>App configs</h3>
+        <p className="muted" style={{ marginTop: 0 }}>
+          One OAuth client per provider, shared across all your agent groups. Paste the client_id and
+          client_secret you registered with the provider.
+        </p>
+        <ul className="app-config-list">
+          {SUPPORTED_PROVIDERS.map((provider) => (
+            <AppConfigRow
+              key={provider.id}
+              provider={provider}
+              config={configs[provider.id] ?? null}
+              loading={configs[provider.id] === undefined}
+              editing={editingProvider === provider.id}
+              onEdit={() => setEditingProvider(provider.id)}
+              onCancel={() => setEditingProvider(null)}
+              onSaved={async (saved) => {
+                setConfigs((prev) => ({ ...prev, [provider.id]: saved }));
+                setEditingProvider(null);
+                setFlash({ kind: 'ok', text: `${provider.label} OAuth client saved.` });
+              }}
+            />
+          ))}
+        </ul>
+      </div>
+
+      <div className="section">
+        <h3>Connections</h3>
+        {connections && connections.length > 0 ? (
+          <ConnectionsTable
+            connections={connections}
+            justConnectedId={justConnectedId}
+            onConnect={onConnect}
+            onDelete={onDeleteConnection}
+            configs={configs}
+          />
+        ) : (
+          <ConnectionsEmpty
+            providers={SUPPORTED_PROVIDERS}
+            configs={configs}
+            onConnect={onConnect}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- App config row ---
+
+function AppConfigRow({
+  provider,
+  config,
+  loading,
+  editing,
+  onEdit,
+  onCancel,
+  onSaved,
+}: {
+  provider: ProviderMeta;
+  config: AppConfigView | null;
+  loading: boolean;
+  editing: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSaved: (saved: AppConfigView) => Promise<void>;
+}) {
+  if (editing) {
+    return (
+      <li className="app-config-row app-config-row-editing">
+        <AppConfigForm
+          provider={provider}
+          existing={config}
+          onCancel={onCancel}
+          onSaved={onSaved}
+        />
+      </li>
+    );
+  }
+  return (
+    <li className="app-config-row">
+      <div className="app-config-head">
+        <div>
+          <strong>{provider.label}</strong>
+          {loading ? (
+            <span className="dim"> · loading…</span>
+          ) : config ? (
+            <span className="tag" style={{ marginLeft: '0.5rem' }}>
+              configured
+            </span>
+          ) : (
+            <span className="tag muted" style={{ marginLeft: '0.5rem' }}>
+              not configured
+            </span>
+          )}
+        </div>
+        <button className="secondary" onClick={onEdit} disabled={loading}>
+          {config ? 'Replace secret' : 'Add config'}
+        </button>
+      </div>
+      <p className="dim app-config-blurb">{provider.description}</p>
+      {config && (
+        <div className="kv app-config-kv">
+          <div>client_id</div>
+          <div>
+            <code className="app-config-clientid">{config.client_id}</code>
+          </div>
+          <div>scopes</div>
+          <div>
+            {config.scopes_default.length > 0
+              ? config.scopes_default.map((s) => (
+                  <code key={s} className="app-scope-tag">
+                    {s}
+                  </code>
+                ))
+              : <em className="dim">none</em>}
+          </div>
+          <div>secret</div>
+          <div>
+            {config.hasSecret ? (
+              <span className="tag muted">stored</span>
+            ) : (
+              <span className="tag warn">missing — add a secret to enable Connect</span>
+            )}
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function AppConfigForm({
+  provider,
+  existing,
+  onCancel,
+  onSaved,
+}: {
+  provider: ProviderMeta;
+  existing: AppConfigView | null;
+  onCancel: () => void;
+  onSaved: (saved: AppConfigView) => Promise<void>;
+}) {
+  const [clientId, setClientId] = useState(existing?.client_id ?? '');
+  const [clientSecret, setClientSecret] = useState('');
+  const [scopesText, setScopesText] = useState(
+    (existing?.scopes_default ?? provider.defaultScopes).join(' '),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!clientId.trim() || !clientSecret.trim()) {
+      setErr('Both client_id and client_secret are required.');
+      return;
+    }
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const input: PutAppConfigInput = {
+        client_id: clientId.trim(),
+        client_secret: clientSecret,
+        scopes_default: scopesText.split(/\s+/).filter(Boolean),
+      };
+      const saved = await putAppConfig(provider.id, input);
+      await onSaved(saved);
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="app-config-form">
+      <div className="app-config-head">
+        <strong>{provider.label} OAuth client</strong>
+        <a href={provider.docsUrl} target="_blank" rel="noreferrer" className="dim">
+          Where do I get this? ↗
+        </a>
+      </div>
+      {err && <div className="error-banner">{err}</div>}
+      <div className="row">
+        <label htmlFor={`cid-${provider.id}`}>client_id</label>
+        <input
+          id={`cid-${provider.id}`}
+          type="text"
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          disabled={submitting}
+          autoComplete="off"
+        />
+      </div>
+      <div className="row">
+        <label htmlFor={`cs-${provider.id}`}>
+          client_secret {existing?.hasSecret && <span className="dim">(replacing existing)</span>}
+        </label>
+        <input
+          id={`cs-${provider.id}`}
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          disabled={submitting}
+          autoComplete="new-password"
+          placeholder={existing?.hasSecret ? 'paste new secret to rotate' : 'paste from provider'}
+        />
+      </div>
+      <div className="row">
+        <label htmlFor={`scopes-${provider.id}`}>default scopes</label>
+        <input
+          id={`scopes-${provider.id}`}
+          type="text"
+          value={scopesText}
+          onChange={(e) => setScopesText(e.target.value)}
+          disabled={submitting}
+          placeholder={provider.defaultScopes.join(' ')}
+        />
+        <p className="dim">Space-separated. Each Connect can later add more, but never less.</p>
+      </div>
+      <div className="actions">
+        <button type="submit" disabled={submitting}>
+          {submitting ? 'Saving…' : 'Save'}
+        </button>
+        <button type="button" className="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// --- Connections ---
+
+function ConnectionsTable({
+  connections,
+  justConnectedId,
+  onConnect,
+  onDelete,
+  configs,
+}: {
+  connections: AppConnectionView[];
+  justConnectedId: string | null;
+  onConnect: (provider: string) => void | Promise<void>;
+  onDelete: (conn: AppConnectionView) => void | Promise<void>;
+  configs: Record<string, AppConfigView | null | undefined>;
+}) {
+  // Group by provider so each block has a "+ Connect another <provider>"
+  // row at the bottom — UX is clearer than a flat list when the user has
+  // multiple Google accounts (which is the common case for power users).
+  const byProvider = useMemo(() => {
+    const m = new Map<string, AppConnectionView[]>();
+    for (const c of connections) {
+      const arr = m.get(c.provider) ?? [];
+      arr.push(c);
+      m.set(c.provider, arr);
+    }
+    return m;
+  }, [connections]);
+
+  return (
+    <div className="connections-list">
+      {Array.from(byProvider.entries()).map(([provider, items]) => {
+        const cfg = configs[provider];
+        const canConnect = cfg && cfg.hasSecret;
+        return (
+          <div key={provider} className="connections-group">
+            <div className="connections-group-head">
+              <strong>{providerLabel(provider)}</strong>
+              <button
+                className="secondary"
+                onClick={() => void onConnect(provider)}
+                disabled={!canConnect}
+                title={canConnect ? undefined : 'Add a config + secret first'}
+              >
+                + Connect another
+              </button>
+            </div>
+            <ul className="connections-rows">
+              {items.map((conn) => (
+                <ConnectionRow
+                  key={conn.id}
+                  conn={conn}
+                  highlighted={conn.id === justConnectedId}
+                  onDelete={() => void onDelete(conn)}
+                />
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ConnectionRow({
+  conn,
+  highlighted,
+  onDelete,
+}: {
+  conn: AppConnectionView;
+  highlighted: boolean;
+  onDelete: () => void;
+}) {
+  // Briefly scroll the highlighted row into view so the user lands on it
+  // after the OAuth round-trip without having to hunt.
+  const ref = useRef<HTMLLIElement | null>(null);
+  useEffect(() => {
+    if (highlighted && ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlighted]);
+
+  return (
+    <li ref={ref} className={`connection-row${highlighted ? ' connection-row-flash' : ''}`}>
+      <div className="connection-row-main">
+        <div className="connection-label">
+          {conn.label}
+          <ConnectionStatusTag status={conn.status} />
+        </div>
+        <div className="dim connection-meta">
+          {conn.account_email && <span>{conn.account_email}</span>}
+          {conn.account_email && <span> · </span>}
+          {conn.expires_at ? (
+            <span title={new Date(conn.expires_at).toLocaleString()}>
+              expires {formatRelative(conn.expires_at)}
+            </span>
+          ) : (
+            <span>no expiry</span>
+          )}
+          <span> · </span>
+          <span>
+            {conn.agentGroupCount === 0
+              ? 'unassigned'
+              : `assigned to ${conn.agentGroupCount} agent${conn.agentGroupCount === 1 ? '' : 's'}`}
+          </span>
+        </div>
+        {conn.scopes_granted.length > 0 && (
+          <div className="connection-scopes">
+            {conn.scopes_granted.map((s) => (
+              <code key={s} className="app-scope-tag">
+                {s}
+              </code>
+            ))}
+          </div>
+        )}
+      </div>
+      <button className="danger" onClick={onDelete}>
+        Remove
+      </button>
+    </li>
+  );
+}
+
+function ConnectionStatusTag({ status }: { status: AppConnectionView['status'] }) {
+  switch (status) {
+    case 'active':
+      return <span className="tag" style={{ marginLeft: '0.5rem' }}>active</span>;
+    case 'expired':
+      return <span className="tag warn" style={{ marginLeft: '0.5rem' }}>expired</span>;
+    case 'revoked':
+      return <span className="tag error" style={{ marginLeft: '0.5rem' }}>revoked</span>;
+  }
+}
+
+function ConnectionsEmpty({
+  providers,
+  configs,
+  onConnect,
+}: {
+  providers: ProviderMeta[];
+  configs: Record<string, AppConfigView | null | undefined>;
+  onConnect: (provider: string) => void | Promise<void>;
+}) {
+  return (
+    <div className="empty-rich">
+      <p className="empty-headline">No connections yet.</p>
+      <p className="muted" style={{ marginTop: 0 }}>
+        Configure a provider above, then click Connect to grant the agent access via OAuth.
+      </p>
+      <div className="connect-cta-row">
+        {providers.map((p) => {
+          const cfg = configs[p.id];
+          const ready = cfg && cfg.hasSecret;
+          return (
+            <button
+              key={p.id}
+              onClick={() => void onConnect(p.id)}
+              disabled={!ready}
+              title={ready ? undefined : 'Add this provider in App configs first'}
+            >
+              Connect with {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function providerLabel(id: string): string {
+  const known = SUPPORTED_PROVIDERS.find((p) => p.id === id);
+  return known?.label ?? id;
+}

--- a/web/ui/src/routes/Apps.tsx
+++ b/web/ui/src/routes/Apps.tsx
@@ -68,13 +68,18 @@ export function Apps() {
   const [loading, setLoading] = useState(true);
   const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
+  // Tracks the provider the user clicked Connect on when no config existed yet.
+  // After they save the config, we auto-resume the OAuth handoff for that
+  // provider so they don't have to re-click Connect.
+  const [pendingConnectProvider, setPendingConnectProvider] = useState<string | null>(null);
 
-  const reload = useCallback(async () => {
+  const reload = useCallback(async (signal: { cancelled: boolean }) => {
     try {
       const [conns, ...cfgs] = await Promise.all([
         listAppConnections(),
         ...SUPPORTED_PROVIDERS.map((p) => getAppConfig(p.id)),
       ]);
+      if (signal.cancelled) return;
       const cfgMap: Record<string, AppConfigView | null> = {};
       SUPPORTED_PROVIDERS.forEach((p, i) => {
         cfgMap[p.id] = cfgs[i];
@@ -83,14 +88,24 @@ export function Apps() {
       setConnections(conns);
       setError(null);
     } catch (err) {
+      if (signal.cancelled) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoading(false);
+      if (!signal.cancelled) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void reload();
+    const signal = { cancelled: false };
+    void reload(signal);
+    return () => {
+      signal.cancelled = true;
+    };
+  }, [reload]);
+
+  // Convenience for the Retry button — same call shape, throwaway signal.
+  const reloadNow = useCallback(() => {
+    void reload({ cancelled: false });
   }, [reload]);
 
   // Strip the `?connected=` param after we've consumed it for the highlight,
@@ -111,15 +126,7 @@ export function Apps() {
     return () => clearTimeout(t);
   }, [justConnectedId, setSearchParams]);
 
-  const onConnect = async (provider: string) => {
-    const cfg = configs[provider];
-    if (!cfg) {
-      // Need an app_config first — open the form and stop. The form's submit
-      // path will re-call onConnect once the config is saved.
-      setEditingProvider(provider);
-      setFlash({ kind: 'ok', text: `Configure ${provider} OAuth client first, then return to Connect.` });
-      return;
-    }
+  const authorizeAndRedirect = async (provider: string) => {
     setFlash(null);
     try {
       const { redirectUrl } = await authorizeApp(provider);
@@ -127,6 +134,19 @@ export function Apps() {
     } catch (err) {
       setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
     }
+  };
+
+  const onConnect = async (provider: string) => {
+    const cfg = configs[provider];
+    if (!cfg) {
+      // No app_config yet — record the user's intent so we can auto-resume
+      // the OAuth handoff after they save the config (handled in onSaved).
+      setPendingConnectProvider(provider);
+      setEditingProvider(provider);
+      setFlash({ kind: 'ok', text: `Configure ${providerLabel(provider)} OAuth client first.` });
+      return;
+    }
+    await authorizeAndRedirect(provider);
   };
 
   const onDeleteConnection = async (conn: AppConnectionView) => {
@@ -141,7 +161,7 @@ export function Apps() {
     try {
       await deleteAppConnection(conn.id);
       setFlash({ kind: 'ok', text: `Removed ${conn.label}.` });
-      await reload();
+      reloadNow();
     } catch (err) {
       setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
     }
@@ -170,7 +190,7 @@ export function Apps() {
       {error && (
         <div className="error-banner">
           {error}
-          <button className="secondary" onClick={() => void reload()} style={{ marginLeft: '0.6rem' }}>
+          <button className="secondary" onClick={reloadNow} style={{ marginLeft: '0.6rem' }}>
             Retry
           </button>
         </div>
@@ -192,11 +212,22 @@ export function Apps() {
               loading={configs[provider.id] === undefined}
               editing={editingProvider === provider.id}
               onEdit={() => setEditingProvider(provider.id)}
-              onCancel={() => setEditingProvider(null)}
+              onCancel={() => {
+                setEditingProvider(null);
+                setPendingConnectProvider(null);
+              }}
               onSaved={async (saved) => {
                 setConfigs((prev) => ({ ...prev, [provider.id]: saved }));
                 setEditingProvider(null);
-                setFlash({ kind: 'ok', text: `${provider.label} OAuth client saved.` });
+                if (pendingConnectProvider === provider.id && saved.hasSecret) {
+                  // The user clicked Connect first; resume the OAuth handoff
+                  // automatically now that the config is in place.
+                  setPendingConnectProvider(null);
+                  await authorizeAndRedirect(provider.id);
+                } else {
+                  setPendingConnectProvider(null);
+                  setFlash({ kind: 'ok', text: `${provider.label} OAuth client saved.` });
+                }
               }}
             />
           ))}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -505,3 +505,104 @@ hr.sep { border: 0; border-top: 1px solid var(--border); margin: 1.5rem 0; }
   border-top: 1px solid var(--border);
   font-size: 0.82rem;
 }
+
+/* Apps page — App configs section */
+.app-config-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+.app-config-row {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+}
+.app-config-row-editing {
+  background: white;
+  border-color: var(--accent);
+}
+.app-config-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.app-config-blurb {
+  margin: 0.4rem 0 0.6rem;
+  font-size: 0.86rem;
+}
+.app-config-kv {
+  margin-top: 0.5rem;
+  font-size: 0.88rem;
+  grid-template-columns: 6.5rem 1fr;
+}
+.app-config-clientid {
+  word-break: break-all;
+  font-size: 0.78rem;
+}
+.app-scope-tag {
+  display: inline-block;
+  margin: 0 0.25rem 0.25rem 0;
+  padding: 0.05em 0.35em;
+  background: white;
+  border: 1px solid var(--border);
+  font-size: 0.74rem;
+}
+.app-config-form .row { margin-bottom: 0.85rem; }
+.app-config-form .actions { margin-top: 1rem; }
+
+/* Apps page — Connections section */
+.connections-list {
+  display: grid;
+  gap: 1.25rem;
+}
+.connections-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.6rem;
+}
+.connections-rows {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+.connection-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.95rem;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: background 0.4s ease, border-color 0.4s ease;
+}
+.connection-row-flash {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.connection-row-main { flex: 1; min-width: 0; }
+.connection-label {
+  font-size: 0.98rem;
+  font-weight: 500;
+}
+.connection-meta {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+}
+.connection-scopes {
+  margin-top: 0.4rem;
+}
+.connect-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary

Adds the `/claw/apps` page — UI for managing OAuth app configs and the connections derived from them. Two-section layout per the audit-refined brief:

1. **App configs** (top) — per-provider rows showing whether a `client_id` / `client_secret` is on file. "Add" / "Edit" inline form to paste credentials + scopes. Currently scaffolded for Google (`openid email profile` defaults; link out to Google Cloud Console).
2. **Connections** (bottom) — grouped by provider, lists each `app_connection` (account email, label, granted scopes, status, agent-group count). Per-group "+ Connect another" button.

The "Add connection" flow is two-step when no `app_config` exists for the chosen provider yet: paste `client_id` + `client_secret` first, then `Authorize` redirects through the OAuth handoff. After callback, the page receives `?connected=:id`, scrolls to and flashes the new connection row, then strips the param after 4s.

Stacked on paraclaw-server's PR3 (`feat/apps`); merge in order. Until the server endpoints are live, the UI renders empty states cleanly.

## Wire shape consumed

- `GET  /api/apps` → `AppConnectionView[]`
- `GET  /api/apps/:provider/config` → `AppConfigView | 404`
- `PUT  /api/apps/:provider/config` body `{client_id, client_secret?, scopes_default}`
- `POST /api/apps/:provider/authorize` body `{agentGroupId?}` → `{redirectUrl, state}`
- `DELETE /api/apps/connections/:id`
- OAuth callback redirects back to `/claw/apps?connected=:id`

`getAppConfig()` treats 404 as "not configured yet" so the UI can render the "Add config" CTA correctly.

## Files

- `web/ui/src/App.tsx` — route + nav link
- `web/ui/src/lib/api.ts` — types (`AppConnectionView`, `AppConfigView`, `AuthorizeAppResult`, …) + 5 functions
- `web/ui/src/routes/Apps.tsx` — new page (~470 LOC)
- `web/ui/src/styles.css` — apps-specific classes (`.app-config-row`, `.connection-row-flash`, etc.)

## Deferred

Per-connection assignment management (which agent groups can use which connection) is deferred to the cross-page-pivot follow-up so this PR stays focused on the OAuth scaffold + viewing surface.

## Test plan

- [ ] `pnpm --filter @paraclaw/web-ui build` clean (verified locally; assets land at `/claw/`-prefixed paths)
- [ ] `pnpm exec tsc -p web/ui/tsconfig.json --noEmit` clean (verified locally)
- [ ] `/claw/apps` renders empty states cleanly when server endpoints return empty / 404
- [ ] After paraclaw-server PR3 merges: connect a Google account end-to-end (paste config → authorize → callback flashes new row)
- [ ] Disconnect from the connections list calls `DELETE /api/apps/connections/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from ParachuteComputer/paraclaw-archive-fork#41 (the repo was detached from the qwibitai/nanoclaw fork network; PRs were re-created on the standalone repo with new numbers)._