### PR TITLE
feat(mcp): host-side MCP server wrapping /api/* surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,27 @@ Four types of skills. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full taxono
 | `/debug` | Container issues, logs, troubleshooting |
 | `/update-nanoclaw` | Bring upstream updates into a customized install |
 
+## MCP server
+
+Paraclaw exposes its host-side admin surface (the things `/api/*` and `/claw/*` mediate from the web UI: agent-groups, sessions, channel wires, secrets metadata, approvals) as MCP tools. The same registry serves both transports — handlers call internal helpers directly, not back through HTTP, so there's no extra round-trip and no second auth seam to keep in sync.
+
+| Transport | Endpoint | Auth | Effective scope |
+|-----------|----------|------|-----------------|
+| stdio | `bun src/mcp/stdio.ts` | ambient (filesystem trust) | `claw:admin` |
+| HTTP  | `POST /mcp` on port 1944 | hub-issued JWT (`Authorization: Bearer …`) | strongest `claw:*` scope on the JWT grant |
+
+Wire stdio into Claude Code:
+
+```bash
+claude mcp add paraclaw bun /absolute/path/to/paraclaw/src/mcp/stdio.ts
+```
+
+Tools advertise as `mcp__paraclaw__<verb>-<noun>` client-side: `list-agent-groups`, `create-agent-group`, `attach-vault`, `detach-vault`, `list-sessions`, `close-session`, `list-channels`, `update-channel-wire`, `delete-channel-wire`, `list-secrets`, `put-secret`, `delete-secret`, `list-approvals`, `decide-approval`. A handful (`assign-secret`, `start-oauth`, `revoke-integration`, `get-activity`) are advertised but `disabled` until the matching paraclaw-server endpoints land — they're filtered out of `tools/list` and refused on `tools/call`.
+
+Secret values **never** traverse MCP. `list-secrets` and `put-secret` return row metadata only; the plaintext flows in once on `put-secret` and lands in the encrypted DB column. Container injection happens at session-spawn time, not over the tool surface.
+
+Stdio gotcha: paraclaw's `log.ts` writes info-level messages to `process.stdout`, which corrupts JSON-RPC frames. `src/mcp/stdio.ts` promotes `LOG_LEVEL` to `warn` before any log-using import. Don't move that block below the dynamic imports.
+
 ## Contributing
 
 Before creating a PR, adding a skill, or preparing any contribution, you MUST read [CONTRIBUTING.md](CONTRIBUTING.md). It covers accepted change types, the four skill types and their guidelines, `SKILL.md` format rules, and the pre-submission checklist.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@chat-adapter/telegram": "4.26.0",
     "@clack/core": "^1.2.0",
     "@clack/prompts": "^1.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chat": "^4.24.0",
     "cron-parser": "5.5.0",
     "jose": "^6.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.2.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       chat:
         specifier: ^4.24.0
         version: 4.26.0
@@ -321,6 +324,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -339,6 +348,16 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -597,6 +616,10 @@ packages:
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -607,8 +630,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -643,6 +677,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -655,6 +693,18 @@ packages:
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -690,8 +740,28 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cron-parser@5.5.0:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
@@ -724,6 +794,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -749,16 +823,42 @@ packages:
     resolution: {integrity: sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==}
     engines: {node: '>=18'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -822,6 +922,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -829,6 +941,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -847,6 +969,9 @@ packages:
 
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -867,6 +992,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -878,6 +1007,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -885,6 +1022,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -904,14 +1052,38 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -938,6 +1110,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -949,6 +1129,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -965,6 +1148,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1083,6 +1272,10 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -1115,6 +1308,14 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1200,6 +1401,14 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1231,12 +1440,28 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1257,6 +1482,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1264,6 +1493,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1274,6 +1506,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -1294,12 +1530,28 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1321,6 +1573,10 @@ packages:
   remend@1.3.0:
     resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1333,13 +1589,31 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1348,6 +1622,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1367,6 +1657,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -1408,6 +1702,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -1434,6 +1732,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript-eslint@8.58.2:
     resolution: {integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==}
@@ -1469,11 +1771,19 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -1597,6 +1907,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1829,6 +2147,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1841,6 +2163,28 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -2091,11 +2435,20 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.14.0:
     dependencies:
@@ -2103,6 +2456,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2135,6 +2495,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -2152,6 +2526,18 @@ snapshots:
   bun-types@1.3.13:
     dependencies:
       '@types/node': 22.19.17
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -2188,7 +2574,20 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cron-parser@5.5.0:
     dependencies:
@@ -2215,6 +2614,8 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -2249,11 +2650,29 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2284,6 +2703,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
     optional: true
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2365,9 +2786,55 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -2383,6 +2850,8 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
+  fast-uri@3.1.0: {}
+
   fast-wrap-ansi@0.1.6:
     dependencies:
       fast-string-width: 1.1.0
@@ -2397,6 +2866,17 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2409,10 +2889,34 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -2429,9 +2933,31 @@ snapshots:
 
   globals@15.15.0: {}
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.15: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   husky@9.1.7: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2450,6 +2976,10 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2457,6 +2987,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2469,6 +3001,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2553,6 +3089,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -2655,6 +3193,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -2847,6 +3389,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
@@ -2869,11 +3417,21 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2900,15 +3458,21 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
     dependencies:
@@ -2935,12 +3499,30 @@ snapshots:
 
   prettier@3.8.2: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2983,6 +3565,8 @@ snapshots:
 
   remend@1.3.0: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0:
@@ -3009,15 +3593,82 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3034,6 +3685,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -3075,6 +3728,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -3100,6 +3755,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript-eslint@8.58.2(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -3147,11 +3808,15 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -3219,5 +3884,11 @@ snapshots:
   ws@8.20.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/src/mcp/http.ts
+++ b/src/mcp/http.ts
@@ -1,0 +1,63 @@
+/**
+ * HTTP MCP transport. Mounted at `/mcp` in `src/web/server.ts`.
+ *
+ * Auth: hub-issued JWT via `authenticate()` — same seam every other
+ * `/api/*` route uses. The strongest claw scope on the token's grant
+ * becomes the server's `effectiveScope`, which gates `tools/list` +
+ * `tools/call`. We require at minimum `claw:read` to even open the
+ * MCP session — without it there's nothing to advertise.
+ *
+ * Stateless mode: a fresh server + transport pair per HTTP request,
+ * with `sessionIdGenerator: undefined`. Each invocation closes its
+ * server in `finally` so we don't leak Protocol instances. The cost
+ * is one Server allocation per call; the win is no shared session
+ * map to evict from.
+ */
+import http from 'node:http';
+
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { authenticate, type ClawScope } from '../web/auth.js';
+import { log } from '../log.js';
+import { buildMcpServer } from './server.js';
+
+function pickEffectiveScope(grantedScopes: string[]): ClawScope {
+  if (grantedScopes.includes('claw:admin') || grantedScopes.includes('vault:admin')) return 'claw:admin';
+  if (grantedScopes.includes('claw:write')) return 'claw:write';
+  return 'claw:read';
+}
+
+export async function handleMcpHttp(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  parsedBody?: unknown,
+): Promise<void> {
+  const auth = await authenticate(req.headers.authorization, 'claw:read');
+  if (!auth.ok) {
+    res.writeHead(auth.status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: auth.error }));
+    return;
+  }
+
+  const effectiveScope = pickEffectiveScope(auth.claims.scopes);
+  const { server } = buildMcpServer({
+    effectiveScope,
+    callerSubject: auth.claims.sub,
+  });
+
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, parsedBody);
+  } catch (err) {
+    log.error('mcp http handler failed', { error: err instanceof Error ? err.message : String(err) });
+    if (!res.headersSent) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'internal mcp error' }));
+    }
+  } finally {
+    await server.close().catch(() => {
+      // best-effort; the request is already done
+    });
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,92 @@
+/**
+ * Build a paraclaw MCP server. Same registry serves both transports
+ * (stdio + HTTP). Scope-filtering: tools are advertised in `tools/list`
+ * only when the caller's effective scope satisfies the tool's required
+ * scope (per `hasScope`); `tools/call` re-validates scope + disabled
+ * status before invocation.
+ *
+ * Why one tool list per server (not per registry): the disabled-tool
+ * filter is the same code on every server build, so building the list
+ * once at construct time is fine. The factory is per-request only on
+ * HTTP, where the JWT changes per request.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { hasScope, type ClawScope } from '../web/auth.js';
+import type { ToolDef } from './types.js';
+import { buildAllTools } from './tools/index.js';
+
+export const MCP_SERVER_NAME = 'paraclaw';
+export const MCP_SERVER_VERSION = '0.1.0';
+
+export interface ServerHooks {
+  /** Strongest claw scope the caller has. Used to filter advertise + gate calls. */
+  effectiveScope: ClawScope;
+  /** JWT `sub` for HTTP, `mcp:stdio` for stdio. Threaded into approval-decide attribution. */
+  callerSubject: string;
+}
+
+export function buildMcpServer(hooks: ServerHooks): { server: Server; tools: ToolDef[] } {
+  const tools = buildAllTools(() => hooks.callerSubject);
+
+  const server = new Server({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: tools
+        .filter((t) => !t.disabled && hasScope([hooks.effectiveScope], t.scope))
+        .map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const name = req.params.name;
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `unknown tool: ${name}` }],
+      };
+    }
+    if (tool.disabled) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `tool disabled: ${tool.disabled.reason}` }],
+      };
+    }
+    if (!hasScope([hooks.effectiveScope], tool.scope)) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `insufficient scope: tool '${name}' requires '${tool.scope}', caller has '${hooks.effectiveScope}'`,
+          },
+        ],
+      };
+    }
+    try {
+      const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+      const result = await tool.handler(args, {
+        effectiveScope: hooks.effectiveScope,
+        callerSubject: hooks.callerSubject,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        isError: true,
+        content: [{ type: 'text', text: message }],
+      };
+    }
+  });
+
+  return { server, tools };
+}

--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * stdio MCP transport entrypoint. Wired with `claude mcp add paraclaw bun
+ * /path/to/paraclaw/src/mcp/stdio.ts`.
+ *
+ * Stdio is a same-machine ambient-trust surface — the operator already has
+ * filesystem access, so we default to `claw:admin`. No JWT, no per-call
+ * auth.
+ *
+ * Stdout discipline: paraclaw's `log.ts` writes info-level messages to
+ * `process.stdout`, which would corrupt the JSON-RPC stream the SDK
+ * speaks over stdout. We promote LOG_LEVEL to 'warn' BEFORE any module
+ * that uses `log` is loaded — dynamic imports below — so the logger
+ * never writes a line that isn't a JSON-RPC frame.
+ */
+if (!process.env.LOG_LEVEL || ['debug', 'info'].includes(process.env.LOG_LEVEL)) {
+  process.env.LOG_LEVEL = 'warn';
+}
+
+const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+const { initDb } = await import('../db/connection.js');
+const { runMigrations } = await import('../db/migrations/index.js');
+const { CENTRAL_DB_PATH } = await import('../config.js');
+const { buildMcpServer } = await import('./server.js');
+
+const STDIO_USER_ID = 'mcp:stdio';
+
+async function main(): Promise<void> {
+  // Open the central DB read-write so admin tools (create-agent-group,
+  // put-secret, decide-approval) can mutate. The host process owns the
+  // sole writer in production, but stdio is operator-driven and run
+  // out-of-band — concurrent writers are tolerable for the human-paced
+  // stdio path. Pragmas (WAL, busy_timeout) are set in `connection.ts`.
+  const db = initDb(CENTRAL_DB_PATH);
+  runMigrations(db);
+
+  const { server } = buildMcpServer({
+    effectiveScope: 'claw:admin',
+    callerSubject: STDIO_USER_ID,
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `paraclaw mcp stdio fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/mcp/tools/activity.ts
+++ b/src/mcp/tools/activity.ts
@@ -1,0 +1,32 @@
+/**
+ * Activity-log MCP tool — STUB. The matching paraclaw-server work
+ * (`agent_activity` table + the ingest path that populates it from
+ * agent-runner tool invocations) hasn't landed on this branch yet. Tool
+ * is advertised in the registry for human introspection and filtered
+ * out of `tools/list` until then.
+ */
+import type { ToolDef } from '../types.js';
+
+const PENDING = 'awaiting paraclaw-server: agent_activity table + ingest path not yet on this branch';
+
+export const activityTools: ToolDef[] = [
+  {
+    name: 'get-activity',
+    description:
+      'Stream recent agent tool-invocations across the install. STUB — disabled until the agent_activity table + ingest land.',
+    scope: 'claw:read',
+    disabled: { reason: PENDING },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentGroupId: { type: 'string', description: 'Optional agent group filter.' },
+        sessionId: { type: 'string', description: 'Optional session filter.' },
+        limit: { type: 'number', description: 'Max rows. Defaults to 100.' },
+      },
+      additionalProperties: false,
+    },
+    handler: async () => {
+      throw new Error(`get-activity disabled: ${PENDING}`);
+    },
+  },
+];

--- a/src/mcp/tools/agent-groups.ts
+++ b/src/mcp/tools/agent-groups.ts
@@ -1,0 +1,183 @@
+/**
+ * MCP tools for the agent-group surface — list / get / create. Mirrors what
+ * the web UI exposes at `/api/groups/*`, but calls the internal helpers
+ * directly rather than HTTP-round-tripping.
+ *
+ * Vault attach is exposed as a separate `attach-vault` tool because the
+ * input shape is meaningfully different (token + scope + label, not a
+ * simple group field). It refuses unknown groups with a structured error
+ * rather than silently no-op'ing — the test suite leans on that contract.
+ */
+import {
+  attachVaultToGroup,
+  detachVaultFromGroup,
+  readVaultAttachment,
+  DEFAULT_VAULT_MCP_NAME,
+} from '../../parachute/vault-mcp.js';
+import type { VaultScope } from '../../parachute/types.js';
+import { getAgentGroup, getAgentGroupByFolder, getAllAgentGroups } from '../../db/agent-groups.js';
+import { createParachuteAgentGroup, isFolderTaken, validateFolderSlug } from '../../parachute/create-agent.js';
+import { getGroupStatus } from '../../parachute/group-status.js';
+import type { ToolDef } from '../types.js';
+
+function viewForGroup(folder: string): Record<string, unknown> | null {
+  const row = getAgentGroupByFolder(folder);
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    folder: row.folder,
+    agentProvider: row.agent_provider,
+    createdAt: row.created_at,
+    vault: readVaultAttachment(row.folder),
+    status: getGroupStatus(row.folder),
+  };
+}
+
+const VALID_VAULT_SCOPES: VaultScope[] = ['vault:read', 'vault:write', 'vault:admin'];
+
+export const agentGroupTools: ToolDef[] = [
+  {
+    name: 'list-agent-groups',
+    description:
+      'List every agent group (workspace) in the install. Returns id, folder, name, agent provider, vault attachment, and live status (alive sessions, container state).',
+    scope: 'claw:read',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    handler: async () => {
+      return {
+        groups: getAllAgentGroups().map((row) => ({
+          id: row.id,
+          name: row.name,
+          folder: row.folder,
+          agentProvider: row.agent_provider,
+          createdAt: row.created_at,
+          vault: readVaultAttachment(row.folder),
+          status: getGroupStatus(row.folder),
+        })),
+      };
+    },
+  },
+  {
+    name: 'get-agent-group',
+    description:
+      'Look up a single agent group by folder slug. Same view shape as list-agent-groups. Returns null when the folder is unknown.',
+    scope: 'claw:read',
+    inputSchema: {
+      type: 'object',
+      properties: { folder: { type: 'string', description: 'Folder slug, e.g. "my-agent".' } },
+      required: ['folder'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const folder = String(args.folder ?? '').trim();
+      if (!folder) throw new Error('folder is required');
+      const view = viewForGroup(folder);
+      if (!view) throw new Error(`agent group not found: ${folder}`);
+      return view;
+    },
+  },
+  {
+    name: 'create-agent-group',
+    description:
+      'Create a new agent group. Validates the folder slug, refuses duplicates, writes the DB row, and scaffolds the per-group filesystem (CLAUDE.md, container.json, …).',
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Display name.' },
+        folder: { type: 'string', description: 'URL-safe slug (kebab-case).' },
+        instructions: { type: 'string', description: 'Optional CLAUDE.md content for the group.' },
+      },
+      required: ['name', 'folder'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const name = String(args.name ?? '').trim();
+      const folder = String(args.folder ?? '').trim();
+      if (!name) throw new Error('name is required');
+      const folderCheck = validateFolderSlug(folder);
+      if (!folderCheck.ok) throw new Error(`invalid folder: ${folderCheck.reason}`);
+      if (isFolderTaken(folder)) throw new Error(`folder already exists: ${folder}`);
+      const instructions = typeof args.instructions === 'string' ? args.instructions : undefined;
+      const result = createParachuteAgentGroup({ name, folder, instructions });
+      return {
+        group: {
+          id: result.group.id,
+          name: result.group.name,
+          folder: result.group.folder,
+          agentProvider: result.group.agent_provider,
+          createdAt: result.group.created_at,
+        },
+      };
+    },
+  },
+  {
+    name: 'attach-vault',
+    description:
+      "Attach a Parachute Vault to an agent group as an MCP server. Writes the entry into the group's container.json and records the attachment in parachute.json. The vault token must already be minted.",
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        folder: { type: 'string', description: 'Agent group folder slug.' },
+        vaultBaseUrl: { type: 'string', description: 'Vault base URL, no trailing slash, no /mcp suffix.' },
+        vaultToken: { type: 'string', description: 'pvt_… token to bake into the MCP entry.' },
+        scope: {
+          type: 'string',
+          enum: VALID_VAULT_SCOPES,
+          description: 'Scope this token was minted at.',
+        },
+        tokenLabel: { type: 'string', description: 'Token label (matches vault registration).' },
+        mcpName: { type: 'string', description: 'Optional MCP entry name. Defaults to "parachute-vault".' },
+        instructions: { type: 'string', description: 'Optional in-context instructions for the agent.' },
+      },
+      required: ['folder', 'vaultBaseUrl', 'vaultToken', 'scope', 'tokenLabel'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const folder = String(args.folder ?? '').trim();
+      if (!folder) throw new Error('folder is required');
+      if (!getAgentGroupByFolder(folder)) throw new Error(`agent group not found: ${folder}`);
+      const scope = String(args.scope ?? '');
+      if (!VALID_VAULT_SCOPES.includes(scope as VaultScope)) {
+        throw new Error(`invalid scope: ${scope}`);
+      }
+      attachVaultToGroup({
+        folder,
+        vaultBaseUrl: String(args.vaultBaseUrl ?? '').replace(/\/+$/, ''),
+        vaultToken: String(args.vaultToken ?? ''),
+        scope: scope as VaultScope,
+        tokenLabel: String(args.tokenLabel ?? ''),
+        mcpName: typeof args.mcpName === 'string' ? args.mcpName : undefined,
+        instructions: typeof args.instructions === 'string' ? args.instructions : undefined,
+      });
+      const mcpName = typeof args.mcpName === 'string' ? args.mcpName : DEFAULT_VAULT_MCP_NAME;
+      return { vault: readVaultAttachment(folder, mcpName) };
+    },
+  },
+  {
+    name: 'detach-vault',
+    description:
+      "Detach a previously attached vault from an agent group. Removes the MCP entry from container.json and the attach record from parachute.json. Does NOT revoke the vault token — that's a separate action against the vault.",
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        folder: { type: 'string', description: 'Agent group folder slug.' },
+        mcpName: { type: 'string', description: 'Optional MCP entry name. Defaults to "parachute-vault".' },
+      },
+      required: ['folder'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const folder = String(args.folder ?? '').trim();
+      if (!folder) throw new Error('folder is required');
+      if (!getAgentGroup(folder) && !getAgentGroupByFolder(folder)) {
+        throw new Error(`agent group not found: ${folder}`);
+      }
+      const mcpName = typeof args.mcpName === 'string' ? args.mcpName : DEFAULT_VAULT_MCP_NAME;
+      detachVaultFromGroup(folder, mcpName);
+      return { detached: true, folder, mcpName };
+    },
+  },
+];

--- a/src/mcp/tools/approvals.ts
+++ b/src/mcp/tools/approvals.ts
@@ -1,0 +1,152 @@
+/**
+ * MCP tools for the approval queue. `decide-approval` flows through the
+ * same `handleApprovalsResponse` dispatcher the chat-card path uses, so
+ * the row-update + module-action + agent-notify behaviour is identical
+ * regardless of whether the operator decides via DM or via this tool.
+ *
+ * Caller identity: `decide-approval` records the decider as the JWT `sub`
+ * for HTTP transport, or `mcp:stdio` for stdio. Approval factory pattern
+ * lets us thread the subject in at server-build time without leaking
+ * transport details to individual handlers.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
+import { getSession } from '../../db/sessions.js';
+import { handleApprovalsResponse } from '../../modules/approvals/response-handler.js';
+import type { ToolDef } from '../types.js';
+
+interface ApprovalRow {
+  approval_id: string;
+  session_id: string | null;
+  action: string;
+  payload: string;
+  created_at: string;
+  agent_group_id: string | null;
+  status: string;
+}
+
+interface ApprovalView {
+  id: string;
+  agentGroupId: string;
+  agentGroupName: string | null;
+  kind: string;
+  actionPayload: Record<string, unknown>;
+  status: 'pending' | 'approved' | 'rejected' | 'expired';
+  requestedAt: string;
+  decidedAt: string | null;
+  requestedBy: string;
+}
+
+function rowToView(row: ApprovalRow): ApprovalView | null {
+  let agentGroupId = row.agent_group_id ?? '';
+  if (!agentGroupId && row.session_id) {
+    const session = getSession(row.session_id);
+    if (session) agentGroupId = session.agent_group_id;
+  }
+  if (!agentGroupId) return null;
+  let agentGroupName: string | null = null;
+  try {
+    const group = getAgentGroup(agentGroupId);
+    if (group) agentGroupName = group.name;
+  } catch {
+    // tolerate FK miss
+  }
+  let actionPayload: Record<string, unknown> = {};
+  try {
+    actionPayload = JSON.parse(row.payload) as Record<string, unknown>;
+  } catch {
+    actionPayload = { _raw: row.payload };
+  }
+  const status = (['pending', 'approved', 'rejected', 'expired'] as const).find((s) => s === row.status) ?? 'pending';
+  return {
+    id: row.approval_id,
+    agentGroupId,
+    agentGroupName,
+    kind: row.action,
+    actionPayload,
+    status,
+    requestedAt: row.created_at,
+    decidedAt: null,
+    requestedBy: row.session_id ?? '',
+  };
+}
+
+function listPending(): ApprovalView[] {
+  const rows = getDb()
+    .prepare<ApprovalRow>(
+      `SELECT approval_id, session_id, action, payload, created_at, agent_group_id, status
+         FROM pending_approvals
+        WHERE status = 'pending'
+        ORDER BY created_at DESC`,
+    )
+    .all() as ApprovalRow[];
+  return rows.flatMap((r) => {
+    const v = rowToView(r);
+    return v ? [v] : [];
+  });
+}
+
+function getOne(approvalId: string): ApprovalView | null {
+  const row = getDb()
+    .prepare<ApprovalRow>(
+      `SELECT approval_id, session_id, action, payload, created_at, agent_group_id, status
+         FROM pending_approvals
+        WHERE approval_id = @id`,
+    )
+    .get({ id: approvalId }) as ApprovalRow | undefined;
+  if (!row) return null;
+  return rowToView(row);
+}
+
+export function buildApprovalTools(getCallerSubject: () => string): ToolDef[] {
+  return [
+    {
+      name: 'list-approvals',
+      description:
+        'List pending approvals — agent-requested actions awaiting human consent (install_packages, add_mcp_server, …).',
+      scope: 'claw:read',
+      inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      handler: async () => ({ approvals: listPending() }),
+    },
+    {
+      name: 'decide-approval',
+      description:
+        "Decide a pending approval. Routes through the same dispatcher the chat-card path uses, so the side effects (row delete, module-action run, agent notify) are identical. The deciding userId is recorded as the caller's JWT sub (or 'mcp:stdio' for stdio).",
+      scope: 'claw:admin',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Approval id.' },
+          decision: { type: 'string', enum: ['approve', 'reject'] },
+        },
+        required: ['id', 'decision'],
+        additionalProperties: false,
+      },
+      handler: async (args) => {
+        const id = String(args.id ?? '');
+        const decision = args.decision === 'approve' || args.decision === 'reject' ? args.decision : null;
+        if (!id) throw new Error('id is required');
+        if (!decision) throw new Error("decision must be 'approve' or 'reject'");
+        const before = getOne(id);
+        if (!before) throw new Error(`approval not found: ${id}`);
+        if (before.status !== 'pending') throw new Error(`approval already ${before.status}`);
+        const handled = await handleApprovalsResponse({
+          questionId: id,
+          value: decision,
+          userId: getCallerSubject(),
+          channelType: 'mcp',
+          platformId: 'paraclaw-mcp',
+          threadId: null,
+        });
+        if (!handled) throw new Error('approval was decided by another path before our update landed');
+        return {
+          approval: {
+            ...before,
+            status: decision === 'approve' ? 'approved' : 'rejected',
+            decidedAt: new Date().toISOString(),
+          },
+        };
+      },
+    },
+  ];
+}

--- a/src/mcp/tools/channels.ts
+++ b/src/mcp/tools/channels.ts
@@ -1,0 +1,199 @@
+/**
+ * MCP tools for channel-wire CRUD. Mirrors `/api/channels`. The DB still
+ * stores the pre-rebuild enum names (engage_mode = mention | pattern |
+ * mention-sticky; sender_scope = all | known; ignored_message_policy = drop
+ * | accumulate); the API contract these tools speak — same as the web API —
+ * uses the new vocabulary (engageMode = mention | pattern | all; senderScope
+ * = allowlist | all; ignoredMessagePolicy = drop | silent). The translator
+ * is small so we inline it here rather than carving out a shared module
+ * that would need its own seam through the route handler.
+ */
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getDb } from '../../db/connection.js';
+import {
+  deleteMessagingGroupAgent,
+  getMessagingGroup,
+  getMessagingGroupAgent,
+  updateMessagingGroupAgent,
+} from '../../db/messaging-groups.js';
+import type {
+  EngageMode as DbEngageMode,
+  IgnoredMessagePolicy as DbIgnoredMessagePolicy,
+  SenderScope as DbSenderScope,
+  MessagingGroupAgent,
+} from '../../types.js';
+import type { ToolDef } from '../types.js';
+
+type ApiEngageMode = 'mention' | 'pattern' | 'all';
+type ApiSenderScope = 'allowlist' | 'all';
+type ApiIgnoredMessagePolicy = 'drop' | 'silent';
+
+const ALL_PATTERN = '.';
+
+function dbToApiEngage(mode: DbEngageMode, pattern: string | null): ApiEngageMode {
+  if (mode === 'pattern') return pattern === ALL_PATTERN ? 'all' : 'pattern';
+  return 'mention';
+}
+function dbToApiSenderScope(s: DbSenderScope): ApiSenderScope {
+  return s === 'known' ? 'allowlist' : 'all';
+}
+function dbToApiIgnoredPolicy(p: DbIgnoredMessagePolicy): ApiIgnoredMessagePolicy {
+  return p === 'accumulate' ? 'silent' : 'drop';
+}
+
+interface WireRow extends MessagingGroupAgent {
+  mg_channel_type: string;
+  mg_platform_id: string;
+  mg_name: string | null;
+  ag_folder: string;
+  ag_name: string;
+}
+
+interface ChannelWireView {
+  id: string;
+  channelType: string;
+  messagingGroupId: string;
+  platformId: string;
+  displayName: string | null;
+  agentGroupId: string;
+  agentGroupFolder: string;
+  agentGroupName: string;
+  engageMode: ApiEngageMode;
+  engagePattern: string | null;
+  senderScope: ApiSenderScope;
+  ignoredMessagePolicy: ApiIgnoredMessagePolicy;
+  priority: number;
+  createdAt: string;
+}
+
+function rowToView(row: WireRow): ChannelWireView {
+  return {
+    id: row.id,
+    channelType: row.mg_channel_type,
+    messagingGroupId: row.messaging_group_id,
+    platformId: row.mg_platform_id,
+    displayName: row.mg_name,
+    agentGroupId: row.agent_group_id,
+    agentGroupFolder: row.ag_folder,
+    agentGroupName: row.ag_name,
+    engageMode: dbToApiEngage(row.engage_mode, row.engage_pattern),
+    engagePattern: row.engage_mode === 'pattern' && row.engage_pattern !== ALL_PATTERN ? row.engage_pattern : null,
+    senderScope: dbToApiSenderScope(row.sender_scope),
+    ignoredMessagePolicy: dbToApiIgnoredPolicy(row.ignored_message_policy),
+    priority: row.priority,
+    createdAt: row.created_at,
+  };
+}
+
+function listAllWires(): ChannelWireView[] {
+  return (
+    getDb()
+      .prepare<WireRow>(
+        `SELECT mga.*,
+                mg.channel_type AS mg_channel_type,
+                mg.platform_id  AS mg_platform_id,
+                mg.name         AS mg_name,
+                ag.folder       AS ag_folder,
+                ag.name         AS ag_name
+           FROM messaging_group_agents mga
+           JOIN messaging_groups mg ON mg.id = mga.messaging_group_id
+           JOIN agent_groups ag     ON ag.id = mga.agent_group_id
+          ORDER BY mga.created_at DESC`,
+      )
+      .all() as WireRow[]
+  ).map(rowToView);
+}
+
+function getWireView(id: string): ChannelWireView | null {
+  const mga = getMessagingGroupAgent(id);
+  if (!mga) return null;
+  const mg = getMessagingGroup(mga.messaging_group_id);
+  const ag = getAgentGroup(mga.agent_group_id);
+  if (!mg || !ag) return null;
+  return rowToView({
+    ...mga,
+    mg_channel_type: mg.channel_type,
+    mg_platform_id: mg.platform_id,
+    mg_name: mg.name,
+    ag_folder: ag.folder,
+    ag_name: ag.name,
+  });
+}
+
+export const channelTools: ToolDef[] = [
+  {
+    name: 'list-channels',
+    description:
+      'List every channel wire in the install — each row is a (messaging-group → agent-group) routing rule with its engage/sender/policy/priority settings.',
+    scope: 'claw:read',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    handler: async () => ({ wires: listAllWires() }),
+  },
+  {
+    name: 'delete-channel-wire',
+    description: 'Delete a channel wire by id. The agent_destinations row created at wire time is left in place.',
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Channel wire id.' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const id = String(args.id ?? '');
+      if (!id) throw new Error('id is required');
+      const current = getMessagingGroupAgent(id);
+      if (!current) throw new Error(`channel wire not found: ${id}`);
+      deleteMessagingGroupAgent(id);
+      return { id, deleted: true };
+    },
+  },
+  {
+    name: 'update-channel-wire',
+    description:
+      'Update a channel wire by id. Any subset of engageMode, engagePattern, senderScope, ignoredMessagePolicy, priority can be supplied.',
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        engageMode: { type: 'string', enum: ['mention', 'pattern', 'all'] },
+        engagePattern: { type: ['string', 'null'] },
+        senderScope: { type: 'string', enum: ['allowlist', 'all'] },
+        ignoredMessagePolicy: { type: 'string', enum: ['drop', 'silent'] },
+        priority: { type: 'number' },
+      },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const id = String(args.id ?? '');
+      const current = getMessagingGroupAgent(id);
+      if (!current) throw new Error(`channel wire not found: ${id}`);
+      const patch: Partial<MessagingGroupAgent> = {};
+      if (args.engageMode === 'all') {
+        patch.engage_mode = 'pattern';
+        patch.engage_pattern = ALL_PATTERN;
+      } else if (args.engageMode === 'pattern') {
+        patch.engage_mode = 'pattern';
+        if (typeof args.engagePattern === 'string' && args.engagePattern !== ALL_PATTERN) {
+          patch.engage_pattern = args.engagePattern;
+        }
+      } else if (args.engageMode === 'mention') {
+        patch.engage_mode = current.engage_mode === 'mention-sticky' ? 'mention-sticky' : 'mention';
+        patch.engage_pattern = null;
+      } else if (typeof args.engagePattern === 'string' || args.engagePattern === null) {
+        patch.engage_pattern = args.engagePattern as string | null;
+      }
+      if (args.senderScope === 'allowlist') patch.sender_scope = 'known';
+      else if (args.senderScope === 'all') patch.sender_scope = 'all';
+      if (args.ignoredMessagePolicy === 'silent') patch.ignored_message_policy = 'accumulate';
+      else if (args.ignoredMessagePolicy === 'drop') patch.ignored_message_policy = 'drop';
+      if (typeof args.priority === 'number' && Number.isFinite(args.priority)) patch.priority = args.priority;
+      updateMessagingGroupAgent(id, patch);
+      const after = getWireView(id);
+      if (!after) throw new Error(`channel wire ${id} disappeared after update`);
+      return { wire: after };
+    },
+  },
+];

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,0 +1,27 @@
+/**
+ * One flat tool registry. The factory threads a `getCallerSubject` getter
+ * through to handlers that need it (today: `decide-approval`). The getter
+ * is closure-captured at server-build time — for HTTP that's per-request
+ * (the JWT `sub` for that request); for stdio that's a constant
+ * `mcp:stdio`.
+ */
+import type { ToolDef } from '../types.js';
+import { activityTools } from './activity.js';
+import { agentGroupTools } from './agent-groups.js';
+import { buildApprovalTools } from './approvals.js';
+import { channelTools } from './channels.js';
+import { oauthTools } from './oauth.js';
+import { secretTools } from './secrets.js';
+import { sessionTools } from './sessions.js';
+
+export function buildAllTools(getCallerSubject: () => string): ToolDef[] {
+  return [
+    ...agentGroupTools,
+    ...sessionTools,
+    ...channelTools,
+    ...secretTools,
+    ...buildApprovalTools(getCallerSubject),
+    ...oauthTools,
+    ...activityTools,
+  ];
+}

--- a/src/mcp/tools/oauth.ts
+++ b/src/mcp/tools/oauth.ts
@@ -1,0 +1,48 @@
+/**
+ * OAuth-flow MCP tools — currently STUBS. The matching paraclaw-server
+ * endpoints (`/api/integrations/*` + the OAuth callback scaffold) haven't
+ * landed on this branch yet. Tools are advertised in the registry for
+ * human introspection (so the team-lead can see the planned surface) but
+ * filtered out of `tools/list` and refused on `tools/call` until then.
+ */
+import type { ToolDef } from '../types.js';
+
+const PENDING = 'awaiting paraclaw-server: /api/integrations/* + OAuth callback scaffold not yet on this branch';
+
+export const oauthTools: ToolDef[] = [
+  {
+    name: 'start-oauth',
+    description:
+      'Kick off an OAuth flow against an external provider (Google, Slack, …). Returns the authorization URL the operator should visit. STUB — disabled until /api/integrations/start lands.',
+    scope: 'claw:admin',
+    disabled: { reason: PENDING },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        provider: { type: 'string', description: 'Provider id, e.g. "google" or "slack".' },
+        agentGroupId: { type: 'string', description: 'Agent group to attach the resulting integration to.' },
+      },
+      required: ['provider', 'agentGroupId'],
+      additionalProperties: false,
+    },
+    handler: async () => {
+      throw new Error(`start-oauth disabled: ${PENDING}`);
+    },
+  },
+  {
+    name: 'revoke-integration',
+    description:
+      'Revoke an existing integration (deletes stored OAuth tokens, removes the MCP entry). STUB — disabled until /api/integrations/:id lands.',
+    scope: 'claw:admin',
+    disabled: { reason: PENDING },
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Integration id.' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async () => {
+      throw new Error(`revoke-integration disabled: ${PENDING}`);
+    },
+  },
+];

--- a/src/mcp/tools/secrets.ts
+++ b/src/mcp/tools/secrets.ts
@@ -1,0 +1,154 @@
+/**
+ * MCP tools for the secret store. Mirrors `/api/secrets` (and the matching
+ * UI under `/claw/secrets`), with one important wrinkle: the MCP surface
+ * NEVER returns plaintext values. Even on `put-secret`, the response only
+ * carries the row id + metadata — the value flows in once over the
+ * transport, lands in the encrypted DB column, and is read back only by
+ * the container-runner at session-spawn time.
+ *
+ * `assign-secret` is advertised but disabled until paraclaw-server lands
+ * the matching `/api/secrets/:id/assignments` endpoints + `secret_assignments`
+ * table on this branch. See PENDING_REASON below.
+ */
+import {
+  type AssignedMode,
+  type SecretKind,
+  type SecretRow,
+  deleteSecret,
+  listSecrets,
+  putSecret,
+} from '../../secrets/index.js';
+import type { ToolDef } from '../types.js';
+
+const ALLOWED_KINDS: SecretKind[] = ['channel-token', 'api-key', 'generic'];
+const ALLOWED_MODES: AssignedMode[] = ['all', 'selective'];
+
+interface SecretView {
+  id: string;
+  name: string;
+  kind: SecretKind;
+  agentGroupId: string | null;
+  assignedMode: AssignedMode;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function toView(r: SecretRow): SecretView {
+  return {
+    id: r.id,
+    name: r.name,
+    kind: r.kind,
+    agentGroupId: r.agent_group_id,
+    assignedMode: r.assigned_mode,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+const ASSIGN_PENDING =
+  'awaiting paraclaw-server: /api/secrets/:id/assignments + secret_assignments table not yet on this branch';
+
+export const secretTools: ToolDef[] = [
+  {
+    name: 'list-secrets',
+    description:
+      'List secret metadata. NEVER returns plaintext values. Optional `agentGroupId` filter: empty string = global only; non-empty = global + that scope.',
+    scope: 'claw:read',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentGroupId: { type: ['string', 'null'], description: 'Optional filter; empty/null = global only.' },
+      },
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      let scope: string | null | undefined = undefined;
+      if (args.agentGroupId === null || args.agentGroupId === '') scope = null;
+      else if (typeof args.agentGroupId === 'string') scope = args.agentGroupId;
+      return { secrets: listSecrets(scope).map(toView) };
+    },
+  },
+  {
+    name: 'put-secret',
+    description:
+      'Insert or update a secret by (name, agentGroupId). Returns the row metadata — never the plaintext. The value is AES-256-GCM encrypted in-process before landing in the DB.',
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        value: { type: 'string', description: 'Plaintext value. Encrypted before storage; never logged.' },
+        kind: { type: 'string', enum: ALLOWED_KINDS, description: 'Defaults to "generic".' },
+        agentGroupId: {
+          type: ['string', 'null'],
+          description: 'null = global; non-empty = scoped to that agent group.',
+        },
+        assignedMode: {
+          type: 'string',
+          enum: ALLOWED_MODES,
+          description:
+            '"all" = injected into every group; "selective" = only into groups in secret_assignments. Defaults to "all".',
+        },
+      },
+      required: ['name', 'value'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const name = String(args.name ?? '').trim();
+      const value = typeof args.value === 'string' ? args.value : '';
+      if (!name) throw new Error('name is required');
+      if (!value) throw new Error('value is required');
+      const kind = (typeof args.kind === 'string' ? args.kind : 'generic') as SecretKind;
+      if (!ALLOWED_KINDS.includes(kind)) throw new Error(`invalid kind: ${kind}`);
+      const mode = (typeof args.assignedMode === 'string' ? args.assignedMode : 'all') as AssignedMode;
+      if (!ALLOWED_MODES.includes(mode)) throw new Error(`invalid assignedMode: ${mode}`);
+      const agentGroupId = typeof args.agentGroupId === 'string' && args.agentGroupId.length ? args.agentGroupId : null;
+
+      const id = putSecret(name, value, { kind, agent_group_id: agentGroupId, assigned_mode: mode });
+      const row = listSecrets(agentGroupId).find((r) => r.id === id);
+      if (!row) throw new Error(`secret ${id} disappeared after write`);
+      return { secret: toView(row) };
+    },
+  },
+  {
+    name: 'delete-secret',
+    description: 'Delete a secret by id. Returns { deleted: true } on success, throws on unknown id.',
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const id = String(args.id ?? '');
+      if (!id) throw new Error('id is required');
+      const ok = deleteSecret(id);
+      if (!ok) throw new Error(`secret not found: ${id}`);
+      return { id, deleted: true };
+    },
+  },
+  {
+    name: 'assign-secret',
+    description:
+      "Assign a 'selective' secret to one or more agent groups. STUB — disabled until paraclaw-server's secret_assignments endpoints land on this branch.",
+    scope: 'claw:admin',
+    disabled: { reason: ASSIGN_PENDING },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Secret id.' },
+        agentGroupIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Agent group ids to inject the secret into.',
+        },
+      },
+      required: ['id', 'agentGroupIds'],
+      additionalProperties: false,
+    },
+    handler: async () => {
+      throw new Error(`assign-secret disabled: ${ASSIGN_PENDING}`);
+    },
+  },
+];

--- a/src/mcp/tools/sessions.ts
+++ b/src/mcp/tools/sessions.ts
@@ -1,0 +1,135 @@
+/**
+ * MCP tools for the per-session surface — list / get / close. Mirrors
+ * `/api/sessions` (and uses the same heartbeat-mtime liveness computation
+ * via DEFAULT_ALIVE_THRESHOLD_MS) but calls the internal helpers directly
+ * rather than HTTP-round-tripping.
+ *
+ * `close-session` calls `killContainer` to actually stop the running
+ * container. Idempotent: calling again on an already-closed session is
+ * a no-op that returns the current view.
+ */
+import fs from 'node:fs';
+
+import { getAllAgentGroups } from '../../db/agent-groups.js';
+import { getSession, getSessionsByAgentGroup, updateSession } from '../../db/sessions.js';
+import { killContainer } from '../../container-runner.js';
+import { DEFAULT_ALIVE_THRESHOLD_MS } from '../../parachute/group-status.js';
+import { heartbeatPath } from '../../session-manager.js';
+import type { ToolDef } from '../types.js';
+
+interface SessionView {
+  id: string;
+  agentGroupId: string;
+  agentGroupFolder: string;
+  agentGroupName: string;
+  messagingGroupId: string | null;
+  status: 'active' | 'closed';
+  containerStatus: 'running' | 'idle' | 'stopped';
+  alive: boolean;
+  createdAt: string;
+  lastActiveAt: string | null;
+  lastHeartbeatAt: string | null;
+}
+
+function readHeartbeatMtimeMs(agentGroupId: string, sessionId: string): number {
+  try {
+    return fs.statSync(heartbeatPath(agentGroupId, sessionId)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function listAllSessions(opts: { folder?: string; status?: 'active' | 'closed' } = {}): SessionView[] {
+  const nowMs = Date.now();
+  const out: SessionView[] = [];
+  for (const group of getAllAgentGroups()) {
+    if (opts.folder && group.folder !== opts.folder) continue;
+    for (const s of getSessionsByAgentGroup(group.id)) {
+      if (opts.status && s.status !== opts.status) continue;
+      const heartbeatMs = readHeartbeatMtimeMs(group.id, s.id);
+      const alive = heartbeatMs > 0 && nowMs - heartbeatMs <= DEFAULT_ALIVE_THRESHOLD_MS;
+      out.push({
+        id: s.id,
+        agentGroupId: group.id,
+        agentGroupFolder: group.folder,
+        agentGroupName: group.name,
+        messagingGroupId: s.messaging_group_id,
+        status: s.status,
+        containerStatus: s.container_status,
+        alive,
+        createdAt: s.created_at,
+        lastActiveAt: s.last_active,
+        lastHeartbeatAt: heartbeatMs > 0 ? new Date(heartbeatMs).toISOString() : null,
+      });
+    }
+  }
+  out.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  return out;
+}
+
+export const sessionTools: ToolDef[] = [
+  {
+    name: 'list-sessions',
+    description:
+      'List sessions across the install. Optional filters: folder (one agent group only) and status (active|closed). Liveness uses the heartbeat mtime.',
+    scope: 'claw:read',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        folder: { type: 'string', description: 'Optional agent-group folder filter.' },
+        status: { type: 'string', enum: ['active', 'closed'], description: 'Optional status filter.' },
+      },
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const folder = typeof args.folder === 'string' && args.folder.length ? args.folder : undefined;
+      const status = args.status === 'active' || args.status === 'closed' ? args.status : undefined;
+      return { sessions: listAllSessions({ folder, status }) };
+    },
+  },
+  {
+    name: 'get-session',
+    description: 'Look up a single session by id. Throws when the id is unknown.',
+    scope: 'claw:read',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Session id.' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const id = String(args.id ?? '');
+      if (!id) throw new Error('id is required');
+      const session = getSession(id);
+      if (!session) throw new Error(`session not found: ${id}`);
+      const all = listAllSessions();
+      const view = all.find((v) => v.id === id);
+      if (!view) throw new Error(`session not found in listing: ${id}`);
+      return view;
+    },
+  },
+  {
+    name: 'close-session',
+    description:
+      "Close a session: mark the row status='closed' and call killContainer to actually stop the container. Idempotent — already-closed sessions return the current view without re-killing.",
+    scope: 'claw:admin',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string', description: 'Session id.' } },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    handler: async (args) => {
+      const id = String(args.id ?? '');
+      if (!id) throw new Error('id is required');
+      const session = getSession(id);
+      if (!session) throw new Error(`session not found: ${id}`);
+      if (session.status === 'closed') {
+        return { id, status: 'closed', alreadyClosed: true };
+      }
+      updateSession(id, { status: 'closed', container_status: 'stopped' });
+      killContainer(id, 'closed via mcp');
+      return { id, status: 'closed' };
+    },
+  },
+];

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types for paraclaw's MCP server. The registry is one flat list of
+ * `ToolDef`s built once per request — both stdio and HTTP transports
+ * consume the same registry, with scope-filtering and "disabled" gating
+ * applied at advertise time and re-checked at call time.
+ *
+ * Why factory-style scope context: stdio defaults to `claw:admin` (the
+ * caller is the operator on the same machine, ambient trust); HTTP derives
+ * the strongest claw scope from the JWT's grant. Both paths flow into a
+ * `ToolHandlerContext` so individual tool handlers can refuse mutating ops
+ * when the caller only holds `claw:read`.
+ */
+import type { ClawScope } from '../web/auth.js';
+
+export type { ClawScope };
+
+/**
+ * Per-call context handed to a tool handler. `effectiveScope` is the
+ * strongest scope the caller has — handlers that mutate state can choose
+ * to refuse if it's below their advertised scope (defense-in-depth; the
+ * registry already gates list/call by `t.scope`).
+ *
+ * `callerSubject` is the JWT `sub` for HTTP and a synthetic
+ * `mcp:stdio` for the stdio transport. Used by approval-decide-style
+ * tools that need an attribution string.
+ */
+export interface ToolHandlerContext {
+  effectiveScope: ClawScope;
+  callerSubject: string;
+}
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  /**
+   * JSON Schema for the tool's input. We pass it straight through to the
+   * MCP SDK's tools/list response; the SDK does no validation, so handlers
+   * are expected to defensively coerce / validate the args they care about.
+   */
+  inputSchema: Record<string, unknown>;
+  /** Required scope to advertise + invoke. */
+  scope: ClawScope;
+  /**
+   * If set, the tool is advertised in the registry (for human introspection)
+   * but filtered out of `tools/list` and refused on `tools/call`. Used for
+   * surfaces that depend on paraclaw-server endpoints not yet on this
+   * branch — see tools/oauth.ts and tools/activity.ts.
+   */
+  disabled?: { reason: string };
+  handler: (args: Record<string, unknown>, ctx: ToolHandlerContext) => Promise<unknown>;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -53,6 +53,7 @@ import {
   type ClawScope,
 } from './auth.js';
 import { fetchHubVaults } from './hub-discovery.js';
+import { handleMcpHttp } from '../mcp/http.js';
 import { handleAppsRoute } from './routes/apps.js';
 import { handleApprovalsRoute } from './routes/approvals.js';
 import { handleChannelsRoute } from './routes/channels.js';
@@ -600,6 +601,13 @@ export function startWebServer(): http.Server {
         await handleApi(req, res, url, dispatchPath);
         return;
       }
+      // MCP transport — same auth seam as /api/* routes (hub JWT, claw:read
+      // minimum). Mount-aware: hits `/mcp` whether the install lives at
+      // origin root or behind PARACLAW_WEB_MOUNT.
+      if (dispatchPath === '/mcp' || dispatchPath.startsWith('/mcp/')) {
+        await handleMcpHttp(req, res);
+        return;
+      }
       // Capability card per parachute-patterns/well-known-discovery-rfc.
       // Lives at the origin root regardless of MOUNT — peer modules and the
       // hub's services catalog hit `/.well-known/parachute.json` directly.
@@ -619,6 +627,7 @@ export function startWebServer(): http.Server {
               paths: manifest.paths,
               health: manifest.health,
               scopes: manifest.scopes,
+              mcp: { http: '/mcp', stdio: true },
             }),
           );
         } catch (err) {


### PR DESCRIPTION
## Summary

- Adds a paraclaw MCP server (`mcp__paraclaw__*` tools) with two transports sharing one tool registry: stdio (`bun src/mcp/stdio.ts`) and HTTP at `POST /mcp` on port 1944.
- Tools: agent-groups (list/get/create + attach/detach-vault), sessions (list/get/close), channels (list/update/delete-wire), secrets (list/put/delete — metadata only, plaintext never traverses MCP), approvals (list/decide — flows through `handleApprovalsResponse`).
- Stubs (`assign-secret`, `start-oauth`, `revoke-integration`, `get-activity`) advertise in the registry but are filtered out of `tools/list` and refused on `tools/call` until the matching paraclaw-server endpoints land.

## Design notes

- **API parity, not API replacement**: handlers call internal helpers directly (`createParachuteAgentGroup`, `putSecret`, `handleApprovalsResponse`, …) — no HTTP round-trip back to `/api/*`.
- **Auth seam**: stdio is same-machine ambient trust → `claw:admin`. HTTP runs through the existing `authenticate()` from `src/web/auth.ts`; effective scope is the strongest `claw:*` on the JWT grant.
- **Caller subject**: stdio = `mcp:stdio`; HTTP = JWT `sub`. Threaded into approval-decide attribution via a factory pattern (`buildApprovalTools(getCallerSubject)`) so individual handlers don't see transport details.
- **Stateless HTTP**: per-request `server`+`transport` pair, `sessionIdGenerator: undefined`, transport closed in `finally`.
- **Stdio gotcha**: paraclaw's `log.ts` writes info-level messages to `process.stdout`, which would corrupt JSON-RPC frames. `src/mcp/stdio.ts` promotes `LOG_LEVEL` to `warn` before any log-using import — don't move that block below the dynamic imports.
- **Capability card**: `/.well-known/parachute.json` now advertises `mcp: { http: '/mcp', stdio: true }`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` clean (27 files / 261 tests)
- [ ] `claude mcp add paraclaw bun /path/to/paraclaw/src/mcp/stdio.ts` then `claude mcp list paraclaw` shows `paraclaw` connected
- [ ] `tools/list` returns the kebab-case inventory; stubbed tools are filtered out under `claw:admin`
- [ ] `tools/call list-agent-groups` returns agent-groups
- [ ] HTTP `/mcp` rejects requests without a hub-issued JWT and accepts requests with one (claw:read)
- [ ] `put-secret` does not echo the plaintext value in its response

Refs #218, #219, #220, #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from ParachuteComputer/paraclaw-archive-fork#42 (the repo was detached from the qwibitai/nanoclaw fork network; PRs were re-created on the standalone repo with new numbers)._