### PR TITLE
fix(mcp): translate loopback URLs to host.docker.internal at spawn

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,6 +17,7 @@ import {
 } from './config.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
+import { rewriteMcpUrlsForContainer } from './parachute/vault-mcp.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -244,9 +245,20 @@ function buildMounts(
 
   // container.json — nested RO mount on top of RW group dir so the agent
   // can read its config but cannot modify it.
+  //
+  // We don't mount the on-disk file directly: we write a per-spawn copy
+  // to the session dir with HTTP MCP URLs translated from loopback
+  // (`127.0.0.1` / `localhost`) to `host.docker.internal`. The on-disk
+  // file keeps the operator-facing URL (what the UI displays, what they
+  // typed); the container sees a derived copy that's actually reachable
+  // from inside Docker. See `rewriteMcpUrlsForContainer` in
+  // src/parachute/vault-mcp.ts for the rewrite rules.
   const containerJsonPath = path.join(groupDir, 'container.json');
   if (fs.existsSync(containerJsonPath)) {
-    mounts.push({ hostPath: containerJsonPath, containerPath: '/workspace/agent/container.json', readonly: true });
+    const spawnConfig = rewriteMcpUrlsForContainer(containerConfig);
+    const spawnConfigPath = path.join(sessDir, '.spawn-container.json');
+    fs.writeFileSync(spawnConfigPath, JSON.stringify(spawnConfig, null, 2) + '\n');
+    mounts.push({ hostPath: spawnConfigPath, containerPath: '/workspace/agent/container.json', readonly: true });
   }
 
   // Composer-managed CLAUDE.md artifacts — nested RO mounts. These are

--- a/src/parachute/vault-mcp.test.ts
+++ b/src/parachute/vault-mcp.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for `localhostToContainerHost` + `rewriteMcpUrlsForContainer`.
+ *
+ * The translation runs at container-spawn time so an HTTP MCP server
+ * with a loopback URL on the host (`127.0.0.1`, `localhost`, …) becomes
+ * reachable from inside the Docker container, where loopback would
+ * otherwise resolve to the container itself.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { ContainerConfig } from '../container-config.js';
+import { localhostToContainerHost, rewriteMcpUrlsForContainer } from './vault-mcp.js';
+
+describe('localhostToContainerHost', () => {
+  it('rewrites 127.0.0.1 → host.docker.internal, preserving port + path + scheme', () => {
+    expect(localhostToContainerHost('http://127.0.0.1:1940/vault/default/mcp')).toBe(
+      'http://host.docker.internal:1940/vault/default/mcp',
+    );
+  });
+
+  it('rewrites localhost', () => {
+    expect(localhostToContainerHost('http://localhost:1942/notes/api')).toBe(
+      'http://host.docker.internal:1942/notes/api',
+    );
+  });
+
+  it('rewrites 0.0.0.0 (treat as loopback for our purposes)', () => {
+    expect(localhostToContainerHost('http://0.0.0.0:1940/mcp')).toBe('http://host.docker.internal:1940/mcp');
+  });
+
+  it('rewrites IPv6 [::1]', () => {
+    expect(localhostToContainerHost('http://[::1]:1940/mcp')).toBe('http://host.docker.internal:1940/mcp');
+  });
+
+  it('rewrites localhost.localdomain', () => {
+    expect(localhostToContainerHost('http://localhost.localdomain:1940/mcp')).toBe(
+      'http://host.docker.internal:1940/mcp',
+    );
+  });
+
+  it('rewrites https scheme + preserves query string', () => {
+    expect(localhostToContainerHost('https://127.0.0.1:8443/mcp?session=abc')).toBe(
+      'https://host.docker.internal:8443/mcp?session=abc',
+    );
+  });
+
+  it('passes through tailnet hosts unchanged', () => {
+    const url = 'https://parachute.taildf9ce2.ts.net/vault/default/mcp';
+    expect(localhostToContainerHost(url)).toBe(url);
+  });
+
+  it('passes through public domains unchanged', () => {
+    const url = 'https://api.example.com/mcp';
+    expect(localhostToContainerHost(url)).toBe(url);
+  });
+
+  it('passes through LAN IPs unchanged (Docker bridge can route them)', () => {
+    expect(localhostToContainerHost('http://192.168.1.5:1940/mcp')).toBe('http://192.168.1.5:1940/mcp');
+    expect(localhostToContainerHost('http://10.0.0.5/mcp')).toBe('http://10.0.0.5/mcp');
+  });
+
+  it('passes through host.docker.internal (already translated)', () => {
+    const url = 'http://host.docker.internal:1940/mcp';
+    expect(localhostToContainerHost(url)).toBe(url);
+  });
+
+  it('returns malformed URL unchanged', () => {
+    expect(localhostToContainerHost('not-a-url')).toBe('not-a-url');
+    expect(localhostToContainerHost('')).toBe('');
+  });
+});
+
+describe('rewriteMcpUrlsForContainer', () => {
+  function baseConfig(): ContainerConfig {
+    return {
+      mcpServers: {},
+      packages: { apt: [], npm: [] },
+      additionalMounts: [],
+      skills: 'all',
+    };
+  }
+
+  it('rewrites URL on http MCP entries, leaves stdio entries alone', () => {
+    const cfg: ContainerConfig = {
+      ...baseConfig(),
+      mcpServers: {
+        'parachute-vault': {
+          type: 'http',
+          url: 'http://127.0.0.1:1940/vault/default/mcp',
+          headers: { Authorization: 'Bearer pvt_test' },
+        },
+        'local-tool': {
+          type: 'stdio',
+          command: 'node',
+          args: ['/app/tool.js'],
+        },
+      },
+    };
+
+    const out = rewriteMcpUrlsForContainer(cfg);
+
+    expect(out.mcpServers['parachute-vault']).toMatchObject({
+      type: 'http',
+      url: 'http://host.docker.internal:1940/vault/default/mcp',
+      headers: { Authorization: 'Bearer pvt_test' },
+    });
+    expect(out.mcpServers['local-tool']).toEqual({
+      type: 'stdio',
+      command: 'node',
+      args: ['/app/tool.js'],
+    });
+  });
+
+  it('does not mutate the input config', () => {
+    const cfg: ContainerConfig = {
+      ...baseConfig(),
+      mcpServers: {
+        v: { type: 'http', url: 'http://127.0.0.1:1940/mcp' },
+      },
+    };
+    const before = JSON.stringify(cfg);
+    rewriteMcpUrlsForContainer(cfg);
+    expect(JSON.stringify(cfg)).toBe(before);
+  });
+
+  it('passes already-tailnet entries through unchanged', () => {
+    const cfg: ContainerConfig = {
+      ...baseConfig(),
+      mcpServers: {
+        v: { type: 'http', url: 'https://parachute.taildf9ce2.ts.net/vault/default/mcp' },
+      },
+    };
+    const out = rewriteMcpUrlsForContainer(cfg);
+    expect((out.mcpServers.v as { url: string }).url).toBe('https://parachute.taildf9ce2.ts.net/vault/default/mcp');
+  });
+
+  it('handles multiple http entries independently', () => {
+    const cfg: ContainerConfig = {
+      ...baseConfig(),
+      mcpServers: {
+        vault: { type: 'http', url: 'http://127.0.0.1:1940/vault/default/mcp' },
+        notes: { type: 'http', url: 'http://localhost:1942/notes/mcp' },
+        public: { type: 'http', url: 'https://api.example.com/mcp' },
+      },
+    };
+    const out = rewriteMcpUrlsForContainer(cfg);
+    expect((out.mcpServers.vault as { url: string }).url).toBe('http://host.docker.internal:1940/vault/default/mcp');
+    expect((out.mcpServers.notes as { url: string }).url).toBe('http://host.docker.internal:1942/notes/mcp');
+    expect((out.mcpServers.public as { url: string }).url).toBe('https://api.example.com/mcp');
+  });
+});

--- a/src/parachute/vault-mcp.ts
+++ b/src/parachute/vault-mcp.ts
@@ -41,6 +41,64 @@ export function buildVaultMcpServer(opts: BuildVaultMcpOpts): HttpMcpServerConfi
   };
 }
 
+/**
+ * Hostnames that point at "this machine" from outside a container, but
+ * inside a container point at the container itself — so an MCP server on
+ * the host is unreachable. Rewrite to `host.docker.internal`, which Docker
+ * Desktop / OrbStack expose natively on macOS+Windows. On Linux, paraclaw
+ * already passes `--add-host=host.docker.internal:host-gateway` to every
+ * `docker run` (`src/container-runtime.ts:hostGatewayArgs`), so the same
+ * hostname resolves there too.
+ *
+ * The point of this rewrite happening at *container-spawn* time (rather
+ * than persisted on disk) is so the on-disk `container.json` keeps the
+ * operator-facing URL — what they typed, what the UI displays. The
+ * container sees a derived copy with loopback addresses translated.
+ *
+ * Non-loopback hostnames (LAN IPs, public domains, tailnet hosts) pass
+ * through unchanged: they're already container-reachable via Docker's
+ * bridge or the host network.
+ */
+const CONTAINER_HOST_NAME = 'host.docker.internal';
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', 'localhost.localdomain']);
+
+export function localhostToContainerHost(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Not a parseable URL — pass through unchanged. Caller will see the
+    // same connection error they would have anyway.
+    return url;
+  }
+  // URL canonicalizes `[::1]` to `[::1]` with brackets; strip for compare.
+  const hostname = parsed.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (LOOPBACK_HOSTNAMES.has(hostname)) {
+    parsed.hostname = CONTAINER_HOST_NAME;
+    return parsed.toString();
+  }
+  return url;
+}
+
+/**
+ * Apply `localhostToContainerHost` to every HTTP MCP entry in a container
+ * config, returning a deep-cloned copy. The input config is left intact —
+ * use this when preparing a per-spawn copy of `container.json` to mount
+ * into a container without modifying what's persisted on disk.
+ */
+export function rewriteMcpUrlsForContainer(config: ContainerConfig): ContainerConfig {
+  // Structured clone is fine here: ContainerConfig is JSON-shaped.
+  const clone = JSON.parse(JSON.stringify(config)) as ContainerConfig;
+  for (const [name, entry] of Object.entries(clone.mcpServers)) {
+    if (entry && typeof entry === 'object' && 'type' in entry && entry.type === 'http' && 'url' in entry) {
+      const httpEntry = entry as HttpMcpServerConfig;
+      httpEntry.url = localhostToContainerHost(httpEntry.url);
+      clone.mcpServers[name] = httpEntry;
+    }
+  }
+  return clone;
+}
+
 export interface AttachVaultOpts {
   /** Group folder name (matches `groups/<folder>`). */
   folder: string;


### PR DESCRIPTION
## Summary

Without this, an MCP server on the host at `127.0.0.1` / `localhost` is unreachable from inside the agent container — loopback resolves to the container itself. Operators get a silent failure: the agent has no vault, no scribe, no anything served locally.

Closes #15.

## What it does

Two pure helpers in `src/parachute/vault-mcp.ts`:

- **`localhostToContainerHost(url)`** — rewrites loopback hostnames (`127.0.0.1`, `localhost`, `0.0.0.0`, `::1`, `localhost.localdomain`) to `host.docker.internal`, preserving scheme + port + path + query. Non-loopback (LAN IPs, public domains, tailnet, already-translated) passes through unchanged.
- **`rewriteMcpUrlsForContainer(config)`** — deep-clones a `ContainerConfig`, applies the URL rewrite to every HTTP-type MCP entry. Stdio entries untouched. Input not mutated.

`container-runner.ts` writes a per-spawn copy to `<sessDir>/.spawn-container.json` and mounts THAT at `/workspace/agent/container.json` instead of the on-disk file. The on-disk `container.json` keeps the operator-facing URL (what the UI displays, what the user typed); the container sees a derived copy that actually works from inside Docker.

## Why at spawn time, not at attach time

Persisting the translated URL on disk would muddle the operator surface — the UI's vault detail page would show `host.docker.internal` instead of the URL the user actually typed. Every `parachute status` view would show the Docker-internal hostname. The translation belongs purely at the container boundary.

## Why host.docker.internal

- macOS + Windows: Docker Desktop / OrbStack expose it natively.
- Linux: paraclaw already passes `--add-host=host.docker.internal:host-gateway` to every `docker run` (`src/container-runtime.ts:hostGatewayArgs`).

So the same hostname resolves on every supported platform.

## Tests

15 new vitest cases:

- 11 cases for `localhostToContainerHost`: every loopback form, scheme preservation, port preservation, query string preservation, public domain pass-through, LAN IP pass-through, malformed URL pass-through, already-translated pass-through.
- 4 cases for `rewriteMcpUrlsForContainer`: stdio entries untouched, input not mutated, tailnet unchanged, multiple http entries handled independently.

276/276 total green. tsc clean.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 276/276 pass
- [ ] Manual: kill any active session, restart paraclaw, DM a bot whose vault attachment uses `127.0.0.1:1940` — agent should now see vault tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)