### PR TITLE
feat(mcp): wire get-activity to live agent_activity helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Wire stdio into Claude Code:
 claude mcp add paraclaw bun /absolute/path/to/paraclaw/src/mcp/stdio.ts
 ```
 
-Tools advertise as `mcp__paraclaw__<verb>-<noun>` client-side: `list-agent-groups`, `create-agent-group`, `attach-vault`, `detach-vault`, `list-sessions`, `close-session`, `list-channels`, `update-channel-wire`, `delete-channel-wire`, `list-secrets`, `put-secret`, `delete-secret`, `assign-secret`, `list-approvals`, `decide-approval`. A handful (`start-oauth`, `revoke-integration`, `get-activity`) are advertised but `disabled` until the matching paraclaw-server endpoints land — they're filtered out of `tools/list` and refused on `tools/call`.
+Tools advertise as `mcp__paraclaw__<verb>-<noun>` client-side: `list-agent-groups`, `create-agent-group`, `attach-vault`, `detach-vault`, `list-sessions`, `close-session`, `list-channels`, `update-channel-wire`, `delete-channel-wire`, `list-secrets`, `put-secret`, `delete-secret`, `assign-secret`, `list-approvals`, `decide-approval`, `get-activity`. The remaining stubs (`start-oauth`, `revoke-integration`) are advertised but `disabled` until the matching paraclaw-server endpoints land — they're filtered out of `tools/list` and refused on `tools/call`.
 
 Secret values **never** traverse MCP. `list-secrets` and `put-secret` return row metadata only; the plaintext flows in once on `put-secret` and lands in the encrypted DB column. Container injection happens at session-spawn time, not over the tool surface.
 

--- a/src/mcp/tools/activity.ts
+++ b/src/mcp/tools/activity.ts
@@ -1,32 +1,88 @@
 /**
- * Activity-log MCP tool — STUB. The matching paraclaw-server work
- * (`agent_activity` table + the ingest path that populates it from
- * agent-runner tool invocations) hasn't landed on this branch yet. Tool
- * is advertised in the registry for human introspection and filtered
- * out of `tools/list` until then.
+ * Activity-log MCP tool. Mirrors `/api/groups/:folder/activity` and
+ * `/api/sessions/:id/activity` — read-only feed of tool invocations from
+ * the central `agent_activity` table. Same auth scope (`claw:read`) and
+ * the same default/max limits the HTTP route enforces.
+ *
+ * One of `agentGroupId` or `sessionId` is required; if both are given the
+ * session filter wins (it's a strict subset of the group). Targets are
+ * canonical ids — not folders — because the MCP surface is id-keyed
+ * elsewhere (sessions, secrets, approvals).
  */
+import { listActivityByAgentGroup, listActivityBySession } from '../../db/agent-activity.js';
+import { getAgentGroup } from '../../db/agent-groups.js';
+import { getSession } from '../../db/sessions.js';
 import type { ToolDef } from '../types.js';
 
-const PENDING = 'awaiting paraclaw-server: agent_activity table + ingest path not yet on this branch';
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+interface ActivityView {
+  id: string;
+  agentGroupId: string;
+  sessionId: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  createdAt: string;
+}
+
+function toView(r: {
+  id: string;
+  agent_group_id: string;
+  session_id: string;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  created_at: string;
+}): ActivityView {
+  return {
+    id: r.id,
+    agentGroupId: r.agent_group_id,
+    sessionId: r.session_id,
+    kind: r.kind,
+    target: r.target,
+    summary: r.summary,
+    createdAt: r.created_at,
+  };
+}
+
+function clampLimit(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(raw), MAX_LIMIT);
+}
 
 export const activityTools: ToolDef[] = [
   {
     name: 'get-activity',
     description:
-      'Stream recent agent tool-invocations across the install. STUB — disabled until the agent_activity table + ingest land.',
+      'List recent agent tool invocations from agent_activity. Requires either agentGroupId or sessionId; if both, sessionId wins. Optional `since` (ISO 8601) returns only newer rows. Default limit 100, hard-capped at 500.',
     scope: 'claw:read',
-    disabled: { reason: PENDING },
     inputSchema: {
       type: 'object',
       properties: {
-        agentGroupId: { type: 'string', description: 'Optional agent group filter.' },
-        sessionId: { type: 'string', description: 'Optional session filter.' },
-        limit: { type: 'number', description: 'Max rows. Defaults to 100.' },
+        agentGroupId: { type: 'string', description: 'Agent group id (canonical, not folder).' },
+        sessionId: { type: 'string', description: 'Session id. Wins over agentGroupId if both given.' },
+        since: { type: 'string', description: 'Only return rows with created_at > this ISO 8601 timestamp.' },
+        limit: { type: 'number', description: 'Max rows. Defaults to 100, capped at 500.' },
       },
       additionalProperties: false,
     },
-    handler: async () => {
-      throw new Error(`get-activity disabled: ${PENDING}`);
+    handler: async (args) => {
+      const sessionId = typeof args.sessionId === 'string' && args.sessionId.length ? args.sessionId : null;
+      const agentGroupId = typeof args.agentGroupId === 'string' && args.agentGroupId.length ? args.agentGroupId : null;
+      if (!sessionId && !agentGroupId) {
+        throw new Error('one of agentGroupId or sessionId is required');
+      }
+      const since = typeof args.since === 'string' && args.since.length ? args.since : undefined;
+      const limit = clampLimit(args.limit);
+
+      if (sessionId) {
+        if (!getSession(sessionId)) throw new Error(`session not found: ${sessionId}`);
+        return { activity: listActivityBySession(sessionId, { since, limit }).map(toView) };
+      }
+      if (!getAgentGroup(agentGroupId!)) throw new Error(`agent group not found: ${agentGroupId}`);
+      return { activity: listActivityByAgentGroup(agentGroupId!, { since, limit }).map(toView) };
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Migration 017 (`agent_activity`) and the `listActivityByAgentGroup` / `listActivityBySession` helpers landed on trunk via PR #213, with matching read-only HTTP routes (`/api/groups/:folder/activity`, `/api/sessions/:id/activity`). The MCP stub for `get-activity` no longer needs to be `disabled`.
- Handler mirrors the route layer: requires one of `agentGroupId` or `sessionId` (session wins if both are given, since it's a strict subset of the group), validates the id exists with a clear 404-style error, accepts optional `since` (ISO 8601) and `limit`. Default limit 100, hard-capped at 500 to match the route.
- Targets are canonical ids — not folders — to stay consistent with the rest of the MCP surface (sessions, secrets, approvals all id-keyed).
- Output shape camelCases the snake_case row at the boundary (same `toView` pattern the route layer uses).
- CLAUDE.md `## MCP server` section: moves `get-activity` into the live-tools list. Remaining disabled stubs: `start-oauth`, `revoke-integration`. (`assign-secret` promotion is its own PR — #17 — independent of this one; whichever lands second will need a one-line CLAUDE.md textual conflict resolved.)

## Independence note

This PR forks from `night/paraclaw-rebirth` independently of #17. The two CLAUDE.md edits target the same line, so the second-to-merge will conflict on that single line — trivial 30-second resolution to combine both into one live-list entry and one stub-list entry.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 308/308 passing (helpers covered by `src/db/agent-activity.test.ts`; route layer covered by HTTP tests)
- [ ] Stdio sanity: `mcp__paraclaw__get-activity` advertises (no longer filtered out of `tools/list`)
- [ ] Spot-call with `{ agentGroupId, limit: 5 }` returns `{ activity: [...] }`
- [ ] Spot-call with neither id throws "one of agentGroupId or sessionId is required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)