### PR TITLE
feat(server): OAuth integration scaffold + Google (refs #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.5",
+  "version": "0.0.14-rc.6",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.6",
+  "version": "0.0.14-rc.7",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.4",
+  "version": "0.0.14-rc.5",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/migrations/018-oauth-app-configs.ts
+++ b/src/db/migrations/018-oauth-app-configs.ts
@@ -1,0 +1,34 @@
+/**
+ * OAuth provider client configs (BYOC — Bring Your Own Client).
+ *
+ * One row per provider. The user (operator) registers their own OAuth
+ * client with the provider (e.g. Google Cloud Console), then drops the
+ * `client_id` + `client_secret` here. paraclaw uses these to mint
+ * authorize URLs and exchange codes for tokens.
+ *
+ *   - `client_secret_encrypted` is `iv || ciphertext || authTag` (base64),
+ *     same wire format as `secrets.value_encrypted`. Encryption key is
+ *     HKDF-derived from the master key with info `paraclaw.oauth.v1`.
+ *   - `scopes_default` is a space-separated OAuth scope string applied
+ *     when the operator doesn't override at authorize-time.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration018: Migration = {
+  version: 18,
+  name: 'oauth-app-configs',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS app_configs (
+        id                       TEXT PRIMARY KEY,
+        provider                 TEXT NOT NULL UNIQUE,
+        client_id                TEXT NOT NULL,
+        client_secret_encrypted  TEXT NOT NULL,
+        scopes_default           TEXT NOT NULL DEFAULT '',
+        created_at               TEXT NOT NULL,
+        updated_at               TEXT NOT NULL
+      );
+    `);
+  },
+};

--- a/src/db/migrations/019-oauth-app-connections.ts
+++ b/src/db/migrations/019-oauth-app-connections.ts
@@ -1,0 +1,48 @@
+/**
+ * OAuth user grants — one row per (provider × authorized account).
+ *
+ *   - `app_config_id` FKs to `app_configs(id)`. ON DELETE CASCADE: if the
+ *     operator drops their Google client config, every connection minted
+ *     against it is gone too (the tokens were issued to that client_id
+ *     and would 401 anyway).
+ *   - `account_email` + `account_id` come from the provider's userinfo
+ *     endpoint at callback time. `(app_config_id, account_id)` is unique
+ *     so re-authorizing the same account just refreshes tokens in place.
+ *   - `access_token_encrypted` / `refresh_token_encrypted` are AES-GCM
+ *     ciphertext (base64) with the same `paraclaw.oauth.v1` derived key
+ *     as `app_configs.client_secret_encrypted`.
+ *   - `scopes_granted` is space-separated; what the provider actually
+ *     gave us, not what we asked for.
+ *   - `expires_at` is ISO-8601; refresh-token flow renews `access_token`
+ *     and bumps this. NULL means provider didn't return an expiry.
+ *   - `metadata_json` is a freeform JSON blob for provider-specific
+ *     fields (e.g. Google's `id_token`, GitHub's `installation_id`).
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration019: Migration = {
+  version: 19,
+  name: 'oauth-app-connections',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS app_connections (
+        id                        TEXT PRIMARY KEY,
+        app_config_id             TEXT NOT NULL REFERENCES app_configs(id) ON DELETE CASCADE,
+        account_email             TEXT,
+        account_id                TEXT NOT NULL,
+        access_token_encrypted    TEXT NOT NULL,
+        refresh_token_encrypted   TEXT,
+        scopes_granted            TEXT NOT NULL DEFAULT '',
+        expires_at                TEXT,
+        label                     TEXT NOT NULL,
+        metadata_json             TEXT,
+        created_at                TEXT NOT NULL,
+        updated_at                TEXT NOT NULL,
+        UNIQUE (app_config_id, account_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_app_connections_config ON app_connections(app_config_id);
+      CREATE INDEX IF NOT EXISTS idx_app_connections_email ON app_connections(account_email);
+    `);
+  },
+};

--- a/src/db/migrations/020-agent-app-connections.ts
+++ b/src/db/migrations/020-agent-app-connections.ts
@@ -1,0 +1,28 @@
+/**
+ * Per-agent allowlist for OAuth connections — same shape as
+ * `secret_assignments` from migration 016. A connection is visible to an
+ * agent group only if there's a row here joining the two.
+ *
+ * Composite PK on (agent_group_id, app_connection_id) prevents duplicate
+ * grants. Both FKs cascade so a deleted agent group or revoked
+ * connection cleans up the join rows automatically.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration020: Migration = {
+  version: 20,
+  name: 'agent-app-connections',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_app_connections (
+        agent_group_id     TEXT NOT NULL REFERENCES agent_groups(id) ON DELETE CASCADE,
+        app_connection_id  TEXT NOT NULL REFERENCES app_connections(id) ON DELETE CASCADE,
+        created_at         TEXT NOT NULL,
+        PRIMARY KEY (agent_group_id, app_connection_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_agent_app_connections_conn
+        ON agent_app_connections(app_connection_id);
+    `);
+  },
+};

--- a/src/db/migrations/021-pending-oauth-states.ts
+++ b/src/db/migrations/021-pending-oauth-states.ts
@@ -1,0 +1,35 @@
+/**
+ * pending_oauth_states — DB-backed CSRF tokens for the OAuth authorize→callback
+ * round-trip. The `state` parameter passed in the authorize redirect is a
+ * CSPRNG-random opaque string mapped here to the originating context
+ * (provider, optional agentGroupId, redirect URI, expires_at).
+ *
+ * Row lifecycle:
+ *   - INSERT at /authorize, ~10min TTL
+ *   - DELETE at /callback (single-use; second redemption is a 400)
+ *   - sweep prunes anything past expires_at
+ *
+ * DB-backed (vs in-memory) so daemon restart mid-flow doesn't drop a
+ * legitimate user's authorize attempt — they finish in their browser and
+ * the callback still finds the row.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration021: Migration = {
+  version: 21,
+  name: 'pending-oauth-states',
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_oauth_states (
+        state           TEXT PRIMARY KEY,
+        provider        TEXT NOT NULL,
+        agent_group_id  TEXT,
+        redirect_uri    TEXT NOT NULL,
+        created_at      TEXT NOT NULL,
+        expires_at      TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_pending_oauth_states_expires ON pending_oauth_states(expires_at);
+    `);
+  },
+};

--- a/src/db/migrations/022-app-connections-provider.ts
+++ b/src/db/migrations/022-app-connections-provider.ts
@@ -1,0 +1,25 @@
+/**
+ * Denormalize `provider` onto `app_connections` for query speed and to
+ * avoid a join+lookup for every list-connection / single-get call. The
+ * source of truth stays `app_configs.provider`; this column is filled
+ * at upsert time from the parent config.
+ *
+ * On apply: backfill any existing rows by joining to app_configs. New
+ * rows from this point set it directly.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration022: Migration = {
+  version: 22,
+  name: 'app-connections-provider',
+  up(db: Database) {
+    db.exec(`
+      ALTER TABLE app_connections ADD COLUMN provider TEXT NOT NULL DEFAULT '';
+      UPDATE app_connections
+         SET provider = (SELECT provider FROM app_configs WHERE app_configs.id = app_connections.app_config_id)
+       WHERE provider = '';
+      CREATE INDEX IF NOT EXISTS idx_app_connections_provider ON app_connections(provider);
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -14,6 +14,9 @@ import { migration014 } from './014-secrets.js';
 import { migration015 } from './015-secrets-drop-host-pattern.js';
 import { migration016 } from './016-secret-assignments.js';
 import { migration017 } from './017-agent-activity.js';
+import { migration018 } from './018-oauth-app-configs.js';
+import { migration019 } from './019-oauth-app-connections.js';
+import { migration020 } from './020-agent-app-connections.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -39,6 +42,9 @@ const migrations: Migration[] = [
   migration015,
   migration016,
   migration017,
+  migration018,
+  migration019,
+  migration020,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -17,6 +17,8 @@ import { migration017 } from './017-agent-activity.js';
 import { migration018 } from './018-oauth-app-configs.js';
 import { migration019 } from './019-oauth-app-connections.js';
 import { migration020 } from './020-agent-app-connections.js';
+import { migration021 } from './021-pending-oauth-states.js';
+import { migration022 } from './022-app-connections-provider.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -45,6 +47,8 @@ const migrations: Migration[] = [
   migration018,
   migration019,
   migration020,
+  migration021,
+  migration022,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/host-sweep.ts
+++ b/src/host-sweep.ts
@@ -42,6 +42,7 @@ import {
   type ContainerState,
 } from './db/session-db.js';
 import { log } from './log.js';
+import { sweepExpiredStates } from './oauth/state-store.js';
 import { openInboundDb, openOutboundDb, inboundDbPath, heartbeatPath } from './session-manager.js';
 import { isContainerRunning, killContainer, wakeContainer } from './container-runner.js';
 import type { Session } from './types.js';
@@ -127,6 +128,16 @@ async function sweep(): Promise<void> {
     }
   } catch (err) {
     log.error('Host sweep error', { err });
+  }
+
+  // Global (non-per-session) maintenance: drop expired OAuth CSRF state rows.
+  // DB-backed state store grows by ~1 row per failed authorize attempt
+  // otherwise.
+  try {
+    const removed = sweepExpiredStates();
+    if (removed > 0) log.info('Swept expired oauth states', { removed });
+  } catch (err) {
+    log.warn('sweepExpiredStates failed', { err: err instanceof Error ? err.message : String(err) });
   }
 
   setTimeout(sweep, SWEEP_INTERVAL_MS);

--- a/src/oauth/agent-app-connections.ts
+++ b/src/oauth/agent-app-connections.ts
@@ -36,6 +36,20 @@ export function listAgentsForConnection(connectionId: string): AgentForConnectio
     .all({ connection_id: connectionId });
 }
 
+/** Map of connectionId → agent count, populated in one query for the list view. */
+export function countAgentsByConnection(): Map<string, number> {
+  const rows = db()
+    .prepare<{ app_connection_id: string; n: number }>(
+      `SELECT app_connection_id, COUNT(*) AS n
+         FROM agent_app_connections
+         GROUP BY app_connection_id`,
+    )
+    .all();
+  const out = new Map<string, number>();
+  for (const r of rows) out.set(r.app_connection_id, r.n);
+  return out;
+}
+
 export function listConnectionsForAgent(agentGroupId: string): string[] {
   return db()
     .prepare<{ app_connection_id: string }>(

--- a/src/oauth/agent-app-connections.ts
+++ b/src/oauth/agent-app-connections.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-agent allowlist for OAuth connections — the `agent_app_connections`
+ * join table. A connection is only visible/injectable to an agent group
+ * if there's a row joining the two.
+ */
+import { getDb } from '../db/connection.js';
+import type { Database } from '../db/connection.js';
+
+function db(): Database {
+  return getDb();
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export interface AgentForConnection {
+  agent_group_id: string;
+  agent_group_folder: string;
+  agent_group_name: string;
+  created_at: string;
+}
+
+export function listAgentsForConnection(connectionId: string): AgentForConnection[] {
+  return db()
+    .prepare<AgentForConnection>(
+      `SELECT a.agent_group_id   AS agent_group_id,
+              g.folder           AS agent_group_folder,
+              g.name             AS agent_group_name,
+              a.created_at       AS created_at
+         FROM agent_app_connections a
+         JOIN agent_groups g ON g.id = a.agent_group_id
+        WHERE a.app_connection_id = @connection_id
+        ORDER BY g.name`,
+    )
+    .all({ connection_id: connectionId });
+}
+
+export function listConnectionsForAgent(agentGroupId: string): string[] {
+  return db()
+    .prepare<{ app_connection_id: string }>(
+      `SELECT app_connection_id FROM agent_app_connections WHERE agent_group_id = @agent_group_id`,
+    )
+    .all({ agent_group_id: agentGroupId })
+    .map((r) => r.app_connection_id);
+}
+
+/** Atomically replace the allowlist for a connection. */
+export function setAgentsForConnection(connectionId: string, agentGroupIds: string[]): void {
+  const tx = db().transaction((ids: string[]) => {
+    db()
+      .prepare(`DELETE FROM agent_app_connections WHERE app_connection_id = @connection_id`)
+      .run({ connection_id: connectionId });
+    const insert = db().prepare(
+      `INSERT OR IGNORE INTO agent_app_connections
+         (agent_group_id, app_connection_id, created_at)
+       VALUES (@agent_group_id, @app_connection_id, @created_at)`,
+    );
+    const now = nowIso();
+    for (const id of ids) {
+      insert.run({ agent_group_id: id, app_connection_id: connectionId, created_at: now });
+    }
+  });
+  tx(agentGroupIds);
+}
+
+export function addAgentToConnection(connectionId: string, agentGroupId: string): void {
+  db()
+    .prepare(
+      `INSERT OR IGNORE INTO agent_app_connections
+         (agent_group_id, app_connection_id, created_at)
+       VALUES (@agent_group_id, @app_connection_id, @created_at)`,
+    )
+    .run({
+      agent_group_id: agentGroupId,
+      app_connection_id: connectionId,
+      created_at: nowIso(),
+    });
+}
+
+export function removeAgentFromConnection(connectionId: string, agentGroupId: string): boolean {
+  const r = db()
+    .prepare(
+      `DELETE FROM agent_app_connections
+        WHERE app_connection_id = @connection_id AND agent_group_id = @agent_group_id`,
+    )
+    .run({ connection_id: connectionId, agent_group_id: agentGroupId });
+  return r.changes > 0;
+}

--- a/src/oauth/app-configs.test.ts
+++ b/src/oauth/app-configs.test.ts
@@ -3,13 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { _setMasterKeyForTest } from '../secrets/master-key.js';
-import {
-  deleteAppConfig,
-  getAppConfig,
-  getAppConfigWithSecret,
-  listAppConfigs,
-  putAppConfig,
-} from './app-configs.js';
+import { deleteAppConfig, getAppConfig, getAppConfigWithSecret, listAppConfigs, putAppConfig } from './app-configs.js';
 
 beforeEach(() => {
   const db = initTestDb();

--- a/src/oauth/app-configs.test.ts
+++ b/src/oauth/app-configs.test.ts
@@ -1,0 +1,70 @@
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../db/index.js';
+import { _setMasterKeyForTest } from '../secrets/master-key.js';
+import {
+  deleteAppConfig,
+  getAppConfig,
+  getAppConfigWithSecret,
+  listAppConfigs,
+  putAppConfig,
+} from './app-configs.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  _setMasterKeyForTest(crypto.randomBytes(32));
+});
+
+afterEach(() => closeDb());
+
+describe('app_configs DB layer', () => {
+  it('inserts a config and returns its id', () => {
+    const id = putAppConfig('google', {
+      client_id: 'abc.apps.googleusercontent.com',
+      client_secret: 'super-secret',
+      scopes_default: 'openid email',
+    });
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('round-trips client_secret via getAppConfigWithSecret', () => {
+    putAppConfig('google', {
+      client_id: 'abc',
+      client_secret: 'shhh',
+    });
+    const got = getAppConfigWithSecret('google');
+    expect(got?.client_secret).toBe('shhh');
+    expect(got?.client_id).toBe('abc');
+  });
+
+  it('hides client_secret from public reads', () => {
+    putAppConfig('google', { client_id: 'abc', client_secret: 'shhh' });
+    const row = getAppConfig('google') as Record<string, unknown> | undefined;
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty('client_secret');
+    expect(row).not.toHaveProperty('client_secret_encrypted');
+  });
+
+  it('updates an existing provider in place', () => {
+    const id1 = putAppConfig('google', { client_id: 'v1', client_secret: 's1' });
+    const id2 = putAppConfig('google', { client_id: 'v2', client_secret: 's2' });
+    expect(id1).toBe(id2);
+    expect(getAppConfig('google')?.client_id).toBe('v2');
+    expect(getAppConfigWithSecret('google')?.client_secret).toBe('s2');
+  });
+
+  it('lists configs alphabetically by provider', () => {
+    putAppConfig('zeta', { client_id: 'z', client_secret: 'sz' });
+    putAppConfig('alpha', { client_id: 'a', client_secret: 'sa' });
+    expect(listAppConfigs().map((r) => r.provider)).toEqual(['alpha', 'zeta']);
+  });
+
+  it('deletes by provider', () => {
+    putAppConfig('google', { client_id: 'abc', client_secret: 'shhh' });
+    expect(deleteAppConfig('google')).toBe(true);
+    expect(getAppConfig('google')).toBeUndefined();
+    expect(deleteAppConfig('google')).toBe(false);
+  });
+});

--- a/src/oauth/app-configs.ts
+++ b/src/oauth/app-configs.ts
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 
 import { getDb } from '../db/connection.js';
 import type { Database } from '../db/connection.js';
-import { decryptOauth, encryptOauth } from './crypto.js';
+import { decryptOauthClient, encryptOauthClient } from './crypto.js';
 
 export interface AppConfigRow {
   id: string;
@@ -46,7 +46,7 @@ export function getAppConfigWithSecret(provider: string): (AppConfigRow & { clie
   const row = db().prepare<RawAppConfigRow>(`SELECT * FROM app_configs WHERE provider = @provider`).get({ provider });
   if (!row) return undefined;
   const { client_secret_encrypted, ...rest } = row;
-  return { ...rest, client_secret: decryptOauth(client_secret_encrypted) };
+  return { ...rest, client_secret: decryptOauthClient(client_secret_encrypted) };
 }
 
 export function listAppConfigs(): AppConfigRow[] {
@@ -61,7 +61,7 @@ export interface PutAppConfigOpts {
 
 /** Insert or update a provider's client config. Returns the row's id. */
 export function putAppConfig(provider: string, opts: PutAppConfigOpts): string {
-  const ct = encryptOauth(opts.client_secret);
+  const ct = encryptOauthClient(opts.client_secret);
   const scopes = opts.scopes_default ?? '';
   const existing = db()
     .prepare<{ id: string }>(`SELECT id FROM app_configs WHERE provider = @provider`)

--- a/src/oauth/app-configs.ts
+++ b/src/oauth/app-configs.ts
@@ -1,0 +1,114 @@
+/**
+ * BYOC client config DB layer — one row per provider.
+ *
+ * `client_secret` is encrypted at rest. The plaintext is materialized
+ * only at authorize-URL build time (`buildAuthorizeUrl`) and at token
+ * exchange (`exchangeCode`); never returned through the API.
+ */
+import crypto from 'crypto';
+
+import { getDb } from '../db/connection.js';
+import type { Database } from '../db/connection.js';
+import { decryptOauth, encryptOauth } from './crypto.js';
+
+export interface AppConfigRow {
+  id: string;
+  provider: string;
+  client_id: string;
+  scopes_default: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RawAppConfigRow extends AppConfigRow {
+  client_secret_encrypted: string;
+}
+
+function db(): Database {
+  return getDb();
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+const PUBLIC_COLS = `id, provider, client_id, scopes_default, created_at, updated_at`;
+
+/** Returns the public (non-secret) shape; never decrypts. */
+export function getAppConfig(provider: string): AppConfigRow | undefined {
+  return db()
+    .prepare<AppConfigRow>(`SELECT ${PUBLIC_COLS} FROM app_configs WHERE provider = @provider`)
+    .get({ provider });
+}
+
+/** Returns the decrypted client_secret + public fields. Internal use only. */
+export function getAppConfigWithSecret(provider: string): (AppConfigRow & { client_secret: string }) | undefined {
+  const row = db().prepare<RawAppConfigRow>(`SELECT * FROM app_configs WHERE provider = @provider`).get({ provider });
+  if (!row) return undefined;
+  const { client_secret_encrypted, ...rest } = row;
+  return { ...rest, client_secret: decryptOauth(client_secret_encrypted) };
+}
+
+export function listAppConfigs(): AppConfigRow[] {
+  return db().prepare<AppConfigRow>(`SELECT ${PUBLIC_COLS} FROM app_configs ORDER BY provider`).all();
+}
+
+export interface PutAppConfigOpts {
+  client_id: string;
+  client_secret: string;
+  scopes_default?: string;
+}
+
+/** Insert or update a provider's client config. Returns the row's id. */
+export function putAppConfig(provider: string, opts: PutAppConfigOpts): string {
+  const ct = encryptOauth(opts.client_secret);
+  const scopes = opts.scopes_default ?? '';
+  const existing = db()
+    .prepare<{ id: string }>(`SELECT id FROM app_configs WHERE provider = @provider`)
+    .get({ provider });
+
+  const now = nowIso();
+  if (existing) {
+    db()
+      .prepare(
+        `UPDATE app_configs
+            SET client_id               = @client_id,
+                client_secret_encrypted = @client_secret_encrypted,
+                scopes_default          = @scopes_default,
+                updated_at              = @updated_at
+          WHERE id = @id`,
+      )
+      .run({
+        id: existing.id,
+        client_id: opts.client_id,
+        client_secret_encrypted: ct,
+        scopes_default: scopes,
+        updated_at: now,
+      });
+    return existing.id;
+  }
+
+  const id = crypto.randomUUID();
+  db()
+    .prepare(
+      `INSERT INTO app_configs
+         (id, provider, client_id, client_secret_encrypted, scopes_default, created_at, updated_at)
+       VALUES
+         (@id, @provider, @client_id, @client_secret_encrypted, @scopes_default, @created_at, @updated_at)`,
+    )
+    .run({
+      id,
+      provider,
+      client_id: opts.client_id,
+      client_secret_encrypted: ct,
+      scopes_default: scopes,
+      created_at: now,
+      updated_at: now,
+    });
+  return id;
+}
+
+export function deleteAppConfig(provider: string): boolean {
+  const r = db().prepare(`DELETE FROM app_configs WHERE provider = @provider`).run({ provider });
+  return r.changes > 0;
+}

--- a/src/oauth/app-connections.test.ts
+++ b/src/oauth/app-connections.test.ts
@@ -99,5 +99,4 @@ describe('app_connections DB layer', () => {
     expect(getAppConnection(id)).toBeUndefined();
     expect(deleteAppConnection(id)).toBe(false);
   });
-
 });

--- a/src/oauth/app-connections.test.ts
+++ b/src/oauth/app-connections.test.ts
@@ -27,6 +27,7 @@ describe('app_connections DB layer', () => {
   it('inserts and round-trips encrypted tokens', () => {
     const id = upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       account_email: 'a@example.com',
       access_token: 'access-1',
@@ -42,6 +43,7 @@ describe('app_connections DB layer', () => {
   it('hides token columns from public reads', () => {
     const id = upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       access_token: 'access-1',
       label: 'a',
@@ -56,12 +58,14 @@ describe('app_connections DB layer', () => {
   it('upserts on (app_config_id, account_id) — same id, refreshed tokens', () => {
     const id1 = upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       access_token: 'old',
       label: 'a',
     });
     const id2 = upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       access_token: 'new',
       refresh_token: 'rnew',
@@ -75,12 +79,14 @@ describe('app_connections DB layer', () => {
   it('treats different account_ids as separate connections', () => {
     upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       access_token: 't1',
       label: 'a',
     });
     upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-2',
       access_token: 't2',
       label: 'b',
@@ -91,6 +97,7 @@ describe('app_connections DB layer', () => {
   it('deletes by id', () => {
     const id = upsertAppConnection({
       app_config_id: configId,
+      provider: 'google',
       account_id: 'sub-1',
       access_token: 'access',
       label: 'a',

--- a/src/oauth/app-connections.test.ts
+++ b/src/oauth/app-connections.test.ts
@@ -1,0 +1,103 @@
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../db/index.js';
+import { _setMasterKeyForTest } from '../secrets/master-key.js';
+import { putAppConfig } from './app-configs.js';
+import {
+  deleteAppConnection,
+  getAppConnection,
+  getAppConnectionWithTokens,
+  listAppConnections,
+  upsertAppConnection,
+} from './app-connections.js';
+
+let configId: string;
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  _setMasterKeyForTest(crypto.randomBytes(32));
+  configId = putAppConfig('google', { client_id: 'cid', client_secret: 'csec' });
+});
+
+afterEach(() => closeDb());
+
+describe('app_connections DB layer', () => {
+  it('inserts and round-trips encrypted tokens', () => {
+    const id = upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      account_email: 'a@example.com',
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      label: 'a@example.com',
+    });
+    const decrypted = getAppConnectionWithTokens(id);
+    expect(decrypted?.access_token).toBe('access-1');
+    expect(decrypted?.refresh_token).toBe('refresh-1');
+    expect(decrypted?.account_email).toBe('a@example.com');
+  });
+
+  it('hides token columns from public reads', () => {
+    const id = upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      access_token: 'access-1',
+      label: 'a',
+    });
+    const row = getAppConnection(id) as Record<string, unknown> | undefined;
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty('access_token');
+    expect(row).not.toHaveProperty('access_token_encrypted');
+    expect(row).not.toHaveProperty('refresh_token');
+  });
+
+  it('upserts on (app_config_id, account_id) — same id, refreshed tokens', () => {
+    const id1 = upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      access_token: 'old',
+      label: 'a',
+    });
+    const id2 = upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      access_token: 'new',
+      refresh_token: 'rnew',
+      label: 'a',
+    });
+    expect(id1).toBe(id2);
+    expect(getAppConnectionWithTokens(id1)?.access_token).toBe('new');
+    expect(getAppConnectionWithTokens(id1)?.refresh_token).toBe('rnew');
+  });
+
+  it('treats different account_ids as separate connections', () => {
+    upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      access_token: 't1',
+      label: 'a',
+    });
+    upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-2',
+      access_token: 't2',
+      label: 'b',
+    });
+    expect(listAppConnections()).toHaveLength(2);
+  });
+
+  it('deletes by id', () => {
+    const id = upsertAppConnection({
+      app_config_id: configId,
+      account_id: 'sub-1',
+      access_token: 'access',
+      label: 'a',
+    });
+    expect(deleteAppConnection(id)).toBe(true);
+    expect(getAppConnection(id)).toBeUndefined();
+    expect(deleteAppConnection(id)).toBe(false);
+  });
+
+});

--- a/src/oauth/app-connections.ts
+++ b/src/oauth/app-connections.ts
@@ -1,19 +1,28 @@
 /**
  * OAuth grant DB layer — one row per (provider × authorized account).
  *
- * Token columns are AES-GCM ciphertext at rest. The list/get views in
- * this module strip those columns; only `getConnectionWithTokens` (used
- * by the runtime injection seam, not the API) decrypts them.
+ * `provider` is denormalized onto this table (mig 022) for query speed
+ * and to avoid a join on every list call. `app_config_id` remains the
+ * authoritative FK; provider is just a copy of `app_configs.provider`
+ * filled at upsert time.
+ *
+ * Token columns are AES-GCM ciphertext at rest, encrypted under
+ * domain-separated keys (`paraclaw.oauth.access.v1` /
+ * `paraclaw.oauth.refresh.v1` — see oauth/crypto.ts). The list/get
+ * views in this module strip those columns; only
+ * `getAppConnectionWithTokens` (used by the runtime injection seam,
+ * not the API) decrypts them.
  */
 import crypto from 'crypto';
 
 import { getDb } from '../db/connection.js';
 import type { Database } from '../db/connection.js';
-import { decryptOauth, encryptOauth } from './crypto.js';
+import { decryptOauthAccess, decryptOauthRefresh, encryptOauthAccess, encryptOauthRefresh } from './crypto.js';
 
 export interface AppConnectionRow {
   id: string;
   app_config_id: string;
+  provider: string;
   account_email: string | null;
   account_id: string;
   scopes_granted: string;
@@ -43,7 +52,7 @@ function nowIso(): string {
 }
 
 const PUBLIC_COLS = `
-  id, app_config_id, account_email, account_id, scopes_granted,
+  id, app_config_id, provider, account_email, account_id, scopes_granted,
   expires_at, label, metadata_json, created_at, updated_at
 `;
 
@@ -62,13 +71,14 @@ export function getAppConnectionWithTokens(id: string): AppConnectionWithTokens 
   const { access_token_encrypted, refresh_token_encrypted, ...rest } = row;
   return {
     ...rest,
-    access_token: decryptOauth(access_token_encrypted),
-    refresh_token: refresh_token_encrypted ? decryptOauth(refresh_token_encrypted) : null,
+    access_token: decryptOauthAccess(access_token_encrypted),
+    refresh_token: refresh_token_encrypted ? decryptOauthRefresh(refresh_token_encrypted) : null,
   };
 }
 
 export interface UpsertConnectionOpts {
   app_config_id: string;
+  provider: string;
   account_id: string;
   account_email?: string | null;
   access_token: string;
@@ -85,8 +95,8 @@ export interface UpsertConnectionOpts {
  * a duplicate row.
  */
 export function upsertAppConnection(opts: UpsertConnectionOpts): string {
-  const accessCt = encryptOauth(opts.access_token);
-  const refreshCt = opts.refresh_token ? encryptOauth(opts.refresh_token) : null;
+  const accessCt = encryptOauthAccess(opts.access_token);
+  const refreshCt = opts.refresh_token ? encryptOauthRefresh(opts.refresh_token) : null;
   const scopes = opts.scopes_granted ?? '';
   const accountEmail = opts.account_email ?? null;
   const expiresAt = opts.expires_at ?? null;
@@ -104,7 +114,8 @@ export function upsertAppConnection(opts: UpsertConnectionOpts): string {
     db()
       .prepare(
         `UPDATE app_connections
-            SET account_email           = @account_email,
+            SET provider                = @provider,
+                account_email           = @account_email,
                 access_token_encrypted  = @access_token_encrypted,
                 refresh_token_encrypted = @refresh_token_encrypted,
                 scopes_granted          = @scopes_granted,
@@ -116,6 +127,7 @@ export function upsertAppConnection(opts: UpsertConnectionOpts): string {
       )
       .run({
         id: existing.id,
+        provider: opts.provider,
         account_email: accountEmail,
         access_token_encrypted: accessCt,
         refresh_token_encrypted: refreshCt,
@@ -132,12 +144,12 @@ export function upsertAppConnection(opts: UpsertConnectionOpts): string {
   db()
     .prepare(
       `INSERT INTO app_connections
-         (id, app_config_id, account_email, account_id,
+         (id, app_config_id, provider, account_email, account_id,
           access_token_encrypted, refresh_token_encrypted,
           scopes_granted, expires_at, label, metadata_json,
           created_at, updated_at)
        VALUES
-         (@id, @app_config_id, @account_email, @account_id,
+         (@id, @app_config_id, @provider, @account_email, @account_id,
           @access_token_encrypted, @refresh_token_encrypted,
           @scopes_granted, @expires_at, @label, @metadata_json,
           @created_at, @updated_at)`,
@@ -145,6 +157,7 @@ export function upsertAppConnection(opts: UpsertConnectionOpts): string {
     .run({
       id,
       app_config_id: opts.app_config_id,
+      provider: opts.provider,
       account_email: accountEmail,
       account_id: opts.account_id,
       access_token_encrypted: accessCt,

--- a/src/oauth/app-connections.ts
+++ b/src/oauth/app-connections.ts
@@ -1,0 +1,165 @@
+/**
+ * OAuth grant DB layer — one row per (provider × authorized account).
+ *
+ * Token columns are AES-GCM ciphertext at rest. The list/get views in
+ * this module strip those columns; only `getConnectionWithTokens` (used
+ * by the runtime injection seam, not the API) decrypts them.
+ */
+import crypto from 'crypto';
+
+import { getDb } from '../db/connection.js';
+import type { Database } from '../db/connection.js';
+import { decryptOauth, encryptOauth } from './crypto.js';
+
+export interface AppConnectionRow {
+  id: string;
+  app_config_id: string;
+  account_email: string | null;
+  account_id: string;
+  scopes_granted: string;
+  expires_at: string | null;
+  label: string;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AppConnectionWithTokens extends AppConnectionRow {
+  access_token: string;
+  refresh_token: string | null;
+}
+
+interface RawAppConnectionRow extends AppConnectionRow {
+  access_token_encrypted: string;
+  refresh_token_encrypted: string | null;
+}
+
+function db(): Database {
+  return getDb();
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+const PUBLIC_COLS = `
+  id, app_config_id, account_email, account_id, scopes_granted,
+  expires_at, label, metadata_json, created_at, updated_at
+`;
+
+export function listAppConnections(): AppConnectionRow[] {
+  return db().prepare<AppConnectionRow>(`SELECT ${PUBLIC_COLS} FROM app_connections ORDER BY created_at DESC`).all();
+}
+
+export function getAppConnection(id: string): AppConnectionRow | undefined {
+  return db().prepare<AppConnectionRow>(`SELECT ${PUBLIC_COLS} FROM app_connections WHERE id = @id`).get({ id });
+}
+
+/** Internal: returns decrypted tokens. Callers MUST NOT serialize the result. */
+export function getAppConnectionWithTokens(id: string): AppConnectionWithTokens | undefined {
+  const row = db().prepare<RawAppConnectionRow>(`SELECT * FROM app_connections WHERE id = @id`).get({ id });
+  if (!row) return undefined;
+  const { access_token_encrypted, refresh_token_encrypted, ...rest } = row;
+  return {
+    ...rest,
+    access_token: decryptOauth(access_token_encrypted),
+    refresh_token: refresh_token_encrypted ? decryptOauth(refresh_token_encrypted) : null,
+  };
+}
+
+export interface UpsertConnectionOpts {
+  app_config_id: string;
+  account_id: string;
+  account_email?: string | null;
+  access_token: string;
+  refresh_token?: string | null;
+  scopes_granted?: string;
+  expires_at?: string | null;
+  label: string;
+  metadata_json?: string | null;
+}
+
+/**
+ * Upsert a connection keyed on (app_config_id, account_id). Re-authorizing
+ * the same account refreshes tokens + scopes in place rather than creating
+ * a duplicate row.
+ */
+export function upsertAppConnection(opts: UpsertConnectionOpts): string {
+  const accessCt = encryptOauth(opts.access_token);
+  const refreshCt = opts.refresh_token ? encryptOauth(opts.refresh_token) : null;
+  const scopes = opts.scopes_granted ?? '';
+  const accountEmail = opts.account_email ?? null;
+  const expiresAt = opts.expires_at ?? null;
+  const metadata = opts.metadata_json ?? null;
+
+  const existing = db()
+    .prepare<{ id: string }>(
+      `SELECT id FROM app_connections
+        WHERE app_config_id = @app_config_id AND account_id = @account_id`,
+    )
+    .get({ app_config_id: opts.app_config_id, account_id: opts.account_id });
+
+  const now = nowIso();
+  if (existing) {
+    db()
+      .prepare(
+        `UPDATE app_connections
+            SET account_email           = @account_email,
+                access_token_encrypted  = @access_token_encrypted,
+                refresh_token_encrypted = @refresh_token_encrypted,
+                scopes_granted          = @scopes_granted,
+                expires_at              = @expires_at,
+                label                   = @label,
+                metadata_json           = @metadata_json,
+                updated_at              = @updated_at
+          WHERE id = @id`,
+      )
+      .run({
+        id: existing.id,
+        account_email: accountEmail,
+        access_token_encrypted: accessCt,
+        refresh_token_encrypted: refreshCt,
+        scopes_granted: scopes,
+        expires_at: expiresAt,
+        label: opts.label,
+        metadata_json: metadata,
+        updated_at: now,
+      });
+    return existing.id;
+  }
+
+  const id = crypto.randomUUID();
+  db()
+    .prepare(
+      `INSERT INTO app_connections
+         (id, app_config_id, account_email, account_id,
+          access_token_encrypted, refresh_token_encrypted,
+          scopes_granted, expires_at, label, metadata_json,
+          created_at, updated_at)
+       VALUES
+         (@id, @app_config_id, @account_email, @account_id,
+          @access_token_encrypted, @refresh_token_encrypted,
+          @scopes_granted, @expires_at, @label, @metadata_json,
+          @created_at, @updated_at)`,
+    )
+    .run({
+      id,
+      app_config_id: opts.app_config_id,
+      account_email: accountEmail,
+      account_id: opts.account_id,
+      access_token_encrypted: accessCt,
+      refresh_token_encrypted: refreshCt,
+      scopes_granted: scopes,
+      expires_at: expiresAt,
+      label: opts.label,
+      metadata_json: metadata,
+      created_at: now,
+      updated_at: now,
+    });
+  return id;
+}
+
+export function deleteAppConnection(id: string): boolean {
+  const r = db().prepare(`DELETE FROM app_connections WHERE id = @id`).run({ id });
+  return r.changes > 0;
+}

--- a/src/oauth/crypto.ts
+++ b/src/oauth/crypto.ts
@@ -1,26 +1,49 @@
 /**
- * Domain-separated key for the OAuth subsystem. Same master key as the
- * secrets store; different HKDF info string so a bug in the secrets
- * subsystem can't decrypt OAuth tokens (and vice versa).
+ * Three domain-separated HKDF-derived keys for OAuth secrets:
  *
- * Bumping `paraclaw.oauth.v1` → `v2` would force re-encryption of every
- * `client_secret_encrypted`, `access_token_encrypted`, and
- * `refresh_token_encrypted` row. Treat the version as a key-rotation
- * trigger, not casual versioning.
+ *   - paraclaw.oauth.client.v1   → app_configs.client_secret_encrypted
+ *   - paraclaw.oauth.access.v1   → app_connections.access_token_encrypted
+ *   - paraclaw.oauth.refresh.v1  → app_connections.refresh_token_encrypted
+ *
+ * Three subkeys instead of one because compromise of one rotation surface
+ * (e.g. refresh tokens accidentally surfaced in a log) shouldn't yield
+ * decryption power on the others. Bumping any `v<n>` suffix is a
+ * per-domain key rotation.
  */
 import { deriveKey, encryptSecret, decryptSecret } from '../secrets/crypto.js';
 import { loadOrCreateMasterKey } from '../secrets/master-key.js';
 
-const OAUTH_INFO = 'paraclaw.oauth.v1';
+const CLIENT_INFO = 'paraclaw.oauth.client.v1';
+const ACCESS_INFO = 'paraclaw.oauth.access.v1';
+const REFRESH_INFO = 'paraclaw.oauth.refresh.v1';
 
-function oauthKey(): Buffer {
-  return deriveKey(loadOrCreateMasterKey(), OAUTH_INFO);
+function clientKey(): Buffer {
+  return deriveKey(loadOrCreateMasterKey(), CLIENT_INFO);
+}
+function accessKey(): Buffer {
+  return deriveKey(loadOrCreateMasterKey(), ACCESS_INFO);
+}
+function refreshKey(): Buffer {
+  return deriveKey(loadOrCreateMasterKey(), REFRESH_INFO);
 }
 
-export function encryptOauth(plaintext: string): string {
-  return encryptSecret(plaintext, oauthKey());
+export function encryptOauthClient(plaintext: string): string {
+  return encryptSecret(plaintext, clientKey());
+}
+export function decryptOauthClient(ciphertext: string): string {
+  return decryptSecret(ciphertext, clientKey());
 }
 
-export function decryptOauth(ciphertext: string): string {
-  return decryptSecret(ciphertext, oauthKey());
+export function encryptOauthAccess(plaintext: string): string {
+  return encryptSecret(plaintext, accessKey());
+}
+export function decryptOauthAccess(ciphertext: string): string {
+  return decryptSecret(ciphertext, accessKey());
+}
+
+export function encryptOauthRefresh(plaintext: string): string {
+  return encryptSecret(plaintext, refreshKey());
+}
+export function decryptOauthRefresh(ciphertext: string): string {
+  return decryptSecret(ciphertext, refreshKey());
 }

--- a/src/oauth/crypto.ts
+++ b/src/oauth/crypto.ts
@@ -1,0 +1,26 @@
+/**
+ * Domain-separated key for the OAuth subsystem. Same master key as the
+ * secrets store; different HKDF info string so a bug in the secrets
+ * subsystem can't decrypt OAuth tokens (and vice versa).
+ *
+ * Bumping `paraclaw.oauth.v1` → `v2` would force re-encryption of every
+ * `client_secret_encrypted`, `access_token_encrypted`, and
+ * `refresh_token_encrypted` row. Treat the version as a key-rotation
+ * trigger, not casual versioning.
+ */
+import { deriveKey, encryptSecret, decryptSecret } from '../secrets/crypto.js';
+import { loadOrCreateMasterKey } from '../secrets/master-key.js';
+
+const OAUTH_INFO = 'paraclaw.oauth.v1';
+
+function oauthKey(): Buffer {
+  return deriveKey(loadOrCreateMasterKey(), OAUTH_INFO);
+}
+
+export function encryptOauth(plaintext: string): string {
+  return encryptSecret(plaintext, oauthKey());
+}
+
+export function decryptOauth(ciphertext: string): string {
+  return decryptSecret(ciphertext, oauthKey());
+}

--- a/src/oauth/flow.ts
+++ b/src/oauth/flow.ts
@@ -1,0 +1,104 @@
+/**
+ * Provider-agnostic OAuth flow primitives.
+ *
+ *   1. `buildAuthorizeUrl` — assembles the redirect URL the user's
+ *      browser hits to consent. Includes client_id, scope, state,
+ *      redirect_uri, plus provider-specific extras (e.g. Google's
+ *      `access_type=offline`).
+ *   2. `exchangeCode` — POST to the token endpoint with the auth code
+ *      from the callback. Returns the raw token payload.
+ *   3. `fetchUserinfo` — pulls the provider's userinfo with the
+ *      newly-minted access token; the caller passes it through
+ *      `provider.extractAccount` to derive the row's `label` /
+ *      `account_email` / `account_id`.
+ *   4. `revokeToken` — best-effort; provider returning non-2xx is logged
+ *      but doesn't block local row deletion.
+ */
+import { log } from '../log.js';
+import type { ProviderSpec } from './providers/index.js';
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  id_token?: string;
+}
+
+export function buildAuthorizeUrl(opts: {
+  provider: ProviderSpec;
+  clientId: string;
+  scopes: string;
+  state: string;
+  redirectUri: string;
+}): string {
+  const u = new URL(opts.provider.authUrl);
+  u.searchParams.set('client_id', opts.clientId);
+  u.searchParams.set('redirect_uri', opts.redirectUri);
+  u.searchParams.set('response_type', 'code');
+  u.searchParams.set('scope', opts.scopes || opts.provider.defaultScopes);
+  u.searchParams.set('state', opts.state);
+  for (const [k, v] of Object.entries(opts.provider.extraAuthParams ?? {})) {
+    u.searchParams.set(k, v);
+  }
+  return u.toString();
+}
+
+export async function exchangeCode(opts: {
+  provider: ProviderSpec;
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: opts.code,
+    client_id: opts.clientId,
+    client_secret: opts.clientSecret,
+    redirect_uri: opts.redirectUri,
+  });
+  const res = await fetch(opts.provider.tokenUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`token exchange ${res.status}: ${text}`);
+  }
+  return (await res.json()) as TokenResponse;
+}
+
+export async function fetchUserinfo(opts: { provider: ProviderSpec; accessToken: string }): Promise<unknown> {
+  const res = await fetch(opts.provider.userinfoUrl, {
+    headers: { authorization: `Bearer ${opts.accessToken}`, accept: 'application/json' },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`userinfo ${res.status}: ${text}`);
+  }
+  return await res.json();
+}
+
+/** Best-effort. Returns true on 2xx, false otherwise (and logs). */
+export async function revokeToken(opts: { provider: ProviderSpec; accessToken: string }): Promise<boolean> {
+  if (!opts.provider.revokeUrl) return false;
+  try {
+    const u = new URL(opts.provider.revokeUrl);
+    u.searchParams.set('token', opts.accessToken);
+    const res = await fetch(u.toString(), { method: 'POST' });
+    if (!res.ok) {
+      log.warn('oauth revoke non-2xx', { provider: opts.provider.slug, status: res.status });
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.warn('oauth revoke failed', {
+      provider: opts.provider.slug,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/src/oauth/providers/google.test.ts
+++ b/src/oauth/providers/google.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { GoogleProvider } from './google.js';
+import { getProvider, listProviderSlugs } from './index.js';
+
+describe('GoogleProvider', () => {
+  it('is registered under slug "google"', () => {
+    expect(getProvider('google')).toBe(GoogleProvider);
+    expect(listProviderSlugs()).toContain('google');
+  });
+
+  it('extracts account from a typical userinfo response', () => {
+    const got = GoogleProvider.extractAccount({
+      sub: '108234567890',
+      email: 'alice@example.com',
+      name: 'Alice',
+    });
+    expect(got.accountId).toBe('108234567890');
+    expect(got.accountEmail).toBe('alice@example.com');
+    expect(got.label).toBe('alice@example.com');
+  });
+
+  it('falls back to name then "google:<sub>" when email is missing', () => {
+    expect(GoogleProvider.extractAccount({ sub: '1', name: 'Bob' }).label).toBe('Bob');
+    expect(GoogleProvider.extractAccount({ sub: '2' }).label).toBe('google:2');
+  });
+
+  it('throws when sub is missing', () => {
+    expect(() => GoogleProvider.extractAccount({ email: 'no-sub@example.com' })).toThrow(/missing `sub`/);
+  });
+
+  it('declares offline access + consent so refresh_token is always issued', () => {
+    expect(GoogleProvider.extraAuthParams).toMatchObject({
+      access_type: 'offline',
+      prompt: 'consent',
+    });
+  });
+});

--- a/src/oauth/providers/google.ts
+++ b/src/oauth/providers/google.ts
@@ -1,0 +1,46 @@
+/**
+ * Google OAuth provider — covers Gmail, Calendar, Drive, Docs, Sheets,
+ * etc. all under one client. Operator registers a single Google Cloud
+ * Console OAuth 2.0 client and grants whatever scopes the agent needs;
+ * paraclaw stores the resulting tokens once.
+ *
+ * Userinfo response shape (from `https://openidconnect.googleapis.com/v1/userinfo`):
+ *   { "sub": "123…", "email": "alice@example.com", "name": "Alice", … }
+ *
+ * `sub` is Google's stable account ID and is what we key on. `email`
+ * goes into both `account_email` and the auto-generated `label`.
+ */
+import type { ProviderSpec, UserinfoExtract } from './index.js';
+
+interface GoogleUserinfo {
+  sub?: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+}
+
+export const GoogleProvider: ProviderSpec = {
+  slug: 'google',
+  displayName: 'Google',
+  authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+  tokenUrl: 'https://oauth2.googleapis.com/token',
+  userinfoUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
+  revokeUrl: 'https://oauth2.googleapis.com/revoke',
+  defaultScopes: 'openid email profile',
+  // access_type=offline + prompt=consent ensures Google issues a
+  // refresh_token even on subsequent authorizations of the same account.
+  extraAuthParams: {
+    access_type: 'offline',
+    prompt: 'consent',
+    include_granted_scopes: 'true',
+  },
+  extractAccount(userinfo: unknown): UserinfoExtract {
+    const u = (userinfo ?? {}) as GoogleUserinfo;
+    if (!u.sub) {
+      throw new Error('google userinfo response missing `sub` (account id)');
+    }
+    const email = u.email ?? null;
+    const label = email ?? u.name ?? `google:${u.sub}`;
+    return { accountId: u.sub, accountEmail: email, label };
+  },
+};

--- a/src/oauth/providers/index.ts
+++ b/src/oauth/providers/index.ts
@@ -42,3 +42,7 @@ export function getProvider(slug: string): ProviderSpec | undefined {
 export function listProviderSlugs(): string[] {
   return Object.keys(PROVIDERS).sort();
 }
+
+export function listProviders(): ProviderSpec[] {
+  return Object.values(PROVIDERS).sort((a, b) => a.slug.localeCompare(b.slug));
+}

--- a/src/oauth/providers/index.ts
+++ b/src/oauth/providers/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Provider registry. New providers (Slack, GitHub, Notion, …) plug in
+ * by exporting a `ProviderSpec` and adding it to `PROVIDERS` below.
+ */
+import { GoogleProvider } from './google.js';
+
+export interface UserinfoExtract {
+  accountId: string;
+  accountEmail: string | null;
+  label: string;
+}
+
+export interface ProviderSpec {
+  /** Slug used in URLs: `/api/apps/:provider/...` */
+  slug: string;
+  /** Human-readable name for the UI. */
+  displayName: string;
+  /** OAuth 2.0 authorization endpoint. */
+  authUrl: string;
+  /** OAuth 2.0 token endpoint. */
+  tokenUrl: string;
+  /** Userinfo endpoint — called post-token-exchange to populate label/email. */
+  userinfoUrl: string;
+  /** Provider-specific token revocation endpoint, or null if not supported. */
+  revokeUrl: string | null;
+  /** Default scope string (space-separated) when the operator doesn't override. */
+  defaultScopes: string;
+  /** Optional extra params on the authorize URL (e.g. Google's access_type=offline). */
+  extraAuthParams?: Record<string, string>;
+  /** Parse the userinfo JSON into account_id + email + label. */
+  extractAccount(userinfo: unknown): UserinfoExtract;
+}
+
+const PROVIDERS: Record<string, ProviderSpec> = {
+  [GoogleProvider.slug]: GoogleProvider,
+};
+
+export function getProvider(slug: string): ProviderSpec | undefined {
+  return PROVIDERS[slug];
+}
+
+export function listProviderSlugs(): string[] {
+  return Object.keys(PROVIDERS).sort();
+}

--- a/src/oauth/state-store.test.ts
+++ b/src/oauth/state-store.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearStateStore, consumeState, mintState, stateStoreSize } from './state-store.js';
+
+afterEach(() => clearStateStore());
+
+describe('oauth state-store', () => {
+  it('mints unique opaque tokens', () => {
+    const a = mintState({ provider: 'google', redirectUri: 'http://x/cb' });
+    const b = mintState({ provider: 'google', redirectUri: 'http://x/cb' });
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(20);
+  });
+
+  it('round-trips context on consume', () => {
+    const state = mintState({
+      provider: 'google',
+      agentGroupId: 'grp-1',
+      redirectUri: 'http://x/cb',
+    });
+    const ctx = consumeState(state);
+    expect(ctx).toBeDefined();
+    expect(ctx?.provider).toBe('google');
+    expect(ctx?.agentGroupId).toBe('grp-1');
+    expect(ctx?.redirectUri).toBe('http://x/cb');
+  });
+
+  it('is single-use — second consume returns undefined', () => {
+    const state = mintState({ provider: 'google', redirectUri: 'http://x/cb' });
+    expect(consumeState(state)).toBeDefined();
+    expect(consumeState(state)).toBeUndefined();
+  });
+
+  it('returns undefined for unknown state', () => {
+    expect(consumeState('never-minted')).toBeUndefined();
+  });
+
+  it('treats expired entries as missing', () => {
+    const state = mintState({ provider: 'google', redirectUri: 'http://x/cb' });
+    // Simulate expiry via clear; consume of arbitrary key returns undefined.
+    clearStateStore();
+    expect(consumeState(state)).toBeUndefined();
+    expect(stateStoreSize()).toBe(0);
+  });
+});

--- a/src/oauth/state-store.test.ts
+++ b/src/oauth/state-store.test.ts
@@ -1,8 +1,17 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { clearStateStore, consumeState, mintState, stateStoreSize } from './state-store.js';
 
-afterEach(() => clearStateStore());
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  clearStateStore();
+  closeDb();
+});
 
 describe('oauth state-store', () => {
   it('mints unique opaque tokens', () => {

--- a/src/oauth/state-store.ts
+++ b/src/oauth/state-store.ts
@@ -1,49 +1,93 @@
 /**
- * Ephemeral OAuth state store. The `state` parameter passed in the
+ * DB-backed OAuth state store. The `state` parameter passed in the
  * authorize redirect is a CSPRNG-random opaque string mapped here to
  * the originating context (provider, optional agentGroupId, redirect
  * URI, expires_at). Single-use: a state consumed at callback can never
  * be replayed.
  *
- * Lives in process memory by design — a paraclaw restart mid-flow
- * forces the user to retry "Connect <provider>", which is acceptable
- * for a self-hosted single-process daemon. Avoids a fourth migration
- * + a stale-row sweeper.
+ * DB-backed (vs in-memory) so that a daemon restart between authorize
+ * and callback doesn't drop the user's flow — they finish in their
+ * browser, the callback hits a fresh process, and the row is still
+ * there.
  */
 import crypto from 'crypto';
+
+import { getDb } from '../db/connection.js';
+import type { Database } from '../db/connection.js';
 
 const TTL_MS = 10 * 60 * 1000;
 
 export interface OauthStateContext {
   provider: string;
-  agentGroupId?: string | null;
+  agentGroupId: string | null;
   redirectUri: string;
-  expiresAt: number;
+  expiresAt: string;
 }
 
-const store = new Map<string, OauthStateContext>();
+interface PendingStateRow {
+  state: string;
+  provider: string;
+  agent_group_id: string | null;
+  redirect_uri: string;
+  created_at: string;
+  expires_at: string;
+}
 
-export function mintState(ctx: Omit<OauthStateContext, 'expiresAt'>): string {
+function db(): Database {
+  return getDb();
+}
+
+export function mintState(ctx: { provider: string; agentGroupId?: string | null; redirectUri: string }): string {
   const state = crypto.randomBytes(24).toString('base64url');
-  store.set(state, { ...ctx, expiresAt: Date.now() + TTL_MS });
+  const now = new Date();
+  const expires = new Date(now.getTime() + TTL_MS);
+  db()
+    .prepare(
+      `INSERT INTO pending_oauth_states
+         (state, provider, agent_group_id, redirect_uri, created_at, expires_at)
+       VALUES
+         (@state, @provider, @agent_group_id, @redirect_uri, @created_at, @expires_at)`,
+    )
+    .run({
+      state,
+      provider: ctx.provider,
+      agent_group_id: ctx.agentGroupId ?? null,
+      redirect_uri: ctx.redirectUri,
+      created_at: now.toISOString(),
+      expires_at: expires.toISOString(),
+    });
   return state;
 }
 
-/** Single-use: returns the context and atomically removes it. */
+/** Single-use: returns the context and atomically removes the row. Expired rows return undefined. */
 export function consumeState(state: string): OauthStateContext | undefined {
-  const ctx = store.get(state);
-  if (!ctx) return undefined;
-  store.delete(state);
-  if (ctx.expiresAt < Date.now()) return undefined;
-  return ctx;
+  const row = db().prepare<PendingStateRow>(`SELECT * FROM pending_oauth_states WHERE state = @state`).get({ state });
+  if (!row) return undefined;
+  db().prepare(`DELETE FROM pending_oauth_states WHERE state = @state`).run({ state });
+  if (new Date(row.expires_at).getTime() < Date.now()) return undefined;
+  return {
+    provider: row.provider,
+    agentGroupId: row.agent_group_id,
+    redirectUri: row.redirect_uri,
+    expiresAt: row.expires_at,
+  };
+}
+
+/** Sweeper — deletes any state past its TTL. Returns rows removed. Called from host-sweep. */
+export function sweepExpiredStates(): number {
+  const r = db()
+    .prepare(`DELETE FROM pending_oauth_states WHERE expires_at < @now`)
+    .run({ now: new Date().toISOString() });
+  return r.changes;
 }
 
 /** Test seam: drop everything. */
 export function clearStateStore(): void {
-  store.clear();
+  db().prepare(`DELETE FROM pending_oauth_states`).run();
 }
 
 /** Test seam: how many live entries (for assertion). */
 export function stateStoreSize(): number {
-  return store.size;
+  const r = db().prepare<{ n: number }>(`SELECT COUNT(*) AS n FROM pending_oauth_states`).get();
+  return r?.n ?? 0;
 }

--- a/src/oauth/state-store.ts
+++ b/src/oauth/state-store.ts
@@ -1,0 +1,49 @@
+/**
+ * Ephemeral OAuth state store. The `state` parameter passed in the
+ * authorize redirect is a CSPRNG-random opaque string mapped here to
+ * the originating context (provider, optional agentGroupId, redirect
+ * URI, expires_at). Single-use: a state consumed at callback can never
+ * be replayed.
+ *
+ * Lives in process memory by design — a paraclaw restart mid-flow
+ * forces the user to retry "Connect <provider>", which is acceptable
+ * for a self-hosted single-process daemon. Avoids a fourth migration
+ * + a stale-row sweeper.
+ */
+import crypto from 'crypto';
+
+const TTL_MS = 10 * 60 * 1000;
+
+export interface OauthStateContext {
+  provider: string;
+  agentGroupId?: string | null;
+  redirectUri: string;
+  expiresAt: number;
+}
+
+const store = new Map<string, OauthStateContext>();
+
+export function mintState(ctx: Omit<OauthStateContext, 'expiresAt'>): string {
+  const state = crypto.randomBytes(24).toString('base64url');
+  store.set(state, { ...ctx, expiresAt: Date.now() + TTL_MS });
+  return state;
+}
+
+/** Single-use: returns the context and atomically removes it. */
+export function consumeState(state: string): OauthStateContext | undefined {
+  const ctx = store.get(state);
+  if (!ctx) return undefined;
+  store.delete(state);
+  if (ctx.expiresAt < Date.now()) return undefined;
+  return ctx;
+}
+
+/** Test seam: drop everything. */
+export function clearStateStore(): void {
+  store.clear();
+}
+
+/** Test seam: how many live entries (for assertion). */
+export function stateStoreSize(): number {
+  return store.size;
+}

--- a/src/web/routes/apps.ts
+++ b/src/web/routes/apps.ts
@@ -1,0 +1,433 @@
+/**
+ * /api/apps — OAuth integrations surface.
+ *
+ *   GET / PUT / DELETE /api/apps/:provider/config       BYOC client config
+ *   POST            /api/apps/:provider/authorize       mint redirect URL
+ *   GET             /api/apps/:provider/callback        token exchange
+ *   GET             /api/apps                            list connections
+ *   DELETE          /api/apps/:id                        revoke + delete
+ *   GET / PUT       /api/apps/:id/agents                 manage allowlist
+ *
+ * Encrypted columns (`client_secret`, `access_token`, `refresh_token`)
+ * are NEVER returned through any of these endpoints. The view shapes
+ * below shape DB rows into camelCase JSON without the secret fields.
+ *
+ * Operator setup: register `${origin}/api/apps/<provider>/callback` as
+ * an authorized redirect URI in the provider's OAuth client console.
+ * The origin is derived from `req.headers.host` (or
+ * `PARACLAW_WEB_ORIGIN` if set, for tunneled deployments).
+ */
+import http from 'node:http';
+
+import {
+  type AgentForConnection,
+  listAgentsForConnection,
+  setAgentsForConnection,
+} from '../../oauth/agent-app-connections.js';
+import {
+  type AppConfigRow,
+  deleteAppConfig,
+  getAppConfig,
+  getAppConfigWithSecret,
+  listAppConfigs,
+  putAppConfig,
+} from '../../oauth/app-configs.js';
+import {
+  type AppConnectionRow,
+  deleteAppConnection,
+  getAppConnection,
+  getAppConnectionWithTokens,
+  listAppConnections,
+  upsertAppConnection,
+} from '../../oauth/app-connections.js';
+import { buildAuthorizeUrl, exchangeCode, fetchUserinfo, revokeToken } from '../../oauth/flow.js';
+import { getProvider } from '../../oauth/providers/index.js';
+import { consumeState, mintState } from '../../oauth/state-store.js';
+import { log } from '../../log.js';
+
+interface AppConfigView {
+  id: string;
+  provider: string;
+  clientId: string;
+  scopesDefault: string;
+  hasSecret: true;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AppConnectionView {
+  id: string;
+  provider: string;
+  appConfigId: string;
+  accountEmail: string | null;
+  accountId: string;
+  scopesGranted: string;
+  expiresAt: string | null;
+  label: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AgentAssignmentView {
+  agentGroupId: string;
+  agentGroupFolder: string;
+  agentGroupName: string;
+  createdAt: string;
+}
+
+function configToView(r: AppConfigRow): AppConfigView {
+  return {
+    id: r.id,
+    provider: r.provider,
+    clientId: r.client_id,
+    scopesDefault: r.scopes_default,
+    hasSecret: true,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function connectionToView(r: AppConnectionRow, provider: string): AppConnectionView {
+  return {
+    id: r.id,
+    provider,
+    appConfigId: r.app_config_id,
+    accountEmail: r.account_email,
+    accountId: r.account_id,
+    scopesGranted: r.scopes_granted,
+    expiresAt: r.expires_at,
+    label: r.label,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function agentToView(r: AgentForConnection): AgentAssignmentView {
+  return {
+    agentGroupId: r.agent_group_id,
+    agentGroupFolder: r.agent_group_folder,
+    agentGroupName: r.agent_group_name,
+    createdAt: r.created_at,
+  };
+}
+
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+const error = (res: http.ServerResponse, status: number, message: string): void =>
+  json(res, status, { error: message });
+
+const redirect = (res: http.ServerResponse, location: string): void => {
+  res.writeHead(302, { location });
+  res.end();
+};
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return {} as T;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+function originFromReq(req: http.IncomingMessage): string {
+  const env = process.env.PARACLAW_WEB_ORIGIN;
+  if (env) return env.replace(/\/$/, '');
+  const host = req.headers.host ?? 'localhost:1944';
+  const proto = (req.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
+  return `${proto}://${host}`;
+}
+
+function callbackUri(req: http.IncomingMessage, providerSlug: string): string {
+  return `${originFromReq(req)}/api/apps/${providerSlug}/callback`;
+}
+
+/** Resolve a connection by id. Returns the resolved provider slug too. */
+function resolveConnectionWithProvider(id: string): { row: AppConnectionRow; providerSlug: string } | undefined {
+  const row = getAppConnection(id);
+  if (!row) return undefined;
+  // Cheap lookup back to the provider slug via the config row.
+  const cfg = getAppConfigViaId(row.app_config_id);
+  if (!cfg) return undefined;
+  return { row, providerSlug: cfg.provider };
+}
+
+function getAppConfigViaId(id: string): AppConfigRow | undefined {
+  // app_configs is provider-keyed at the lookup layer; we walk the
+  // small list to find the row by id. Practical at <20 providers.
+  for (const row of listAppConfigs()) {
+    if (row.id === id) return row;
+  }
+  return undefined;
+}
+
+export interface AppsRouteContext {
+  pathname: string;
+  method: string;
+  url: URL;
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+}
+
+const CONFIG_RE = /^\/api\/apps\/([^/]+)\/config$/;
+const AUTHORIZE_RE = /^\/api\/apps\/([^/]+)\/authorize$/;
+const CALLBACK_RE = /^\/api\/apps\/([^/]+)\/callback$/;
+const AGENTS_RE = /^\/api\/apps\/([^/]+)\/agents$/;
+const ID_RE = /^\/api\/apps\/([^/]+)$/;
+
+export async function handleAppsRoute(ctx: AppsRouteContext): Promise<boolean> {
+  const { pathname, method, url, req, res } = ctx;
+
+  // List connections (no tokens, no secrets).
+  if (pathname === '/api/apps' && method === 'GET') {
+    const rows = listAppConnections();
+    const providers = new Map<string, string>();
+    for (const cfg of listAppConfigs()) providers.set(cfg.id, cfg.provider);
+    json(res, 200, {
+      connections: rows.map((r) => connectionToView(r, providers.get(r.app_config_id) ?? 'unknown')),
+    });
+    return true;
+  }
+
+  const cfgMatch = pathname.match(CONFIG_RE);
+  if (cfgMatch) {
+    const provider = decodeURIComponent(cfgMatch[1]);
+    if (!getProvider(provider)) {
+      error(res, 404, `unknown provider: ${provider}`);
+      return true;
+    }
+    if (method === 'GET') {
+      const row = getAppConfig(provider);
+      if (!row) {
+        error(res, 404, `no config for provider: ${provider}`);
+        return true;
+      }
+      json(res, 200, { config: configToView(row) });
+      return true;
+    }
+    if (method === 'PUT') {
+      let body: { clientId?: string; clientSecret?: string; scopesDefault?: string };
+      try {
+        body = await readJsonBody(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      const clientId = (body.clientId ?? '').trim();
+      const clientSecret = body.clientSecret ?? '';
+      if (!clientId) {
+        error(res, 400, 'clientId is required');
+        return true;
+      }
+      if (!clientSecret) {
+        error(res, 400, 'clientSecret is required');
+        return true;
+      }
+      putAppConfig(provider, {
+        client_id: clientId,
+        client_secret: clientSecret,
+        scopes_default: body.scopesDefault ?? '',
+      });
+      const row = getAppConfig(provider);
+      if (!row) {
+        error(res, 500, 'config disappeared between write and read');
+        return true;
+      }
+      json(res, 200, { config: configToView(row) });
+      return true;
+    }
+    if (method === 'DELETE') {
+      const ok = deleteAppConfig(provider);
+      if (!ok) {
+        error(res, 404, `no config for provider: ${provider}`);
+        return true;
+      }
+      json(res, 200, { provider, deleted: true });
+      return true;
+    }
+  }
+
+  const authMatch = pathname.match(AUTHORIZE_RE);
+  if (authMatch && method === 'POST') {
+    const providerSlug = decodeURIComponent(authMatch[1]);
+    const provider = getProvider(providerSlug);
+    if (!provider) {
+      error(res, 404, `unknown provider: ${providerSlug}`);
+      return true;
+    }
+    const cfg = getAppConfig(providerSlug);
+    if (!cfg) {
+      error(res, 409, `provider ${providerSlug} has no client config — PUT /api/apps/${providerSlug}/config first`);
+      return true;
+    }
+    let body: { agentGroupId?: string | null; scopes?: string };
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      error(res, 400, 'invalid JSON body');
+      return true;
+    }
+    const redirectUri = callbackUri(req, providerSlug);
+    const state = mintState({
+      provider: providerSlug,
+      agentGroupId: body.agentGroupId ?? null,
+      redirectUri,
+    });
+    const authorizeUrl = buildAuthorizeUrl({
+      provider,
+      clientId: cfg.client_id,
+      scopes: body.scopes || cfg.scopes_default || provider.defaultScopes,
+      state,
+      redirectUri,
+    });
+    json(res, 200, { authorizeUrl, state });
+    return true;
+  }
+
+  const cbMatch = pathname.match(CALLBACK_RE);
+  if (cbMatch && method === 'GET') {
+    const providerSlug = decodeURIComponent(cbMatch[1]);
+    const provider = getProvider(providerSlug);
+    if (!provider) {
+      error(res, 404, `unknown provider: ${providerSlug}`);
+      return true;
+    }
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const oauthError = url.searchParams.get('error');
+    if (oauthError) {
+      error(res, 400, `provider returned error: ${oauthError}`);
+      return true;
+    }
+    if (!code || !state) {
+      error(res, 400, 'missing code or state');
+      return true;
+    }
+    const stateCtx = consumeState(state);
+    if (!stateCtx) {
+      error(res, 400, 'invalid or expired state');
+      return true;
+    }
+    if (stateCtx.provider !== providerSlug) {
+      error(res, 400, 'state/provider mismatch');
+      return true;
+    }
+    const cfg = getAppConfigWithSecret(providerSlug);
+    if (!cfg) {
+      error(res, 409, `provider ${providerSlug} has no client config`);
+      return true;
+    }
+    let tokens;
+    try {
+      tokens = await exchangeCode({
+        provider,
+        clientId: cfg.client_id,
+        clientSecret: cfg.client_secret,
+        code,
+        redirectUri: stateCtx.redirectUri,
+      });
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+      return true;
+    }
+    let userinfo: unknown;
+    try {
+      userinfo = await fetchUserinfo({ provider, accessToken: tokens.access_token });
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+      return true;
+    }
+    let extracted;
+    try {
+      extracted = provider.extractAccount(userinfo);
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+      return true;
+    }
+    const expiresAt = tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000).toISOString() : null;
+    const connectionId = upsertAppConnection({
+      app_config_id: cfg.id,
+      account_id: extracted.accountId,
+      account_email: extracted.accountEmail,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token ?? null,
+      scopes_granted: tokens.scope ?? '',
+      expires_at: expiresAt,
+      label: extracted.label,
+      metadata_json: tokens.id_token ? JSON.stringify({ id_token: tokens.id_token }) : null,
+    });
+    if (stateCtx.agentGroupId) {
+      try {
+        const existing = listAgentsForConnection(connectionId).map((a) => a.agent_group_id);
+        if (!existing.includes(stateCtx.agentGroupId)) {
+          setAgentsForConnection(connectionId, [...existing, stateCtx.agentGroupId]);
+        }
+      } catch (err) {
+        log.warn('oauth callback: failed to attach agent', {
+          connectionId,
+          agentGroupId: stateCtx.agentGroupId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // Redirect back to the SPA. We don't know the SPA's deep-link;
+    // the operator's UI handles `/apps?connected=<id>`. Fall back to
+    // root if the mount-prefix env isn't set.
+    const mount = (process.env.PARACLAW_WEB_MOUNT ?? '').replace(/\/$/, '');
+    redirect(res, `${originFromReq(req)}${mount}/apps?connected=${connectionId}`);
+    return true;
+  }
+
+  const agentsMatch = pathname.match(AGENTS_RE);
+  if (agentsMatch) {
+    const id = decodeURIComponent(agentsMatch[1]);
+    if (!getAppConnection(id)) {
+      error(res, 404, `connection not found: ${id}`);
+      return true;
+    }
+    if (method === 'GET') {
+      json(res, 200, { agents: listAgentsForConnection(id).map(agentToView) });
+      return true;
+    }
+    if (method === 'PUT') {
+      let body: { agentGroupIds?: string[] };
+      try {
+        body = await readJsonBody(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      if (!Array.isArray(body.agentGroupIds)) {
+        error(res, 400, 'agentGroupIds must be a string[]');
+        return true;
+      }
+      setAgentsForConnection(id, body.agentGroupIds);
+      json(res, 200, { agents: listAgentsForConnection(id).map(agentToView) });
+      return true;
+    }
+  }
+
+  const idMatch = pathname.match(ID_RE);
+  if (idMatch && method === 'DELETE') {
+    const id = decodeURIComponent(idMatch[1]);
+    const resolved = resolveConnectionWithProvider(id);
+    if (!resolved) {
+      error(res, 404, `connection not found: ${id}`);
+      return true;
+    }
+    const provider = getProvider(resolved.providerSlug);
+    if (provider) {
+      const withTokens = getAppConnectionWithTokens(id);
+      if (withTokens) {
+        // Best-effort revocation; never blocks local delete.
+        await revokeToken({ provider, accessToken: withTokens.access_token });
+      }
+    }
+    deleteAppConnection(id);
+    json(res, 200, { id, deleted: true });
+    return true;
+  }
+
+  return false;
+}

--- a/src/web/routes/apps.ts
+++ b/src/web/routes/apps.ts
@@ -5,6 +5,7 @@
  *   POST            /api/apps/:provider/authorize       mint redirect URL
  *   GET             /api/apps/:provider/callback        token exchange
  *   GET             /api/apps                            list connections
+ *   GET             /api/apps/:id                        single connection
  *   DELETE          /api/apps/:id                        revoke + delete
  *   GET / PUT       /api/apps/:id/agents                 manage allowlist
  *
@@ -21,6 +22,7 @@ import http from 'node:http';
 
 import {
   type AgentForConnection,
+  countAgentsByConnection,
   listAgentsForConnection,
   setAgentsForConnection,
 } from '../../oauth/agent-app-connections.js';
@@ -29,7 +31,6 @@ import {
   deleteAppConfig,
   getAppConfig,
   getAppConfigWithSecret,
-  listAppConfigs,
   putAppConfig,
 } from '../../oauth/app-configs.js';
 import {
@@ -64,6 +65,7 @@ interface AppConnectionView {
   scopesGranted: string;
   expiresAt: string | null;
   label: string;
+  agentGroupCount: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -87,16 +89,17 @@ function configToView(r: AppConfigRow): AppConfigView {
   };
 }
 
-function connectionToView(r: AppConnectionRow, provider: string): AppConnectionView {
+function connectionToView(r: AppConnectionRow, agentGroupCount: number): AppConnectionView {
   return {
     id: r.id,
-    provider,
+    provider: r.provider,
     appConfigId: r.app_config_id,
     accountEmail: r.account_email,
     accountId: r.account_id,
     scopesGranted: r.scopes_granted,
     expiresAt: r.expires_at,
     label: r.label,
+    agentGroupCount,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -143,25 +146,6 @@ function callbackUri(req: http.IncomingMessage, providerSlug: string): string {
   return `${originFromReq(req)}/api/apps/${providerSlug}/callback`;
 }
 
-/** Resolve a connection by id. Returns the resolved provider slug too. */
-function resolveConnectionWithProvider(id: string): { row: AppConnectionRow; providerSlug: string } | undefined {
-  const row = getAppConnection(id);
-  if (!row) return undefined;
-  // Cheap lookup back to the provider slug via the config row.
-  const cfg = getAppConfigViaId(row.app_config_id);
-  if (!cfg) return undefined;
-  return { row, providerSlug: cfg.provider };
-}
-
-function getAppConfigViaId(id: string): AppConfigRow | undefined {
-  // app_configs is provider-keyed at the lookup layer; we walk the
-  // small list to find the row by id. Practical at <20 providers.
-  for (const row of listAppConfigs()) {
-    if (row.id === id) return row;
-  }
-  return undefined;
-}
-
 export interface AppsRouteContext {
   pathname: string;
   method: string;
@@ -182,10 +166,9 @@ export async function handleAppsRoute(ctx: AppsRouteContext): Promise<boolean> {
   // List connections (no tokens, no secrets).
   if (pathname === '/api/apps' && method === 'GET') {
     const rows = listAppConnections();
-    const providers = new Map<string, string>();
-    for (const cfg of listAppConfigs()) providers.set(cfg.id, cfg.provider);
+    const counts = countAgentsByConnection();
     json(res, 200, {
-      connections: rows.map((r) => connectionToView(r, providers.get(r.app_config_id) ?? 'unknown')),
+      connections: rows.map((r) => connectionToView(r, counts.get(r.id) ?? 0)),
     });
     return true;
   }
@@ -348,6 +331,7 @@ export async function handleAppsRoute(ctx: AppsRouteContext): Promise<boolean> {
     const expiresAt = tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000).toISOString() : null;
     const connectionId = upsertAppConnection({
       app_config_id: cfg.id,
+      provider: providerSlug,
       account_id: extracted.accountId,
       account_email: extracted.accountEmail,
       access_token: tokens.access_token,
@@ -409,24 +393,31 @@ export async function handleAppsRoute(ctx: AppsRouteContext): Promise<boolean> {
   }
 
   const idMatch = pathname.match(ID_RE);
-  if (idMatch && method === 'DELETE') {
+  if (idMatch) {
     const id = decodeURIComponent(idMatch[1]);
-    const resolved = resolveConnectionWithProvider(id);
-    if (!resolved) {
+    const row = getAppConnection(id);
+    if (!row) {
       error(res, 404, `connection not found: ${id}`);
       return true;
     }
-    const provider = getProvider(resolved.providerSlug);
-    if (provider) {
-      const withTokens = getAppConnectionWithTokens(id);
-      if (withTokens) {
-        // Best-effort revocation; never blocks local delete.
-        await revokeToken({ provider, accessToken: withTokens.access_token });
-      }
+    if (method === 'GET') {
+      const counts = countAgentsByConnection();
+      json(res, 200, { connection: connectionToView(row, counts.get(row.id) ?? 0) });
+      return true;
     }
-    deleteAppConnection(id);
-    json(res, 200, { id, deleted: true });
-    return true;
+    if (method === 'DELETE') {
+      const provider = getProvider(row.provider);
+      if (provider) {
+        const withTokens = getAppConnectionWithTokens(id);
+        if (withTokens) {
+          // Best-effort revocation; never blocks local delete.
+          await revokeToken({ provider, accessToken: withTokens.access_token });
+        }
+      }
+      deleteAppConnection(id);
+      json(res, 200, { id, deleted: true });
+      return true;
+    }
   }
 
   return false;

--- a/src/web/routes/apps.ts
+++ b/src/web/routes/apps.ts
@@ -13,10 +13,12 @@
  * are NEVER returned through any of these endpoints. The view shapes
  * below shape DB rows into camelCase JSON without the secret fields.
  *
- * Operator setup: register `${origin}/api/apps/<provider>/callback` as
- * an authorized redirect URI in the provider's OAuth client console.
- * The origin is derived from `req.headers.host` (or
- * `PARACLAW_WEB_ORIGIN` if set, for tunneled deployments).
+ * Operator setup: register `${origin}${mount}/api/apps/<provider>/callback`
+ * as an authorized redirect URI in the provider's OAuth client console.
+ * `${mount}` is `PARACLAW_WEB_MOUNT` (e.g. `/claw` when fronted by the
+ * Parachute hub), empty when paraclaw serves at the origin root. The
+ * origin is derived from `req.headers.host` (or `PARACLAW_WEB_ORIGIN` if
+ * set, for tunneled deployments).
  */
 import http from 'node:http';
 
@@ -143,7 +145,13 @@ function originFromReq(req: http.IncomingMessage): string {
 }
 
 function callbackUri(req: http.IncomingMessage, providerSlug: string): string {
-  return `${originFromReq(req)}/api/apps/${providerSlug}/callback`;
+  // Must include PARACLAW_WEB_MOUNT (e.g. `/claw`) when the daemon is
+  // fronted at a path prefix — otherwise the provider redirects the
+  // browser to ${origin}/api/... which 404s on the hub. Authorize +
+  // token-exchange use this same string, so the operator-registered
+  // redirect_uri in the provider console must match.
+  const mount = (process.env.PARACLAW_WEB_MOUNT ?? '').replace(/\/$/, '');
+  return `${originFromReq(req)}${mount}/api/apps/${providerSlug}/callback`;
 }
 
 export interface AppsRouteContext {

--- a/src/web/routes/oauth-providers.ts
+++ b/src/web/routes/oauth-providers.ts
@@ -1,0 +1,42 @@
+/**
+ * /api/oauth/providers — read-only provider registry.
+ *
+ * The UI's "add integration" picker is data-driven off this list rather
+ * than hard-coding provider slugs in the SPA bundle. New providers
+ * registered in `src/oauth/providers/index.ts` automatically surface
+ * here. No secrets, no per-account state — just the registry shape.
+ */
+import http from 'node:http';
+
+import { listProviders } from '../../oauth/providers/index.js';
+
+interface ProviderView {
+  slug: string;
+  displayName: string;
+  defaultScopes: string;
+}
+
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+export interface OauthProvidersRouteContext {
+  pathname: string;
+  method: string;
+  res: http.ServerResponse;
+}
+
+export function handleOauthProvidersRoute(ctx: OauthProvidersRouteContext): boolean {
+  const { pathname, method, res } = ctx;
+  if (pathname === '/api/oauth/providers' && method === 'GET') {
+    const providers: ProviderView[] = listProviders().map((p) => ({
+      slug: p.slug,
+      displayName: p.displayName,
+      defaultScopes: p.defaultScopes,
+    }));
+    json(res, 200, { providers });
+    return true;
+  }
+  return false;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -57,6 +57,7 @@ import { handleAppsRoute } from './routes/apps.js';
 import { handleApprovalsRoute } from './routes/approvals.js';
 import { handleChannelsRoute } from './routes/channels.js';
 import { handleActivityRoute } from './routes/activity.js';
+import { handleOauthProvidersRoute } from './routes/oauth-providers.js';
 import { handleSecretsRoute } from './routes/secrets.js';
 import { handleSessionsRoute } from './routes/sessions.js';
 import { handleSetupStatusRoute } from './routes/setup-status.js';
@@ -77,7 +78,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // hub#83) sets this from `module.json` `paths[0]` automatically. Empty
 // string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.14-rc.4';
+const SERVICE_VERSION = '0.0.14-rc.5';
 
 interface AgentGroupRow {
   id: string;
@@ -287,6 +288,19 @@ async function handleApi(
     if (!(await gate(req, res, required))) return;
     try {
       const handled = await handleSessionsRoute({ pathname, method, res });
+      if (handled) return;
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+      return;
+    }
+  }
+
+  // Read-only provider registry — data-drives the SPA's "add integration"
+  // picker so new providers don't require a UI bundle change.
+  if (pathname === '/api/oauth/providers' && method === 'GET') {
+    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
+    try {
+      const handled = handleOauthProvidersRoute({ pathname, method, res });
       if (handled) return;
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -78,7 +78,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // hub#83) sets this from `module.json` `paths[0]` automatically. Empty
 // string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.14-rc.6';
+const SERVICE_VERSION = '0.0.14-rc.7';
 
 interface AgentGroupRow {
   id: string;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -78,7 +78,7 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // hub#83) sets this from `module.json` `paths[0]` automatically. Empty
 // string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.14-rc.5';
+const SERVICE_VERSION = '0.0.14-rc.6';
 
 interface AgentGroupRow {
   id: string;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -53,6 +53,7 @@ import {
   type ClawScope,
 } from './auth.js';
 import { fetchHubVaults } from './hub-discovery.js';
+import { handleAppsRoute } from './routes/apps.js';
 import { handleApprovalsRoute } from './routes/approvals.js';
 import { handleChannelsRoute } from './routes/channels.js';
 import { handleActivityRoute } from './routes/activity.js';
@@ -286,6 +287,25 @@ async function handleApi(
     if (!(await gate(req, res, required))) return;
     try {
       const handled = await handleSessionsRoute({ pathname, method, res });
+      if (handled) return;
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+      return;
+    }
+  }
+
+  // OAuth callback redirects come from the provider's authorization
+  // server with no Authorization header — the unguessable `state` token
+  // (single-use, 10-min TTL, see oauth/state-store.ts) is the auth.
+  // Everything else under /api/apps requires a JWT.
+  if (pathname === '/api/apps' || pathname.startsWith('/api/apps/')) {
+    const isCallback = /^\/api\/apps\/[^/]+\/callback$/.test(pathname) && method === 'GET';
+    if (!isCallback) {
+      const required: ClawScope = method === 'GET' ? SCOPE_CLAW_READ : SCOPE_CLAW_ADMIN;
+      if (!(await gate(req, res, required))) return;
+    }
+    try {
+      const handled = await handleAppsRoute({ pathname, method, url, req, res });
       if (handled) return;
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

PR3 of three stacked on `night/paraclaw-rebirth` — server backend for `/api/apps`, mirroring OneCLI's OAuth model verbatim. Powers the UI in #41.

**Three-table model:**
- `app_configs` — BYOC client config; `client_secret` AES-GCM at rest
- `app_connections` — per-account grants; `access_token` / `refresh_token` AES-GCM at rest
- `agent_app_connections` — per-agent allowlist join (mirrors `secret_assignments`)

**Routes (mirror OneCLI verbatim):**
- `GET / PUT / DELETE /api/apps/:provider/config` — BYOC config (PUT/DELETE: `claw:admin`)
- `POST /api/apps/:provider/authorize` `{ agentGroupId?, scopes? }` → `{ authorizeUrl, state }`
- `GET /api/apps/:provider/callback?code&state` — no-auth (state token IS the auth)
- `GET /api/apps` — list connections (no tokens, no secrets)
- `DELETE /api/apps/:id` — best-effort revoke + local delete
- `GET / PUT /api/apps/:id/agents` — agent allowlist (PUT: `claw:admin`)

**Provider scaffold:**
- `src/oauth/providers/index.ts` — `ProviderSpec` interface + registry
- `src/oauth/providers/google.ts` — Google (offline access + `prompt=consent` so refresh_token always issued); covers Gmail, Calendar, Drive, etc.

**Encryption:**
- `src/oauth/crypto.ts` derives a domain-separated HKDF key (`paraclaw.oauth.v1`) from the same master key as secrets; OAuth blast radius stays separate from the secret-store keyspace.

**State store** is in-memory (10-min TTL, single-use, CSPRNG-random). Daemon restart mid-flow forces user retry, which is acceptable for a single-process self-hosted daemon and avoids a fourth migration + sweeper.

## Migrations

- `018-oauth-app-configs` — UNIQUE on provider
- `019-oauth-app-connections` — UNIQUE on (app_config_id, account_id), FK CASCADE from app_configs
- `020-agent-app-connections` — composite PK (agent_group_id, app_connection_id), FK CASCADE both sides

(Versions 018-020 because PR2 took 017; uniqueness is by name.)

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 282/282 pass
- [x] 21 new vitest cases:
  - `state-store.test.ts` (5) — mint/consume single-use, expired, unknown
  - `app-configs.test.ts` (6) — round-trip, secret hiding, upsert, list, delete
  - `app-connections.test.ts` (5) — token round-trip, public hide, upsert keying, multi-account, delete
  - `providers/google.test.ts` (5) — registry, extractAccount happy + fallbacks, missing sub throws
- [ ] Live Google flow (operator-side; needs PR merged + UI #41 wired)

## Security notes

- Token columns + client_secret never traverse the API; `getAppConfigWithSecret` / `getAppConnectionWithTokens` are the only decrypt seams and are not called from any route handler that serializes its result.
- Callback path is auth-skipped because the provider redirects from a browser with no Authorization header — the unguessable state token is the auth (single-use, 10-min TTL).
- Best-effort revoke on DELETE `/api/apps/:id` always followed by local delete; provider returning non-2xx is logged but never blocks.



## Deferred follow-up

- **#44 — feat(oauth): container injection seam + access token refresh.** The persistence layer (refresh_token_encrypted, expires_at, getAppConnectionWithTokens) lands in this PR; the runtime seam (refreshIfNeeded() + PARACLAW_OAUTH_INTEGRATIONS env var on container spawn) follows in #44 because it touches container-runner. Don't merge this PR thinking the OAuth flow is end-to-end working for agents — the agent-side wiring lives in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Migrated from ParachuteComputer/paraclaw-archive-fork#43 (the repo was detached from the qwibitai/nanoclaw fork network; PRs were re-created on the standalone repo with new numbers)._