### PR TITLE
Move secret_mode from per-secret to recipient agent_group (#9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.9",
+  "version": "0.0.14-rc.10",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -429,11 +429,12 @@ async function buildContainerArgs(
     }
   }
 
-  // Paraclaw secret injection — every secret with assigned_mode='all'
-  // for this agent group (or global) lands as an env var on the container.
-  // Agent-scoped beats global on name collision (handled inside
-  // resolveInjectableSecrets). Plaintext lives in container env only;
-  // never logged here, never written to chat context.
+  // Paraclaw secret injection. Mode is per-recipient agent group
+  // (`agent_groups.secret_mode`): `all` injects every in-scope secret,
+  // `selective` only those with an explicit assignment row. Agent-scoped
+  // beats global on name collision (handled inside resolveInjectableSecrets).
+  // Plaintext lives in container env only; never logged here, never
+  // written to chat context.
   try {
     const secrets = resolveInjectableSecrets(agentGroup.id);
     for (const [name, value] of secrets) {

--- a/src/db/agent-groups.ts
+++ b/src/db/agent-groups.ts
@@ -1,13 +1,24 @@
-import type { AgentGroup } from '../types.js';
+import type { AgentGroup, SecretMode } from '../types.js';
 import { getDb } from './connection.js';
 
-export function createAgentGroup(group: AgentGroup): void {
+export function createAgentGroup(group: Omit<AgentGroup, 'secret_mode'> & { secret_mode?: SecretMode }): void {
   getDb()
     .prepare(
-      `INSERT INTO agent_groups (id, name, folder, agent_provider, created_at)
-       VALUES (@id, @name, @folder, @agent_provider, @created_at)`,
+      `INSERT INTO agent_groups (id, name, folder, agent_provider, secret_mode, created_at)
+       VALUES (@id, @name, @folder, @agent_provider, @secret_mode, @created_at)`,
     )
-    .run(group);
+    .run({ ...group, secret_mode: group.secret_mode ?? 'selective' });
+}
+
+export function getAgentGroupSecretMode(agentGroupId: string): SecretMode | undefined {
+  const row = getDb()
+    .prepare<{ secret_mode: SecretMode }>('SELECT secret_mode FROM agent_groups WHERE id = ?')
+    .get(agentGroupId);
+  return row?.secret_mode;
+}
+
+export function setAgentGroupSecretMode(agentGroupId: string, mode: SecretMode): void {
+  getDb().prepare('UPDATE agent_groups SET secret_mode = @mode WHERE id = @id').run({ id: agentGroupId, mode });
 }
 
 export function getAgentGroup(id: string): AgentGroup | undefined {
@@ -22,7 +33,10 @@ export function getAllAgentGroups(): AgentGroup[] {
   return getDb().prepare('SELECT * FROM agent_groups ORDER BY name').all() as AgentGroup[];
 }
 
-export function updateAgentGroup(id: string, updates: Partial<Pick<AgentGroup, 'name' | 'agent_provider'>>): void {
+export function updateAgentGroup(
+  id: string,
+  updates: Partial<Pick<AgentGroup, 'name' | 'agent_provider' | 'secret_mode'>>,
+): void {
   const fields: string[] = [];
   const values: Record<string, unknown> = { id };
 

--- a/src/db/migrations/023-agent-group-secret-mode.ts
+++ b/src/db/migrations/023-agent-group-secret-mode.ts
@@ -1,0 +1,65 @@
+/**
+ * Move `assigned_mode` from `secrets` (per-secret) to `agent_groups.secret_mode`
+ * (per-group). Mode is a property of the recipient agent group ("how should
+ * this group's secrets get injected?"), not of each individual credential.
+ *
+ * Default for new groups is `selective` — operators must opt a credential in
+ * before it lands in container env. This errs on the side of withholding
+ * (cf. paraclaw#9), unlike the per-secret default of `all` we're replacing.
+ *
+ * Backfill rule: per agent_group, look at every in-scope secret (rows scoped
+ * to that group OR global). If all such secrets shared one mode, adopt it.
+ * If modes were mixed, adopt the most-permissive (`all`) and warn so the
+ * operator notices any previously-selective scoped secret is now injected.
+ * Groups with no in-scope secrets keep the new default (`selective`).
+ */
+import { log } from '../../log.js';
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration023: Migration = {
+  version: 23,
+  name: 'agent-group-secret-mode',
+  up(db: Database) {
+    db.exec(`
+      ALTER TABLE agent_groups
+        ADD COLUMN secret_mode TEXT NOT NULL DEFAULT 'selective';
+    `);
+
+    interface Row {
+      id: string;
+      modes: string | null;
+    }
+    const rows = db
+      .prepare<Row>(
+        `SELECT g.id AS id,
+                GROUP_CONCAT(DISTINCT s.assigned_mode) AS modes
+           FROM agent_groups g
+           LEFT JOIN secrets s
+             ON s.agent_group_id = g.id OR s.agent_group_id IS NULL
+          GROUP BY g.id`,
+      )
+      .all();
+
+    const updateMode = db.prepare(`UPDATE agent_groups SET secret_mode = @mode WHERE id = @id`);
+
+    for (const r of rows) {
+      if (!r.modes) continue;
+      const modes = r.modes.split(',').filter(Boolean);
+      if (modes.length === 0) continue;
+      let chosen: 'all' | 'selective';
+      if (modes.length === 1) {
+        chosen = modes[0] as 'all' | 'selective';
+      } else {
+        chosen = 'all';
+        log.warn('agent_group has mixed-mode secrets — collapsing to all', {
+          agent_group_id: r.id,
+          modes,
+        });
+      }
+      updateMode.run({ id: r.id, mode: chosen });
+    }
+
+    db.exec(`ALTER TABLE secrets DROP COLUMN assigned_mode;`);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -19,6 +19,7 @@ import { migration019 } from './019-oauth-app-connections.js';
 import { migration020 } from './020-agent-app-connections.js';
 import { migration021 } from './021-pending-oauth-states.js';
 import { migration022 } from './022-app-connections-provider.js';
+import { migration023 } from './023-agent-group-secret-mode.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -49,6 +50,7 @@ const migrations: Migration[] = [
   migration020,
   migration021,
   migration022,
+  migration023,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/mcp/tools/secrets.ts
+++ b/src/mcp/tools/secrets.ts
@@ -6,6 +6,7 @@
  * transport, lands in the encrypted DB column, and is read back only by
  * the container-runner at session-spawn time.
  */
+import { getAgentGroupSecretMode, setAgentGroupSecretMode } from '../../db/agent-groups.js';
 import {
   type AssignedMode,
   type SecretKind,
@@ -31,13 +32,19 @@ interface SecretView {
   updatedAt: string;
 }
 
+// Per-secret `assignedMode` derives from the recipient agent group's
+// `secret_mode` (paraclaw#9). Globals report 'all' — a global is in-scope
+// for every group; the group's own mode gates injection.
 function toView(r: SecretRow): SecretView {
+  const assignedMode: AssignedMode = r.agent_group_id
+    ? (getAgentGroupSecretMode(r.agent_group_id) ?? 'selective')
+    : 'all';
   return {
     id: r.id,
     name: r.name,
     kind: r.kind,
     agentGroupId: r.agent_group_id,
-    assignedMode: r.assigned_mode,
+    assignedMode,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -82,7 +89,7 @@ export const secretTools: ToolDef[] = [
           type: 'string',
           enum: ALLOWED_MODES,
           description:
-            '"all" = injected into every group; "selective" = only into groups in secret_assignments. Defaults to "all".',
+            '"all" = the recipient agent group injects every in-scope secret; "selective" = only those with an explicit assignment. Setting this on a scoped secret flips the parent group\'s secret_mode. No-op for globals.',
         },
       },
       required: ['name', 'value'],
@@ -95,11 +102,12 @@ export const secretTools: ToolDef[] = [
       if (!value) throw new Error('value is required');
       const kind = (typeof args.kind === 'string' ? args.kind : 'generic') as SecretKind;
       if (!ALLOWED_KINDS.includes(kind)) throw new Error(`invalid kind: ${kind}`);
-      const mode = (typeof args.assignedMode === 'string' ? args.assignedMode : 'all') as AssignedMode;
-      if (!ALLOWED_MODES.includes(mode)) throw new Error(`invalid assignedMode: ${mode}`);
+      const mode = typeof args.assignedMode === 'string' ? (args.assignedMode as AssignedMode) : undefined;
+      if (mode !== undefined && !ALLOWED_MODES.includes(mode)) throw new Error(`invalid assignedMode: ${mode}`);
       const agentGroupId = typeof args.agentGroupId === 'string' && args.agentGroupId.length ? args.agentGroupId : null;
 
-      const id = putSecret(name, value, { kind, agent_group_id: agentGroupId, assigned_mode: mode });
+      const id = putSecret(name, value, { kind, agent_group_id: agentGroupId });
+      if (mode !== undefined && agentGroupId) setAgentGroupSecretMode(agentGroupId, mode);
       const row = listSecrets(agentGroupId).find((r) => r.id === id);
       if (!row) throw new Error(`secret ${id} disappeared after write`);
       return { secret: toView(row) };

--- a/src/modules/agent-to-agent/create-agent.ts
+++ b/src/modules/agent-to-agent/create-agent.ts
@@ -79,6 +79,7 @@ export async function handleCreateAgent(content: Record<string, unknown>, sessio
     name,
     folder,
     agent_provider: null,
+    secret_mode: 'selective',
     created_at: now,
   };
   createAgentGroup(newGroup);

--- a/src/parachute/create-agent.ts
+++ b/src/parachute/create-agent.ts
@@ -97,6 +97,7 @@ export function createParachuteAgentGroup(opts: CreateAgentGroupOpts): CreateAge
     name: trimmedName,
     folder: opts.folder,
     agent_provider: null,
+    secret_mode: 'selective',
     created_at,
   };
 

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -8,6 +8,10 @@
  *
  * Resolution preference at injection time: agent-scoped secret with that
  * name beats the global one. The host walks both rows and the scoped wins.
+ *
+ * Injection policy lives on the recipient `agent_groups.secret_mode` row
+ * (migration 023): `all` injects every in-scope secret; `selective` injects
+ * only those with an explicit `secret_assignments` row pointing to the group.
  */
 import crypto from 'crypto';
 
@@ -32,7 +36,6 @@ export interface SecretRow {
   name: string;
   kind: SecretKind;
   agent_group_id: string | null;
-  assigned_mode: AssignedMode;
   created_at: string;
   updated_at: string;
 }
@@ -40,7 +43,6 @@ export interface SecretRow {
 export interface PutSecretOpts {
   kind?: SecretKind;
   agent_group_id?: string | null;
-  assigned_mode?: AssignedMode;
 }
 
 interface RawRow extends SecretRow {
@@ -61,7 +63,6 @@ export function putSecret(name: string, value: string, opts: PutSecretOpts = {})
   const ct = encryptSecret(value, key);
   const agentGroupId = opts.agent_group_id ?? null;
   const kind = opts.kind ?? 'generic';
-  const mode = opts.assigned_mode ?? 'all';
 
   const existing = db()
     .prepare<{ id: string }>(`SELECT id FROM secrets WHERE name = @name AND agent_group_id IS @agent_group_id`)
@@ -74,7 +75,6 @@ export function putSecret(name: string, value: string, opts: PutSecretOpts = {})
         `UPDATE secrets
             SET value_encrypted = @value_encrypted,
                 kind            = @kind,
-                assigned_mode   = @assigned_mode,
                 updated_at      = @updated_at
           WHERE id = @id`,
       )
@@ -82,7 +82,6 @@ export function putSecret(name: string, value: string, opts: PutSecretOpts = {})
         id: existing.id,
         value_encrypted: ct,
         kind,
-        assigned_mode: mode,
         updated_at: now,
       });
     return existing.id;
@@ -92,9 +91,9 @@ export function putSecret(name: string, value: string, opts: PutSecretOpts = {})
   db()
     .prepare(
       `INSERT INTO secrets
-         (id, name, value_encrypted, kind, agent_group_id, assigned_mode, created_at, updated_at)
+         (id, name, value_encrypted, kind, agent_group_id, created_at, updated_at)
        VALUES
-         (@id, @name, @value_encrypted, @kind, @agent_group_id, @assigned_mode, @created_at, @updated_at)`,
+         (@id, @name, @value_encrypted, @kind, @agent_group_id, @created_at, @updated_at)`,
     )
     .run({
       id,
@@ -102,7 +101,6 @@ export function putSecret(name: string, value: string, opts: PutSecretOpts = {})
       value_encrypted: ct,
       kind,
       agent_group_id: agentGroupId,
-      assigned_mode: mode,
       created_at: now,
       updated_at: now,
     });
@@ -132,7 +130,7 @@ export function listSecrets(agentGroupId?: string | null): SecretRow[] {
   if (agentGroupId === undefined) {
     return db()
       .prepare<SecretRow>(
-        `SELECT id, name, kind, agent_group_id, assigned_mode, created_at, updated_at
+        `SELECT id, name, kind, agent_group_id, created_at, updated_at
          FROM secrets ORDER BY name`,
       )
       .all();
@@ -140,14 +138,14 @@ export function listSecrets(agentGroupId?: string | null): SecretRow[] {
   if (agentGroupId === null) {
     return db()
       .prepare<SecretRow>(
-        `SELECT id, name, kind, agent_group_id, assigned_mode, created_at, updated_at
+        `SELECT id, name, kind, agent_group_id, created_at, updated_at
          FROM secrets WHERE agent_group_id IS NULL ORDER BY name`,
       )
       .all();
   }
   return db()
     .prepare<SecretRow>(
-      `SELECT id, name, kind, agent_group_id, assigned_mode, created_at, updated_at
+      `SELECT id, name, kind, agent_group_id, created_at, updated_at
        FROM secrets
        WHERE agent_group_id = @agent_group_id OR agent_group_id IS NULL
        ORDER BY name`,
@@ -165,13 +163,16 @@ export function deleteSecret(id: string): boolean {
  * agent group. Returns plaintext values; callers are expected to inject as
  * env vars and never log. Agent-scoped wins over global on name collision.
  *
- * Mode semantics:
- *   - `all`       — inject if scope matches (scoped row → its own group;
- *                   global row → every group). Default behaviour.
- *   - `selective` — inject only when an explicit `secret_assignments` row
- *                   names this agent group. Lets operators stage a credential
- *                   in the store before any agent gets it (and revoke per-
- *                   agent without rotating the value).
+ * Mode lives on the recipient `agent_groups.secret_mode`:
+ *   - `all`       — inject every in-scope secret (scoped + globals).
+ *   - `selective` — inject only those with an explicit assignment row
+ *                   pointing to this group. Lets operators stage credentials
+ *                   in the store before any agent gets them and revoke per
+ *                   agent without rotating the value.
+ *
+ * Unknown agent_group_id is treated as `selective` (the safe default) — the
+ * group-level row is the source of truth, so a missing row means we err on
+ * the side of withholding.
  */
 export function resolveInjectableSecrets(agentGroupId: string): Map<string, string> {
   const key = secretsKey();
@@ -182,8 +183,10 @@ export function resolveInjectableSecrets(agentGroupId: string): Map<string, stri
          LEFT JOIN secret_assignments a
            ON a.secret_id = s.id
           AND a.agent_group_id = @agent_group_id
+         LEFT JOIN agent_groups g
+           ON g.id = @agent_group_id
         WHERE (s.agent_group_id = @agent_group_id OR s.agent_group_id IS NULL)
-          AND (s.assigned_mode = 'all' OR a.secret_id IS NOT NULL)
+          AND (g.secret_mode = 'all' OR a.secret_id IS NOT NULL)
         ORDER BY s.agent_group_id IS NULL`,
     )
     .all({ agent_group_id: agentGroupId });

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { SecretMode } from '../types.js';
 import { closeDb, initTestDb, runMigrations } from '../db/index.js';
 import { _setMasterKeyForTest } from './master-key.js';
 import {
@@ -25,11 +26,11 @@ afterEach(() => {
   closeDb();
 });
 
-function seedAgentGroup(db: ReturnType<typeof initTestDb>, id: string) {
+function seedAgentGroup(db: ReturnType<typeof initTestDb>, id: string, mode: SecretMode = 'selective') {
   db.prepare(
-    `INSERT INTO agent_groups (id, folder, name, created_at)
-     VALUES (?, ?, ?, datetime('now'))`,
-  ).run(id, id, id);
+    `INSERT INTO agent_groups (id, folder, name, secret_mode, created_at)
+     VALUES (?, ?, ?, ?, datetime('now'))`,
+  ).run(id, id, id, mode);
 }
 
 describe('secrets store', () => {
@@ -88,11 +89,11 @@ describe('secrets store', () => {
     expect(deleteSecret(id)).toBe(false);
   });
 
-  it('resolveInjectableSecrets unions global + scoped, scoped wins', () => {
+  it('resolveInjectableSecrets in mode=all unions global + scoped, scoped wins', () => {
     const db = initTestDb();
     runMigrations(db);
     _setMasterKeyForTest(crypto.randomBytes(32));
-    seedAgentGroup(db, 'g1');
+    seedAgentGroup(db, 'g1', 'all');
 
     putSecret('G', 'global-only');
     putSecret('S', 'scoped-only', { agent_group_id: 'g1' });
@@ -105,30 +106,34 @@ describe('secrets store', () => {
     expect(env.get('B')).toBe('scoped-B');
   });
 
-  it('skips assigned_mode=selective rows from resolveInjectableSecrets', () => {
+  it('mode=selective injects nothing without explicit assignments', () => {
     const db = initTestDb();
     runMigrations(db);
     _setMasterKeyForTest(crypto.randomBytes(32));
-    seedAgentGroup(db, 'g1');
+    seedAgentGroup(db, 'g1', 'selective');
 
-    putSecret('OPT_IN', 'value', { assigned_mode: 'selective' });
-    putSecret('AUTO', 'value', { assigned_mode: 'all' });
+    putSecret('GLOBAL', 'value');
+    putSecret('SCOPED', 'value', { agent_group_id: 'g1' });
 
     const env = resolveInjectableSecrets('g1');
-    expect(env.has('OPT_IN')).toBe(false);
-    expect(env.has('AUTO')).toBe(true);
+    expect(env.size).toBe(0);
+  });
+
+  it('unknown agent_group_id resolves as no-secrets (selective default)', () => {
+    putSecret('GLOBAL', 'v');
+    expect(resolveInjectableSecrets('does-not-exist').size).toBe(0);
   });
 });
 
 describe('secret assignments (selective mode)', () => {
-  it('round-trips: selective secret with assignment to A injects into A, not B', () => {
+  it('round-trips: assignment to A injects into A, not B', () => {
     const db = initTestDb();
     runMigrations(db);
     _setMasterKeyForTest(crypto.randomBytes(32));
-    seedAgentGroup(db, 'A');
-    seedAgentGroup(db, 'B');
+    seedAgentGroup(db, 'A', 'selective');
+    seedAgentGroup(db, 'B', 'selective');
 
-    const secretId = putSecret('SHARED_KEY', 'top-secret', { assigned_mode: 'selective' });
+    const secretId = putSecret('SHARED_KEY', 'top-secret');
     addAssignment(secretId, 'A');
 
     expect(resolveInjectableSecrets('A').get('SHARED_KEY')).toBe('top-secret');
@@ -143,7 +148,7 @@ describe('secret assignments (selective mode)', () => {
     seedAgentGroup(db, 'B');
     seedAgentGroup(db, 'C');
 
-    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    const id = putSecret('K', 'v');
     expect(listAssignments(id)).toEqual([]);
 
     replaceAssignments(id, ['A', 'B']);
@@ -175,7 +180,7 @@ describe('secret assignments (selective mode)', () => {
     _setMasterKeyForTest(crypto.randomBytes(32));
     seedAgentGroup(db, 'A');
 
-    const id = putSecret('K', 'v', { assigned_mode: 'selective' });
+    const id = putSecret('K', 'v');
     addAssignment(id, 'A');
     expect(listAssignments(id)).toEqual(['A']);
 
@@ -185,17 +190,17 @@ describe('secret assignments (selective mode)', () => {
     expect(remaining?.n).toBe(0);
   });
 
-  it('selective + assignment lets agent-scoped secrets coexist via name', () => {
+  it('selective group + assignment + scoped secret in mode=all peer group', () => {
     const db = initTestDb();
     runMigrations(db);
     _setMasterKeyForTest(crypto.randomBytes(32));
-    seedAgentGroup(db, 'A');
-    seedAgentGroup(db, 'B');
+    seedAgentGroup(db, 'A', 'selective');
+    seedAgentGroup(db, 'B', 'all');
 
-    // Global selective with assignment to A only.
-    const globalId = putSecret('TOKEN', 'shared-via-allowlist', { assigned_mode: 'selective' });
+    // Global with explicit assignment to A only — A sees it via assignment,
+    // B sees its own scoped row instead (scoped wins on name collision).
+    const globalId = putSecret('TOKEN', 'shared-via-allowlist');
     addAssignment(globalId, 'A');
-    // Scoped-to-B (mode: all) — different value, only B sees it.
     putSecret('TOKEN', 'b-only', { agent_group_id: 'B' });
 
     expect(resolveInjectableSecrets('A').get('TOKEN')).toBe('shared-via-allowlist');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,19 @@
 // ── Central DB entities ──
 
+export type SecretMode = 'all' | 'selective';
+
 export interface AgentGroup {
   id: string;
   name: string;
   folder: string;
   agent_provider: string | null;
+  /**
+   * Per-group injection policy for secrets in this group's scope (its own
+   * scoped secrets + globals): `all` injects every in-scope secret;
+   * `selective` injects only those with an explicit `secret_assignments`
+   * row pointing to this group. Defaults to `selective` (migration 023).
+   */
+  secret_mode: SecretMode;
   created_at: string;
 }
 

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -9,6 +9,7 @@
  */
 import http from 'node:http';
 
+import { getAgentGroupSecretMode, setAgentGroupSecretMode } from '../../db/agent-groups.js';
 import {
   type AssignedMode,
   type SecretKind,
@@ -38,13 +39,23 @@ interface SecretView {
   updatedAt: string;
 }
 
+/**
+ * Per-secret `assignedMode` is now derived from the recipient agent group's
+ * `secret_mode` (paraclaw#9 — modes moved off the per-secret row). For a
+ * scoped secret we read its containing group; globals report `'all'` because
+ * a global is unconditionally in-scope and the recipient group's mode gates
+ * actual injection. Field stays in the response shape for UI continuity.
+ */
 function toView(r: SecretRow): SecretView {
+  const assignedMode: AssignedMode = r.agent_group_id
+    ? (getAgentGroupSecretMode(r.agent_group_id) ?? 'selective')
+    : 'all';
   return {
     id: r.id,
     name: r.name,
     kind: r.kind,
     agentGroupId: r.agent_group_id,
-    assignedMode: r.assigned_mode,
+    assignedMode,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
   };
@@ -58,6 +69,12 @@ interface PutBody {
   // input — saves a coordinated migration, costs one or-fallback line.
   agent_group_id?: string | null;
   agentGroupId?: string | null;
+  /**
+   * Accepted on POST for backward-compatibility with the existing UI/MCP
+   * callers that still send it. Now applies to the recipient agent_group
+   * (paraclaw#9): scoped secret + assigned_mode='all' flips the parent
+   * group's secret_mode to 'all'. No-op for globals (no parent group).
+   */
   assigned_mode?: string;
 }
 
@@ -121,8 +138,8 @@ export async function handleSecretsRoute(ctx: SecretsRouteContext): Promise<bool
       error(res, 400, `invalid kind: ${kind}`);
       return true;
     }
-    const mode = (body.assigned_mode ?? 'all') as AssignedMode;
-    if (!ALLOWED_MODES.includes(mode)) {
+    const mode = body.assigned_mode === undefined ? undefined : (body.assigned_mode as AssignedMode);
+    if (mode !== undefined && !ALLOWED_MODES.includes(mode)) {
       error(res, 400, `invalid assigned_mode: ${mode}`);
       return true;
     }
@@ -131,8 +148,10 @@ export async function handleSecretsRoute(ctx: SecretsRouteContext): Promise<bool
     const id = putSecret(name, body.value, {
       kind,
       agent_group_id: agentGroupId,
-      assigned_mode: mode,
     });
+    if (mode !== undefined && agentGroupId) {
+      setAgentGroupSecretMode(agentGroupId, mode);
+    }
     // Re-read so the response carries the canonical timestamps the upsert
     // wrote (rather than guessing). Same scope filter — listSecrets returns
     // both global + scoped rows when scope is the agent id, so we narrow


### PR DESCRIPTION
## Summary

Moves the secret-injection mode flag from `secrets.assigned_mode` (per-secret) to `agent_groups.secret_mode` (per-recipient-group). Same semantics, but policy lives in one place — when a group injects, every in-scope secret follows the group's mode.

Closes #9.

## Changes

- **Migration 023** — adds `agent_groups.secret_mode TEXT NOT NULL DEFAULT 'selective'`, backfills from each group's in-scope `secrets.assigned_mode` rows (scoped + globals), collapses mixed modes to `'all'` with a warning log, drops `secrets.assigned_mode`.
- **`resolveInjectableSecrets`** — joins `agent_groups` and gates on `g.secret_mode = 'all' OR a.secret_id IS NOT NULL`. Unknown agent_group_id resolves to no secrets (group row is the source of truth; safe default).
- **`/api/secrets` + MCP `list-secrets` / `put-secret`** — keep the `assignedMode` field in the response shape. Sourced from the scoped secret's parent group; reports `'all'` for globals (a global is unconditionally in-scope; the recipient group's mode gates it). POST still accepts `assignedMode` / `assigned_mode` and flips the parent group's `secret_mode` when the secret is scoped.
- **`createAgentGroup`** picks up a `secret_mode` argument (defaults to `'selective'`); two existing constructor sites updated.
- **Tests** — `seedAgentGroup` helper now takes the group's mode; per-test seeding picks `'all'` vs `'selective'` based on what the assertion needs. New cases for "selective + no assignments injects nothing" and "unknown agent_group_id resolves as no-secrets".

## Per-issue commits

1. `feat(db): migration 023 — agent_groups.secret_mode (refs #9)`
2. `refactor(secrets): source mode from agent_group (refs #9)`
3. `test(secrets): rewrite for per-group mode + bump rc.10 (refs #9)`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 318/318 pass
- [x] `cd container/agent-runner && bun test` — 59/59 pass (re-run after one flaky "unable to open database file" startup error)
- [x] Migration verified by host vitest stack (the `Migration applied name=agent-group-secret-mode` line shows in the test logs)
- [ ] Reviewer eyes-on