### PR TITLE
feat(mcp): promote assign-secret stub to live impl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Wire stdio into Claude Code:
 claude mcp add paraclaw bun /absolute/path/to/paraclaw/src/mcp/stdio.ts
 ```
 
-Tools advertise as `mcp__paraclaw__<verb>-<noun>` client-side: `list-agent-groups`, `create-agent-group`, `attach-vault`, `detach-vault`, `list-sessions`, `close-session`, `list-channels`, `update-channel-wire`, `delete-channel-wire`, `list-secrets`, `put-secret`, `delete-secret`, `list-approvals`, `decide-approval`. A handful (`assign-secret`, `start-oauth`, `revoke-integration`, `get-activity`) are advertised but `disabled` until the matching paraclaw-server endpoints land — they're filtered out of `tools/list` and refused on `tools/call`.
+Tools advertise as `mcp__paraclaw__<verb>-<noun>` client-side: `list-agent-groups`, `create-agent-group`, `attach-vault`, `detach-vault`, `list-sessions`, `close-session`, `list-channels`, `update-channel-wire`, `delete-channel-wire`, `list-secrets`, `put-secret`, `delete-secret`, `assign-secret`, `list-approvals`, `decide-approval`. A handful (`start-oauth`, `revoke-integration`, `get-activity`) are advertised but `disabled` until the matching paraclaw-server endpoints land — they're filtered out of `tools/list` and refused on `tools/call`.
 
 Secret values **never** traverse MCP. `list-secrets` and `put-secret` return row metadata only; the plaintext flows in once on `put-secret` and lands in the encrypted DB column. Container injection happens at session-spawn time, not over the tool surface.
 

--- a/src/mcp/tools/secrets.ts
+++ b/src/mcp/tools/secrets.ts
@@ -5,18 +5,16 @@
  * carries the row id + metadata — the value flows in once over the
  * transport, lands in the encrypted DB column, and is read back only by
  * the container-runner at session-spawn time.
- *
- * `assign-secret` is advertised but disabled until paraclaw-server lands
- * the matching `/api/secrets/:id/assignments` endpoints + `secret_assignments`
- * table on this branch. See PENDING_REASON below.
  */
 import {
   type AssignedMode,
   type SecretKind,
   type SecretRow,
   deleteSecret,
+  listAssignments,
   listSecrets,
   putSecret,
+  replaceAssignments,
 } from '../../secrets/index.js';
 import type { ToolDef } from '../types.js';
 
@@ -44,9 +42,6 @@ function toView(r: SecretRow): SecretView {
     updatedAt: r.updated_at,
   };
 }
-
-const ASSIGN_PENDING =
-  'awaiting paraclaw-server: /api/secrets/:id/assignments + secret_assignments table not yet on this branch';
 
 export const secretTools: ToolDef[] = [
   {
@@ -131,9 +126,8 @@ export const secretTools: ToolDef[] = [
   {
     name: 'assign-secret',
     description:
-      "Assign a 'selective' secret to one or more agent groups. STUB — disabled until paraclaw-server's secret_assignments endpoints land on this branch.",
+      "Replace the agent-group assignment list for a 'selective' secret. Empty array revokes everything. Atomic; throws on unknown secret id. Returns the new assignment list.",
     scope: 'claw:admin',
-    disabled: { reason: ASSIGN_PENDING },
     inputSchema: {
       type: 'object',
       properties: {
@@ -141,14 +135,21 @@ export const secretTools: ToolDef[] = [
         agentGroupIds: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Agent group ids to inject the secret into.',
+          description: 'Agent group ids to inject the secret into. Empty array revokes all assignments.',
         },
       },
       required: ['id', 'agentGroupIds'],
       additionalProperties: false,
     },
-    handler: async () => {
-      throw new Error(`assign-secret disabled: ${ASSIGN_PENDING}`);
+    handler: async (args) => {
+      const id = String(args.id ?? '').trim();
+      if (!id) throw new Error('id is required');
+      const groupIds = Array.isArray(args.agentGroupIds) ? args.agentGroupIds : null;
+      if (!groupIds || !groupIds.every((x) => typeof x === 'string')) {
+        throw new Error('agentGroupIds must be a string[]');
+      }
+      replaceAssignments(id, groupIds as string[]);
+      return { secretId: id, agentGroupIds: listAssignments(id) };
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Migration 016 (`secret_assignments`) and the matching `/api/secrets/:id/assignments` HTTP endpoints landed on trunk via prior PRs, so the `assign-secret` MCP tool no longer needs to be `disabled`.
- Wires the handler to `replaceAssignments(id, agentGroupIds[])` from `src/secrets/index.ts` — atomic PUT-style replace, empty array revokes everything, throws on unknown secret id. Returns the post-replace assignment list via `listAssignments(id)`.
- Drops the now-stale `ASSIGN_PENDING` constant and the disabled-tool advertisement.
- CLAUDE.md `## MCP server` section: moves `assign-secret` from the disabled-pending list to the live-tools list. Remaining stubs: `start-oauth`, `revoke-integration`, `get-activity` (the activity stub is the next follow-up).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 308/308 passing (no new tests; the secret-assignments helpers are already covered by `src/secrets/secrets.test.ts` and the route layer)
- [ ] Stdio sanity: `claude mcp list paraclaw` advertises `assign-secret` (no longer filtered out)
- [ ] HTTP: `POST /mcp` `tools/call` with `{ id, agentGroupIds: [] }` revokes; with non-empty array assigns

🤖 Generated with [Claude Code](https://claude.com/claude-code)