### PR TITLE
Test nits: paraclaw#34 + paraclaw#35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.12",
+  "version": "0.0.14-rc.13",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/migrations/023-agent-group-secret-mode.test.ts
+++ b/src/db/migrations/023-agent-group-secret-mode.test.ts
@@ -3,32 +3,21 @@
  * secrets or a single mode per group, so the interesting paths — mixed-mode
  * collapse and group-level fan-out — only get exercised with fixtures.
  *
- * Strategy: pre-record `agent-group-secret-mode` in `schema_version` so
- * `runMigrations()` skips it, build the pre-023 DB shape (no `secret_mode`
- * column on `agent_groups`, `assigned_mode` still present on `secrets`),
- * seed fixtures, then call `migration023.up(db)` directly and assert.
+ * Strategy: skip 023 (and 025, which assumes the column 023 adds) via the
+ * `applyMigrationsExcept` helper, build the pre-023 DB shape (no
+ * `secret_mode` column on `agent_groups`, `assigned_mode` still present on
+ * `secrets`), seed fixtures, then call `migration023.up(db)` directly and
+ * assert. 024 doesn't depend on either, so it runs cleanly between the gaps.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { closeDb, getDb, initTestDb, runMigrations } from '../index.js';
+import { closeDb, getDb } from '../index.js';
 import { migration023 } from './023-agent-group-secret-mode.js';
+import { migration025 } from './025-secret-mode-check.js';
+import { applyMigrationsExcept } from './_test-helpers.js';
 
 function applyAllExcept023(): void {
-  const db = initTestDb();
-  // Mark 023 as already-applied so runMigrations skips it. Also skip 025
-  // (the secret_mode CHECK constraint) since it assumes the column exists.
-  // 024 doesn't depend on either, so it runs cleanly between the gaps.
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS schema_version (
-      version INTEGER PRIMARY KEY,
-      name    TEXT NOT NULL,
-      applied TEXT NOT NULL
-    );
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_version_name ON schema_version(name);
-    INSERT INTO schema_version (version, name, applied) VALUES (9999, 'agent-group-secret-mode', '2026-01-01');
-    INSERT INTO schema_version (version, name, applied) VALUES (9998, 'secret-mode-check', '2026-01-01');
-  `);
-  runMigrations(db);
+  applyMigrationsExcept([migration023, migration025]);
 }
 
 function seedAgentGroup(id: string): void {

--- a/src/db/migrations/025-secret-mode-check.test.ts
+++ b/src/db/migrations/025-secret-mode-check.test.ts
@@ -1,11 +1,14 @@
 /**
  * Migration 025 (paraclaw#28): CHECK constraint on agent_groups.secret_mode.
- * Verify it (a) preserves existing rows and (b) rejects out-of-range writes
- * that previously would have been silently accepted.
+ * Verify it (a) preserves existing rows across the table recreate-and-rename
+ * and (b) rejects out-of-range writes that previously would have been
+ * silently accepted.
  */
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { closeDb, getDb, initTestDb, runMigrations } from '../index.js';
+import { closeDb, initTestDb, runMigrations } from '../index.js';
+import { migration025 } from './025-secret-mode-check.js';
+import { applyMigrationsExcept } from './_test-helpers.js';
 
 afterEach(() => {
   closeDb();
@@ -13,12 +16,22 @@ afterEach(() => {
 
 describe('migration 025 — secret_mode CHECK constraint', () => {
   it('preserves rows already in agent_groups across the table recreate', () => {
-    const db = initTestDb();
-    runMigrations(db);
+    // Apply everything up through 024, leaving 025 unrun. Insert a row
+    // with the pre-025 shape (no CHECK constraint). Then run 025 directly
+    // and confirm the row survives the DROP-and-RENAME dance.
+    //
+    // The migration runner wraps each migration in a transaction so
+    // `PRAGMA defer_foreign_keys = TRUE` defers FK checks until commit;
+    // we replicate that wrapping here, otherwise the DROP TABLE
+    // agent_groups would trip the FKs on sessions/secrets/etc.
+    const db = applyMigrationsExcept([migration025]);
     db.prepare(
       `INSERT INTO agent_groups (id, name, folder, agent_provider, secret_mode, created_at)
        VALUES (?, ?, ?, NULL, 'all', datetime('now'))`,
     ).run('keepme', 'keepme', 'keepme');
+
+    db.transaction(() => migration025.up(db))();
+
     const row = db.prepare(`SELECT * FROM agent_groups WHERE id = ?`).get('keepme') as {
       secret_mode: string;
     };

--- a/src/db/migrations/_test-helpers.ts
+++ b/src/db/migrations/_test-helpers.ts
@@ -1,0 +1,41 @@
+/**
+ * Helpers for migration tests. Lives next to migrations so the import path
+ * stays one directory deep, and the underscore prefix signals "not a real
+ * migration" — the barrel index doesn't import it.
+ */
+import { initTestDb, runMigrations } from '../index.js';
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+/**
+ * Build a fresh in-memory test DB and run every migration in the barrel
+ * EXCEPT the ones listed.
+ *
+ * Implementation: pre-record each skip migration's `name` in
+ * `schema_version` so `runMigrations()` treats it as already-applied
+ * (skip detection is keyed on `name`, not `version`). The `version`
+ * column is auto-assigned via `MAX+1` at insert time, so reusing each
+ * skipped migration's own version here is collision-free — the unique
+ * index on `name` blocks any duplicate-skip first.
+ *
+ * Replaces the older sentinel-version trick (e.g. inserting at version
+ * 9998/9999) which encoded the migration name as a magic string and
+ * silently rotted if the migration was renamed.
+ */
+export function applyMigrationsExcept(skip: Migration[]): Database {
+  const db = initTestDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY,
+      name    TEXT NOT NULL,
+      applied TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_version_name ON schema_version(name);
+  `);
+  const stmt = db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)');
+  for (const m of skip) {
+    stmt.run(m.version, m.name, '2026-01-01');
+  }
+  runMigrations(db);
+  return db;
+}


### PR DESCRIPTION
## Summary
Two test-only nits filed during the #33 review. Both touch migration test fixtures; no production code changes.

- **paraclaw#34** — `src/db/migrations/025-secret-mode-check.test.ts`: the 'preserves rows' test inserted the row AFTER `runMigrations()` completed, so it proved the post-recreate table was writable, not that the DROP-and-RENAME dance preserved existing rows. Rewritten with the schema-version skip pattern: apply migrations through 024 only, INSERT a row into the pre-025 shape, then call `migration025.up(db)` directly inside a transaction so `PRAGMA defer_foreign_keys = TRUE` defers the FK checks the way the migration runner would.

- **paraclaw#35** — `src/db/migrations/023-agent-group-secret-mode.test.ts`: the 9998/9999 sentinel-version inserts in `applyAllExcept023` encoded migration names as hardcoded strings and silently rotted on rename. Extracted a shared `applyMigrationsExcept(skip: Migration[])` helper at `src/db/migrations/_test-helpers.ts` that takes Migration objects directly. Skip detection is keyed on `name` (the UNIQUE INDEX), so reusing each migration's own `version` here is collision-free — the unique-index blocks any duplicate first.

The new helper is now used by both 023 and 025 tests.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 332/332 pass (host vitest)
- [x] `cd container/agent-runner && bun test` — 59/59 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)