### PR TITLE
cleanup: sessions dir rename + NanoClaw doc-residue sweep (closes #12, #14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Privilege is user-level (owner/admin), not agent-group-level. See [docs/isolatio
 
 ## Two-DB Session Split
 
-Each session has **two** SQLite files under `data/v2-sessions/<session_id>/`:
+Each session has **two** SQLite files under `data/sessions/<agent_group_id>/<session_id>/`:
 
 - `inbound.db` — host writes, container reads. `messages_in`, routing, destinations, pending_questions, processing_ack.
 - `outbound.db` — container writes, host reads. `messages_out`, session_state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 1. **Check for existing work.** Search open PRs and issues before starting:
    ```bash
-   gh pr list --repo qwibitai/nanoclaw --search "<your feature>"
-   gh issue list --repo qwibitai/nanoclaw --search "<your feature>"
+   gh pr list --repo ParachuteComputer/paraclaw --search "<your feature>"
+   gh issue list --repo ParachuteComputer/paraclaw --search "<your feature>"
    ```
    If a related PR or issue exists, build on it rather than duplicating effort.
 
@@ -21,7 +21,7 @@
 
 ## Skills
 
-NanoClaw uses [Claude Code skills](https://code.claude.com/docs/en/skills) — markdown files with optional supporting files that teach Claude how to do something. There are four types of skills in NanoClaw, each serving a different purpose.
+Paraclaw uses [Claude Code skills](https://code.claude.com/docs/en/skills) — markdown files with optional supporting files that teach Claude how to do something. There are four types of skills in Paraclaw, each serving a different purpose.
 
 ### Why skills?
 
@@ -31,7 +31,7 @@ Every user should have clean and minimal code that does exactly what they need. 
 
 #### 1. Feature skills (branch-based)
 
-Add capabilities to NanoClaw by merging a git branch. The SKILL.md contains setup instructions; the actual code lives on a `skill/*` branch.
+Add capabilities to Paraclaw by merging a git branch. The SKILL.md contains setup instructions; the actual code lives on a `skill/*` branch.
 
 **Location:** `.claude/skills/` on `main` (instructions only), code on `skill/*` branch
 
@@ -43,7 +43,7 @@ Add capabilities to NanoClaw by merging a git branch. The SKILL.md contains setu
 3. Claude walks through interactive setup (env vars, bot creation, etc.)
 
 **Contributing a feature skill:**
-1. Fork `qwibitai/nanoclaw` and branch from `main`
+1. Fork `ParachuteComputer/paraclaw` and branch from `main`
 2. Make the code changes (new files, modified source, updated `package.json`, etc.)
 3. Add a SKILL.md in `.claude/skills/<name>/` with setup instructions — step 1 should be merging the branch
 4. Open a PR. We'll create the `skill/<name>` branch from your work
@@ -71,7 +71,7 @@ Workflows and guides with no code changes. The SKILL.md is the entire skill — 
 
 **Location:** `.claude/skills/` on `main`
 
-**Examples:** `/setup`, `/debug`, `/customize`, `/update-nanoclaw`, `/update-skills`
+**Examples:** `/setup`, `/debug`, `/customize`, `/update-skills`
 
 **Guidelines:**
 - Pure instructions — no code files, no branch merges

--- a/docs/APPLE-CONTAINER-NETWORKING.md
+++ b/docs/APPLE-CONTAINER-NETWORKING.md
@@ -51,7 +51,7 @@ sysctl net.inet.ip.forwarding
 # Expected: net.inet.ip.forwarding: 1
 
 # Test container internet access
-container run --rm --entrypoint curl nanoclaw-agent:latest \
+container run --rm --entrypoint curl paraclaw-agent:latest \
   -s4 --connect-timeout 5 -o /dev/null -w "%{http_code}" https://api.anthropic.com
 # Expected: 404
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,7 +23,7 @@ This is the primary security boundary. Rather than relying on application-level 
 
 ### 2. Mount Security
 
-**External Allowlist** - Mount permissions stored at `~/.config/nanoclaw/mount-allowlist.json`, which is:
+**External Allowlist** - Mount permissions stored at `~/.config/paraclaw/mount-allowlist.json`, which is:
 - Outside project root
 - Never mounted into containers
 - Cannot be modified by agents

--- a/docs/agent-runner-details.md
+++ b/docs/agent-runner-details.md
@@ -115,7 +115,7 @@ class ClaudeProvider implements AgentProvider {
         mcpServers: input.mcpServers,  // already the right shape
         additionalDirectories: input.additionalDirectories,
         env: input.env,
-        allowedTools: NANOCLAW_TOOL_ALLOWLIST,
+        allowedTools: TOOL_ALLOWLIST,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
         hooks: {
@@ -712,7 +712,7 @@ These are ephemeral to the container's lifetime. When the container is killed an
 
 The agent-runner receives configuration via:
 
-- **Environment variables:** `AGENT_PROVIDER` (claude/codex/opencode), `NANOCLAW_ADMIN_USER_ID`, provider-specific vars (API keys, model overrides), `TZ`
+- **Environment variables:** `AGENT_PROVIDER` (claude/codex/opencode), provider-specific vars (API keys, model overrides), `TZ`
 - **Fixed mount paths:** Session DB at `/workspace/session.db`. Agent group folder at `/workspace/agent/`. System prompt from `/workspace/agent/CLAUDE.md` and `/workspace/global/CLAUDE.md`.
 - **Optional startup config:** Some config may be passed as a JSON file at a fixed path (e.g., `/workspace/config.json`) for things like the session ID to resume, assistant name, and admin user ID. This avoids overloading environment variables.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ heartbeat file.
 The schema is the contract. Most primitives below correspond to a table
 in the **central** `~/.parachute/claw/paraclaw.db`. The message-bus
 tables — `messages_in`, `messages_out`, `session_state` — live in
-**per-session** files under `data/v2-sessions/<session_id>/`, split into
+**per-session** files under `data/sessions/<agent_group_id>/<session_id>/`, split into
 `inbound.db` and `outbound.db` so each file has exactly one writer
 across the bind mount. The §Schema section explains why; the TypeScript
 types are in `src/db/`.
@@ -300,7 +300,7 @@ lifecycles — containers are not.
 ### How the host and container talk
 
 Through SQLite — but **not** through the central DB. Each session has
-two per-session files under `data/v2-sessions/<session_id>/`:
+two per-session files under `data/sessions/<agent_group_id>/<session_id>/`:
 
 - `inbound.db` — **host writes, container reads.** Mounted into the
   container read-only at `/workspace/.inbound.db`. Holds `messages_in`.
@@ -354,7 +354,7 @@ State splits across two SQLite surfaces, by *who can write to what*:
 - **Central** `~/.parachute/claw/paraclaw.db` — host-only writer. Never
   mounted into a container. Holds every primitive that isn't a live
   message queue.
-- **Per-session** under `data/v2-sessions/<session_id>/` — two files:
+- **Per-session** under `data/sessions/<agent_group_id>/<session_id>/` — two files:
   `inbound.db` (host writes, container reads) and `outbound.db`
   (container writes, host reads). Both run in `journal_mode=DELETE` and
   obey the one-writer-per-file rule. See "How the host and container
@@ -476,7 +476,7 @@ those approvals. Membership-as-access-gate (NanoClaw's
 
 ### Per-session `inbound.db` / `outbound.db`
 
-Two files per session under `data/v2-sessions/<session_id>/`, both
+Two files per session under `data/sessions/<agent_group_id>/<session_id>/`, both
 opened with `journal_mode=DELETE`. No foreign keys to the central DB
 (neither file can reference a row it cannot see) and no cross-file
 references either — `outbound.db.in_reply_to` is an opaque message id

--- a/docs/db-session.md
+++ b/docs/db-session.md
@@ -9,7 +9,7 @@ Schemas live in `src/db/schema.ts` as the `INBOUND_SCHEMA` and `OUTBOUND_SCHEMA`
 ## 1. Session folder layout
 
 ```
-data/v2-sessions/<agent_group_id>/<session_id>/
+data/sessions/<agent_group_id>/<session_id>/
   inbound.db              ← host writes, container reads (read-only mount)
   outbound.db             ← container writes, host reads (read-only open)
   .heartbeat              ← mtime touched by container (not a DB write)

--- a/docs/db.md
+++ b/docs/db.md
@@ -2,7 +2,7 @@
 
 Orientation for the data model: the three databases, how they fit together, and the invariants that hold across them. For table-level schemas, follow the links below.
 
-- **[db-central.md](db-central.md)** — every table in `data/v2.db` (identity, wiring, approvals, Chat SDK state) plus the migration system.
+- **[db-central.md](db-central.md)** — every table in the central DB (identity, wiring, approvals, Chat SDK state) plus the migration system.
 - **[db-session.md](db-session.md)** — the per-session `inbound.db` + `outbound.db` pair, seq parity, and session folder layout.
 
 Related: [architecture.md](architecture.md) for the high-level design; [api-details.md](api-details.md) for inbound/outbound message content shapes; [isolation-model.md](isolation-model.md) for channel-to-agent wiring modes.
@@ -15,9 +15,9 @@ Paraclaw uses **three kinds of SQLite database**, all on the host filesystem:
 
 | DB | Location | Writer | Readers | Purpose |
 |----|----------|--------|---------|---------|
-| **Central** | `data/v2.db` | host | host | Identity, permissions, routing, wiring — the admin plane |
-| **Session inbound** | `data/v2-sessions/<agent_group_id>/<session_id>/inbound.db` | host | host (sync), container (read-only) | Host → container messages + routing projections |
-| **Session outbound** | `data/v2-sessions/<agent_group_id>/<session_id>/outbound.db` | container | host (poll), container | Container → host messages + processing status |
+| **Central** | `~/.parachute/claw/paraclaw.db` | host | host | Identity, permissions, routing, wiring — the admin plane |
+| **Session inbound** | `data/sessions/<agent_group_id>/<session_id>/inbound.db` | host | host (sync), container (read-only) | Host → container messages + routing projections |
+| **Session outbound** | `data/sessions/<agent_group_id>/<session_id>/outbound.db` | container | host (poll), container | Container → host messages + processing status |
 
 **Single-writer rule.** Every SQLite file has exactly one writer. Host writes the central DB and every `inbound.db`; container writes only its own `outbound.db`. This eliminates write contention across the Docker/Apple Container mount boundary — SQLite locking across that boundary is unreliable.
 
@@ -30,9 +30,9 @@ Paraclaw uses **three kinds of SQLite database**, all on the host filesystem:
 ## 2. Database map
 
 ```
+~/.parachute/claw/paraclaw.db             ← CENTRAL (host ↔ host)
 data/
-  v2.db                                   ← CENTRAL (host ↔ host)
-  v2-sessions/
+  sessions/
     <agent_group_id>/
       .claude-shared/                     ← shared Claude state for the agent group
       agent-runner-src/                   ← per-group agent-runner overlay

--- a/docs/docker-sandboxes.md
+++ b/docs/docker-sandboxes.md
@@ -11,7 +11,7 @@ Host (macOS / Windows WSL)
     │   ├── Channel adapters (WhatsApp, Telegram, etc.)
     │   └── Container spawner → nested Docker daemon
     └── Docker-in-Docker
-        └── nanoclaw-agent containers
+        └── paraclaw-agent containers
             └── Claude Agent SDK
 ```
 
@@ -39,16 +39,16 @@ On your host machine:
 
 ```bash
 # Create a workspace directory
-mkdir -p ~/nanoclaw-workspace
+mkdir -p ~/paraclaw-workspace
 
 # Create a shell sandbox with the workspace mounted
-docker sandbox create shell ~/nanoclaw-workspace
+docker sandbox create shell ~/paraclaw-workspace
 ```
 
 If you're using WhatsApp, configure proxy bypass so WhatsApp's Noise protocol isn't MITM-inspected:
 
 ```bash
-docker sandbox network proxy shell-nanoclaw-workspace \
+docker sandbox network proxy shell-paraclaw-workspace \
   --bypass-host web.whatsapp.com \
   --bypass-host "*.whatsapp.com" \
   --bypass-host "*.whatsapp.net"
@@ -58,7 +58,7 @@ Telegram does not need proxy bypass.
 
 Enter the sandbox:
 ```bash
-docker sandbox run shell-nanoclaw-workspace
+docker sandbox run shell-paraclaw-workspace
 ```
 
 ## Step 2: Install Prerequisites
@@ -77,14 +77,14 @@ Paraclaw must live inside the workspace directory — Docker-in-Docker can only 
 ```bash
 # Clone to home first (virtiofs can corrupt git pack files during clone)
 cd ~
-git clone https://github.com/qwibitai/nanoclaw.git
+git clone https://github.com/ParachuteComputer/paraclaw.git
 
 # Replace with YOUR workspace path (the host path you passed to `docker sandbox create`)
-WORKSPACE=/Users/you/nanoclaw-workspace
+WORKSPACE=/Users/you/paraclaw-workspace
 
 # Move into workspace so DinD mounts work
-mv nanoclaw "$WORKSPACE/nanoclaw"
-cd "$WORKSPACE/nanoclaw"
+mv paraclaw "$WORKSPACE/paraclaw"
+cd "$WORKSPACE/paraclaw"
 
 # Install dependencies
 pnpm install
@@ -160,7 +160,7 @@ if (caCertSrc) {
 
 ### 4d. Container runtime — prevent self-termination
 
-In `src/container-runtime.ts`, the `cleanupOrphans()` function matches containers by the `nanoclaw-` prefix. Inside a sandbox, the sandbox container itself may match (e.g., `nanoclaw-docker-sandbox`). Filter out the current hostname:
+In `src/container-runtime.ts`, the `cleanupOrphans()` function matches containers by the `paraclaw-install=<slug>` label. Inside a sandbox, the sandbox container itself may match. Filter out the current hostname:
 
 ```typescript
 // In cleanupOrphans(), filter out os.hostname() from the list of containers to stop
@@ -203,7 +203,7 @@ pnpm run build
 # Configure .env
 cat > .env << EOF
 TELEGRAM_BOT_TOKEN=<your-token-from-botfather>
-ASSISTANT_NAME=nanoclaw
+ASSISTANT_NAME=paraclaw
 ANTHROPIC_API_KEY=proxy-managed
 EOF
 mkdir -p data/env && cp .env data/env/env
@@ -212,10 +212,10 @@ mkdir -p data/env && cp .env data/env/env
 pnpm exec tsx setup/index.ts --step register \
   --jid "tg:<your-chat-id>" \
   --name "My Chat" \
-  --trigger "@nanoclaw" \
+  --trigger "@paraclaw" \
   --folder "telegram_main" \
   --channel telegram \
-  --assistant-name "nanoclaw" \
+  --assistant-name "paraclaw" \
   --is-main \
   --no-trigger-required
 ```
@@ -242,7 +242,7 @@ pnpm run build
 
 # Configure .env
 cat > .env << EOF
-ASSISTANT_NAME=nanoclaw
+ASSISTANT_NAME=paraclaw
 ANTHROPIC_API_KEY=proxy-managed
 EOF
 mkdir -p data/env && cp .env data/env/env
@@ -259,10 +259,10 @@ pnpm exec tsx src/whatsapp-auth.ts --pairing-code --phone <phone-number-no-plus>
 pnpm exec tsx setup/index.ts --step register \
   --jid "<phone>@s.whatsapp.net" \
   --name "My Chat" \
-  --trigger "@nanoclaw" \
+  --trigger "@paraclaw" \
   --folder "whatsapp_main" \
   --channel whatsapp \
-  --assistant-name "nanoclaw" \
+  --assistant-name "paraclaw" \
   --is-main \
   --no-trigger-required
 ```
@@ -316,7 +316,7 @@ npm config set strict-ssl false
 docker build \
   --build-arg http_proxy=$http_proxy \
   --build-arg https_proxy=$https_proxy \
-  -t nanoclaw-agent:latest container/
+  -t paraclaw-agent:latest container/
 ```
 
 ### Agent containers fail with "path not shared"
@@ -347,13 +347,13 @@ docker sandbox network proxy <sandbox-name> \
 ### Git clone fails with "inflate: data stream error"
 Clone to a non-workspace path first, then move:
 ```bash
-cd ~ && git clone https://github.com/qwibitai/nanoclaw.git && mv nanoclaw /path/to/workspace/nanoclaw
+cd ~ && git clone https://github.com/ParachuteComputer/paraclaw.git && mv paraclaw /path/to/workspace/paraclaw
 ```
 
 ### WhatsApp QR code doesn't display
 Run the auth command interactively inside the sandbox (not piped through `docker sandbox exec`):
 ```bash
-docker sandbox run shell-nanoclaw-workspace
+docker sandbox run shell-paraclaw-workspace
 # Then inside:
 pnpm exec tsx src/whatsapp-auth.ts
 ```

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -32,7 +32,7 @@ With this in place, even if the model setting drifts back to a Claude model name
 
 ## Model Selection
 
-The Claude Code CLI reads its model from `~/.claude/settings.json` inside the container, which paraclaw bind-mounts from `data/v2-sessions/<agent-group-id>/.claude-shared/settings.json`. Set `"model": "gemma4:latest"` (or whatever Ollama model you've pulled) there. Use the exact name from `ollama list`.
+The Claude Code CLI reads its model from `~/.claude/settings.json` inside the container, which paraclaw bind-mounts from `data/sessions/<agent-group-id>/.claude-shared/settings.json`. Set `"model": "gemma4:latest"` (or whatever Ollama model you've pulled) there. Use the exact name from `ollama list`.
 
 Model selection considerations for Apple Silicon:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.7",
+  "version": "0.0.14-rc.8",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -226,7 +226,7 @@ function buildMounts(
   initGroupFilesystem(agentGroup);
 
   // Sync skill symlinks based on container.json selection before mounting.
-  const claudeDir = path.join(DATA_DIR, 'v2-sessions', agentGroup.id, '.claude-shared');
+  const claudeDir = path.join(DATA_DIR, 'sessions', agentGroup.id, '.claude-shared');
   syncSkillSymlinks(claudeDir, containerConfig);
 
   // Compose CLAUDE.md fresh every spawn from the shared base, enabled skill

--- a/src/group-init.ts
+++ b/src/group-init.ts
@@ -60,8 +60,8 @@ export function initGroupFilesystem(group: AgentGroup, opts?: { instructions?: s
     initialized.push('container.json');
   }
 
-  // 2. data/v2-sessions/<id>/.claude-shared/ — Claude state + per-group skills
-  const claudeDir = path.join(DATA_DIR, 'v2-sessions', group.id, '.claude-shared');
+  // 2. data/sessions/<id>/.claude-shared/ — Claude state + per-group skills
+  const claudeDir = path.join(DATA_DIR, 'sessions', group.id, '.claude-shared');
   if (!fs.existsSync(claudeDir)) {
     fs.mkdirSync(claudeDir, { recursive: true });
     initialized.push('.claude-shared');

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runti
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
+import { migrateSessionsDir } from './session-manager.js';
 import { startWebServer } from './web/server.js';
 import { log } from './log.js';
 
@@ -69,8 +70,9 @@ async function main(): Promise<void> {
   runMigrations(db);
   log.info('Central DB ready', { path: CENTRAL_DB_PATH });
 
-  // 1b. One-time filesystem cutover — idempotent, no-op after first run.
+  // 1b. One-time filesystem cutovers — idempotent, no-op after first run.
   migrateGroupsToClaudeLocal();
+  migrateSessionsDir();
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();

--- a/src/parachute/group-status.ts
+++ b/src/parachute/group-status.ts
@@ -8,7 +8,7 @@
  * host-process scoped — useless from the web server. Heartbeat file mtime
  * is the only cross-process liveness signal:
  *
- *   data/v2-sessions/<agent_group_id>/<session_id>/.heartbeat
+ *   data/sessions/<agent_group_id>/<session_id>/.heartbeat
  *
  * The container's agent-runner touches this on every poll iteration. The
  * host sweep runs at 60s intervals; we use 90s as the "alive" threshold

--- a/src/providers/provider-container-registry.ts
+++ b/src/providers/provider-container-registry.ts
@@ -23,7 +23,7 @@ export interface VolumeMount {
 }
 
 export interface ProviderContainerContext {
-  /** Per-session host directory: `<DATA_DIR>/v2-sessions/<session_id>`. */
+  /** Per-session host directory: `<DATA_DIR>/sessions/<session_id>`. */
   sessionDir: string;
   /** Agent group ID, for any per-group logic. */
   agentGroupId: string;

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -38,7 +38,29 @@ import type { Session } from './types.js';
 
 /** Root directory for all session data. */
 export function sessionsBaseDir(): string {
+  return path.join(DATA_DIR, 'sessions');
+}
+
+/** Legacy location, pre-rename. Kept only so `migrateSessionsDir` can find it. */
+export function legacySessionsBaseDir(): string {
   return path.join(DATA_DIR, 'v2-sessions');
+}
+
+/**
+ * One-shot rename: `data/v2-sessions/` → `data/sessions/`. Idempotent — noop
+ * if the legacy directory doesn't exist or the new directory already does.
+ *
+ * Called from `src/index.ts` at startup, before any session DB is opened.
+ * Same-filesystem rename is atomic, so partial-migration recovery is not a
+ * concern (unlike the central-DB copy in `migrateCentralDbLocation`).
+ */
+export function migrateSessionsDir(): void {
+  const legacy = legacySessionsBaseDir();
+  const current = sessionsBaseDir();
+  if (fs.existsSync(current)) return;
+  if (!fs.existsSync(legacy)) return;
+  fs.renameSync(legacy, current);
+  log.info('Sessions directory renamed', { from: legacy, to: current });
 }
 
 /** Directory for a specific session: sessions/{agent_group_id}/{session_id}/ */


### PR DESCRIPTION
## What

Bundled mechanical cleanups, two per-issue commits + an rc bump:

- **#12** — rename `data/v2-sessions/` → `data/sessions/` (NanoClaw versioning artifact; paraclaw has no v1).
- **#14** — sweep residual NanoClaw references from non-architecture docs.

Closes #12.
Closes #14.

## #12 — sessions dir rename

- Renames the on-disk path to `data/sessions/` everywhere it's referenced in source: `src/session-manager.ts`, `src/group-init.ts`, `src/container-runner.ts`, plus a couple of doc-comment paths in providers/parachute helpers.
- Adds a one-shot startup migration `migrateSessionsDir()` in `src/session-manager.ts`, wired in `src/index.ts` next to the existing `migrateGroupsToClaudeLocal()` cutover. Idempotent same-filesystem `fs.renameSync` — no-op if `data/sessions/` already exists or `data/v2-sessions/` is absent. Same shape as `migrateCentralDbLocation()` in `src/db/connection.ts`.
- Updates `CLAUDE.md`, `docs/architecture.md`, `docs/db.md`, `docs/db-session.md`, `docs/ollama.md`. The `architecture.md` heritage table at lines 673–687 is intentionally untouched.

## #14 — NanoClaw doc-residue sweep

- `CONTRIBUTING.md` — `qwibitai/nanoclaw` gh URLs → `ParachuteComputer/paraclaw`; "NanoClaw" prose → "Paraclaw"; dropped the now-removed `/update-nanoclaw` skill reference.
- `docs/agent-runner-details.md` — `NANOCLAW_TOOL_ALLOWLIST` → `TOOL_ALLOWLIST` (matches `container/agent-runner/src/providers/claude.ts:45`); dropped stale `NANOCLAW_ADMIN_USER_ID` env var.
- `docs/SECURITY.md` — `~/.config/nanoclaw/` → `~/.config/paraclaw/` (matches `MOUNT_ALLOWLIST_PATH` in `src/config.ts:20`).
- `docs/APPLE-CONTAINER-NETWORKING.md` — `nanoclaw-agent` → `paraclaw-agent` image name.
- `docs/docker-sandboxes.md` — bulk rebrand: workspace paths, sandbox names, repo URLs, image name, env vars (`ASSISTANT_NAME`, `--trigger`, `--assistant-name`).

## Why

Both are pure debt — no behavior change. The directory name was carried over unchanged from the v1→v2 NanoClaw transition; paraclaw is a fresh start with no v1 to coexist with, so the `v2-` prefix is misleading. The doc strings were missed in earlier rebrand passes.

## How it was tested

- `pnpm exec tsc --noEmit` — clean.
- `pnpm test` — 308/308 vitest pass.
- `cd container/agent-runner && bun test` — 59/59 bun:test pass.
- Migration logic mirrors `migrateCentralDbLocation()`; same idempotency proof.

## What's intentionally NOT touched

- `docs/architecture.md` heritage table (lines 673–687) — preserves "inherited vs rewritten" history per the #14 issue scope.
- `docs/BRANCH-FORK-MAINTENANCE.md` — describes the per-channel-fork model that paraclaw replaced with the `channels` branch + `/add-<channel>` skills; mechanical rebrand would leave factually wrong content. Separate delete-or-rewrite call.
- `README_ja.md` / `README_zh.md` — full translations of the old README; need separate rewrite or removal.
- `.claude/skills/*` files — six still reference the old `data/v2-sessions/` path; explicit out-of-scope per review feedback. Separate sweep follow-up.
- `data/v2.db` central DB filename — only #12 (sessions dir) and #14 (NanoClaw branding) were in scope.

## RC bump

`0.0.14-rc.7` → `0.0.14-rc.8` per pre-1.0 RC governance.