### PR TITLE
Phase 1 backend: vault management endpoints (paraclaw#38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.13",
+  "version": "0.0.14-rc.14",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/parachute/vault-mcp.test.ts
+++ b/src/parachute/vault-mcp.test.ts
@@ -6,10 +6,14 @@
  * reachable from inside the Docker container, where loopback would
  * otherwise resolve to the container itself.
  */
-import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { GROUPS_DIR } from '../config.js';
 import type { ContainerConfig } from '../container-config.js';
-import { localhostToContainerHost, rewriteMcpUrlsForContainer } from './vault-mcp.js';
+import { listVaultAttachments, localhostToContainerHost, rewriteMcpUrlsForContainer } from './vault-mcp.js';
 
 describe('localhostToContainerHost', () => {
   it('rewrites 127.0.0.1 → host.docker.internal, preserving port + path + scheme', () => {
@@ -147,5 +151,101 @@ describe('rewriteMcpUrlsForContainer', () => {
     expect((out.mcpServers.vault as { url: string }).url).toBe('http://host.docker.internal:1940/vault/default/mcp');
     expect((out.mcpServers.notes as { url: string }).url).toBe('http://host.docker.internal:1942/notes/mcp');
     expect((out.mcpServers.public as { url: string }).url).toBe('https://api.example.com/mcp');
+  });
+});
+
+describe('listVaultAttachments', () => {
+  const created: string[] = [];
+
+  function makeGroup(folder: string, parachuteJson: object | null): string {
+    const dir = path.join(GROUPS_DIR, folder);
+    fs.mkdirSync(dir, { recursive: true });
+    if (parachuteJson !== null) {
+      fs.writeFileSync(path.join(dir, 'parachute.json'), JSON.stringify(parachuteJson, null, 2));
+    }
+    created.push(dir);
+    return folder;
+  }
+
+  afterEach(() => {
+    while (created.length > 0) {
+      const dir = created.pop()!;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns one entry per (folder, mcpName) for folders with attachments', () => {
+    const a = makeGroup(`vmtest-a-${Date.now()}`, {
+      vault: {
+        'parachute-vault': {
+          vaultBaseUrl: 'https://h/vault/work',
+          scope: 'vault:read',
+          tokenLabel: 'claw-a',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    });
+    const b = makeGroup(`vmtest-b-${Date.now()}`, {
+      vault: {
+        'parachute-vault': {
+          vaultBaseUrl: 'https://h/vault/personal',
+          scope: 'vault:write',
+          tokenLabel: 'claw-b',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    });
+    const entries = listVaultAttachments([a, b]);
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.folder === a)?.attachment.tokenLabel).toBe('claw-a');
+    expect(entries.find((e) => e.folder === b)?.attachment.tokenLabel).toBe('claw-b');
+  });
+
+  it('skips folders without parachute.json (forgiveness for unattached groups)', () => {
+    const a = makeGroup(`vmtest-noattach-${Date.now()}`, null);
+    const b = makeGroup(`vmtest-attach-${Date.now()}`, {
+      vault: {
+        'parachute-vault': {
+          vaultBaseUrl: 'https://h/vault/work',
+          scope: 'vault:read',
+          tokenLabel: 'claw-x',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    });
+    const entries = listVaultAttachments([a, b]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.folder).toBe(b);
+  });
+
+  it('silently skips malformed parachute.json — never throws', () => {
+    const folder = `vmtest-bad-${Date.now()}`;
+    const dir = path.join(GROUPS_DIR, folder);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'parachute.json'), 'not json {{{');
+    created.push(dir);
+    expect(listVaultAttachments([folder])).toEqual([]);
+  });
+
+  it('returns one entry per mcpName when a folder has multiple attachments', () => {
+    const folder = makeGroup(`vmtest-multi-${Date.now()}`, {
+      vault: {
+        'parachute-vault': {
+          vaultBaseUrl: 'https://h/vault/work',
+          scope: 'vault:read',
+          tokenLabel: 'claw-work',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+        'parachute-vault-personal': {
+          vaultBaseUrl: 'https://h/vault/personal',
+          scope: 'vault:write',
+          tokenLabel: 'claw-personal',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    });
+    const entries = listVaultAttachments([folder]);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.mcpName).sort()).toEqual(['parachute-vault', 'parachute-vault-personal']);
   });
 });

--- a/src/parachute/vault-mcp.ts
+++ b/src/parachute/vault-mcp.ts
@@ -163,6 +163,41 @@ export function readVaultAttachment(folder: string, mcpName = DEFAULT_VAULT_MCP_
 }
 
 /**
+ * Read every vault attachment record across the given folders. Used by the
+ * `/claw/vaults` UI to compute "this token is attached to these groups" by
+ * matching `tokenLabel` against the vault's listed tokens.
+ *
+ * Returns one entry per (folder, mcpName) — a single group can have multiple
+ * attachments under different MCP names, though in practice we only use
+ * `parachute-vault`. Folders without a parachute.json or with malformed JSON
+ * are silently skipped (same forgiveness as `readVaultAttachment`).
+ */
+export interface VaultAttachmentEntry {
+  folder: string;
+  mcpName: string;
+  attachment: VaultAttachment;
+}
+
+export function listVaultAttachments(folders: string[]): VaultAttachmentEntry[] {
+  const out: VaultAttachmentEntry[] = [];
+  for (const folder of folders) {
+    const p = parachuteJsonPath(folder);
+    if (!fs.existsSync(p)) continue;
+    let raw: { vault?: Record<string, VaultAttachment> };
+    try {
+      raw = JSON.parse(fs.readFileSync(p, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (!raw.vault) continue;
+    for (const [mcpName, attachment] of Object.entries(raw.vault)) {
+      out.push({ folder, mcpName, attachment });
+    }
+  }
+  return out;
+}
+
+/**
  * Detach a vault from an agent group. Removes the MCP entry from
  * `container.json` and the attach record from `parachute.json`. Does NOT
  * revoke the vault token — caller is responsible for `parachute vault

--- a/src/web/routes/vaults.test.ts
+++ b/src/web/routes/vaults.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Route-level tests for `/api/vaults*`. The proxy primitives are exercised
+ * in `src/web/vault-proxy.test.ts`; this file covers the dispatcher in
+ * `routes/vaults.ts` — URL pattern matching, the attached-to-group merge
+ * by tokenLabel, vault-not-found 404s, and refresh-cache invalidation.
+ *
+ * Strategy: stub global `fetch` for the HTTP calls (vault REST + hub
+ * well-known), and `vi.mock` the DB/attachment readers so the test
+ * doesn't need a real central DB or filesystem groups dir.
+ */
+import http from 'node:http';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearHubDiscoveryCache } from '../hub-discovery.js';
+
+vi.mock('../../db/connection.js', () => ({
+  openDb: () => ({
+    prepare: () => ({ all: () => [{ folder: 'group-a' }, { folder: 'group-b' }] }),
+    close: () => {},
+  }),
+}));
+
+vi.mock('../../parachute/vault-mcp.js', () => ({
+  listVaultAttachments: vi.fn(() => []),
+}));
+
+import { listVaultAttachments } from '../../parachute/vault-mcp.js';
+import { handleVaultsRoute } from './vaults.js';
+
+const mockedListVaultAttachments = listVaultAttachments as unknown as ReturnType<typeof vi.fn>;
+
+let prevHub: string | undefined;
+
+beforeEach(() => {
+  prevHub = process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACLAW_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.example';
+  clearHubDiscoveryCache();
+  mockedListVaultAttachments.mockReset();
+  mockedListVaultAttachments.mockReturnValue([]);
+});
+
+afterEach(() => {
+  if (prevHub === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHub;
+  clearHubDiscoveryCache();
+  vi.unstubAllGlobals();
+});
+
+interface FakeResponse {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  res: http.ServerResponse;
+}
+
+function fakeRes(): FakeResponse {
+  const captured: FakeResponse = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res: undefined as any,
+  };
+  const res = {
+    writeHead(status: number, headers: Record<string, string>) {
+      captured.statusCode = status;
+      captured.headers = headers;
+    },
+    end(chunk: string) {
+      try {
+        captured.body = chunk ? JSON.parse(chunk) : undefined;
+      } catch {
+        captured.body = chunk;
+      }
+    },
+  } as unknown as http.ServerResponse;
+  captured.res = res;
+  return captured;
+}
+
+function fakeReq(body?: unknown): http.IncomingMessage {
+  if (body === undefined) {
+    return Object.assign(Object.create(null), {
+      [Symbol.asyncIterator]: async function* () {},
+    }) as http.IncomingMessage;
+  }
+  const buf = Buffer.from(JSON.stringify(body));
+  return Object.assign(Object.create(null), {
+    [Symbol.asyncIterator]: async function* () {
+      yield buf;
+    },
+  }) as http.IncomingMessage;
+}
+
+function jsonOk(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** Each call returns a fresh Response — Response bodies are single-use. */
+function alwaysOk(body: unknown, status = 200) {
+  return vi.fn().mockImplementation(async () => jsonOk(body, status));
+}
+
+const HUB_VAULTS_BODY = {
+  vaults: [
+    { name: 'work', url: 'https://h/vault/work', version: '0.4.7' },
+    { name: 'personal', url: 'https://h/vault/personal', version: '0.4.7' },
+  ],
+};
+
+describe('handleVaultsRoute', () => {
+  it('GET /api/vaults returns the hub well-known list', async () => {
+    vi.stubGlobal('fetch', alwaysOk(HUB_VAULTS_BODY));
+    const cap = fakeRes();
+    const handled = await handleVaultsRoute({
+      pathname: '/api/vaults',
+      method: 'GET',
+      url: new URL('https://x/api/vaults'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(200);
+    expect(cap.body).toEqual({ vaults: HUB_VAULTS_BODY.vaults });
+  });
+
+  it('POST /api/vaults/refresh clears the cache so the next call refetches', async () => {
+    const stub = alwaysOk(HUB_VAULTS_BODY);
+    vi.stubGlobal('fetch', stub);
+    // Prime the cache via GET.
+    await handleVaultsRoute({
+      pathname: '/api/vaults',
+      method: 'GET',
+      url: new URL('https://x/api/vaults'),
+      req: fakeReq(),
+      res: fakeRes().res,
+      authHeader: 'Bearer x',
+    });
+    expect(stub).toHaveBeenCalledTimes(1);
+    // Same call — cache hit, no extra fetch.
+    await handleVaultsRoute({
+      pathname: '/api/vaults',
+      method: 'GET',
+      url: new URL('https://x/api/vaults'),
+      req: fakeReq(),
+      res: fakeRes().res,
+      authHeader: 'Bearer x',
+    });
+    expect(stub).toHaveBeenCalledTimes(1);
+    // Refresh forces a refetch.
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/refresh',
+      method: 'POST',
+      url: new URL('https://x/api/vaults/refresh'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(200);
+    expect(stub).toHaveBeenCalledTimes(2);
+  });
+
+  it('GET /api/vaults/:name returns 404 when the vault is unknown', async () => {
+    vi.stubGlobal('fetch', alwaysOk(HUB_VAULTS_BODY));
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/ghost',
+      method: 'GET',
+      url: new URL('https://x/api/vaults/ghost'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(404);
+    expect(cap.body).toMatchObject({ error: expect.stringContaining('ghost') });
+  });
+
+  it('GET /api/vaults/:name surfaces attached groups via listVaultAttachments', async () => {
+    vi.stubGlobal('fetch', alwaysOk(HUB_VAULTS_BODY));
+    mockedListVaultAttachments.mockReturnValue([
+      {
+        folder: 'group-a',
+        mcpName: 'parachute-vault',
+        attachment: {
+          vaultBaseUrl: 'https://h/vault/work',
+          scope: 'vault:read',
+          tokenLabel: 'claw-a',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+      {
+        folder: 'group-b',
+        mcpName: 'parachute-vault',
+        attachment: {
+          // Different vault — must not appear in the response.
+          vaultBaseUrl: 'https://h/vault/personal',
+          scope: 'vault:write',
+          tokenLabel: 'claw-b',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    ]);
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work',
+      method: 'GET',
+      url: new URL('https://x/api/vaults/work'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(200);
+    const body = cap.body as { vault: unknown; attachedGroups: Array<{ folder: string }> };
+    expect(body.vault).toMatchObject({ name: 'work' });
+    expect(body.attachedGroups).toHaveLength(1);
+    expect(body.attachedGroups[0]).toMatchObject({ folder: 'group-a', tokenLabel: 'claw-a' });
+  });
+
+  it('GET /api/vaults/:name/tokens enriches each token with attachedTo by tokenLabel', async () => {
+    const fetchStub = vi
+      .fn()
+      // 1st call: hub well-known (resolveVaultBaseUrl)
+      .mockResolvedValueOnce(jsonOk(HUB_VAULTS_BODY))
+      // 2nd call: vault GET /tokens
+      .mockResolvedValueOnce(
+        jsonOk({
+          tokens: [
+            { id: 't_1', label: 'claw-work', scopes: ['vault:read'] },
+            { id: 't_2', label: 'orphan-token', scopes: ['vault:read'] },
+          ],
+        }),
+      );
+    vi.stubGlobal('fetch', fetchStub);
+    mockedListVaultAttachments.mockReturnValue([
+      {
+        folder: 'group-a',
+        mcpName: 'parachute-vault',
+        attachment: {
+          vaultBaseUrl: 'https://h/vault/work',
+          scope: 'vault:read',
+          tokenLabel: 'claw-work',
+          attachedAt: '2026-04-29T00:00:00Z',
+        },
+      },
+    ]);
+
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work/tokens',
+      method: 'GET',
+      url: new URL('https://x/api/vaults/work/tokens'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer the-jwt',
+    });
+    expect(cap.statusCode).toBe(200);
+    const body = cap.body as { tokens: Array<{ id: string; attachedTo: Array<{ folder: string }> }> };
+    const claw = body.tokens.find((t) => t.id === 't_1');
+    const orphan = body.tokens.find((t) => t.id === 't_2');
+    expect(claw?.attachedTo).toEqual([{ folder: 'group-a', scope: 'vault:read' }]);
+    expect(orphan?.attachedTo).toEqual([]);
+    // Vault was hit with the operator's JWT verbatim.
+    expect(fetchStub).toHaveBeenLastCalledWith(
+      'https://h/vault/work/tokens',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer the-jwt' }),
+      }),
+    );
+  });
+
+  it('GET /api/vaults/:name/tokens mirrors a vault 401 verbatim (consent prompt path)', async () => {
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk(HUB_VAULTS_BODY))
+      .mockResolvedValueOnce(jsonOk({ error: 'missing vault:work:admin' }, 401));
+    vi.stubGlobal('fetch', fetchStub);
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work/tokens',
+      method: 'GET',
+      url: new URL('https://x/api/vaults/work/tokens'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(401);
+    expect(cap.body).toMatchObject({ error: 'missing vault:work:admin' });
+  });
+
+  it('POST /api/vaults/:name/tokens forwards body and mirrors the vault 201', async () => {
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk(HUB_VAULTS_BODY))
+      .mockResolvedValueOnce(jsonOk({ id: 't_new', token: 'pvt_new', label: 'fresh' }, 201));
+    vi.stubGlobal('fetch', fetchStub);
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work/tokens',
+      method: 'POST',
+      url: new URL('https://x/api/vaults/work/tokens'),
+      req: fakeReq({ label: 'fresh', scopes: ['vault:read'] }),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(201);
+    expect(cap.body).toMatchObject({ id: 't_new' });
+    const [, init] = fetchStub.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      label: 'fresh',
+      scopes: ['vault:read'],
+    });
+  });
+
+  it('POST /api/vaults/:name/tokens returns 400 on invalid JSON body', async () => {
+    vi.stubGlobal('fetch', alwaysOk(HUB_VAULTS_BODY));
+    const badReq = Object.assign(Object.create(null), {
+      [Symbol.asyncIterator]: async function* () {
+        yield Buffer.from('{not-json');
+      },
+    }) as http.IncomingMessage;
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work/tokens',
+      method: 'POST',
+      url: new URL('https://x/api/vaults/work/tokens'),
+      req: badReq,
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(400);
+  });
+
+  it('DELETE /api/vaults/:name/tokens/:id forwards and mirrors the vault 200', async () => {
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(jsonOk(HUB_VAULTS_BODY))
+      .mockResolvedValueOnce(jsonOk({ ok: true }));
+    vi.stubGlobal('fetch', fetchStub);
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/work/tokens/t_abc123',
+      method: 'DELETE',
+      url: new URL('https://x/api/vaults/work/tokens/t_abc123'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(200);
+    expect(fetchStub).toHaveBeenLastCalledWith(
+      'https://h/vault/work/tokens/t_abc123',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('returns 404 for token routes when vault name is unknown', async () => {
+    vi.stubGlobal('fetch', alwaysOk(HUB_VAULTS_BODY));
+    const cap = fakeRes();
+    await handleVaultsRoute({
+      pathname: '/api/vaults/ghost/tokens',
+      method: 'GET',
+      url: new URL('https://x/api/vaults/ghost/tokens'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(cap.statusCode).toBe(404);
+  });
+
+  it('returns false for an unmatched path so the dispatcher falls through', async () => {
+    const cap = fakeRes();
+    const handled = await handleVaultsRoute({
+      pathname: '/api/something-else',
+      method: 'GET',
+      url: new URL('https://x/api/something-else'),
+      req: fakeReq(),
+      res: cap.res,
+      authHeader: 'Bearer x',
+    });
+    expect(handled).toBe(false);
+  });
+});

--- a/src/web/routes/vaults.ts
+++ b/src/web/routes/vaults.ts
@@ -1,0 +1,225 @@
+/**
+ * /api/vaults — vault management surface for `/claw/vaults`.
+ *
+ * Five endpoints, plus a list endpoint that lived inline in `server.ts`
+ * before this module landed. All admin operations forward the operator's
+ * hub-issued session JWT to the vault unmodified — see
+ * `docs/design/2026-04-29-vault-management-ui.md` § Admin auth model and
+ * `src/web/vault-proxy.ts` for the rationale.
+ *
+ * Scope at the paraclaw boundary is checked by `server.ts` via
+ * `pickVaultScope()` before dispatch reaches this handler. The vault
+ * validates `vault:<name>:admin` independently — paraclaw doesn't downgrade
+ * or re-issue. A 401/403 from the vault is mirrored verbatim so the
+ * browser can trigger an OAuth consent flow for the missing narrow scope.
+ */
+import http from 'node:http';
+
+import { CENTRAL_DB_PATH } from '../../config.js';
+import { openDb } from '../../db/connection.js';
+import { listVaultAttachments } from '../../parachute/vault-mcp.js';
+import { clearHubDiscoveryCache, fetchHubVaults, type VaultListing } from '../hub-discovery.js';
+import { forwardToVault, resolveVaultBaseUrl } from '../vault-proxy.js';
+
+interface VaultTokenRecord {
+  id: string;
+  label: string;
+  scopes?: string[];
+  permission?: string;
+  expires_at?: string | null;
+  created_at?: string;
+  last_used_at?: string | null;
+}
+
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+
+const error = (res: http.ServerResponse, status: number, message: string): void =>
+  json(res, status, { error: message });
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return {} as T;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+function listGroupFolders(): string[] {
+  const db = openDb(CENTRAL_DB_PATH, { readonly: true });
+  try {
+    return db
+      .prepare<{ folder: string }>('SELECT folder FROM agent_groups')
+      .all()
+      .map((r) => r.folder);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Build the "attached to" map for a vault: which agent groups currently
+ * have a parachute.json record pointing at this vault, keyed by tokenLabel
+ * for cheap merge into the tokens listing.
+ *
+ * Match by `vaultBaseUrl` (canonical, hub-published form, trailing slashes
+ * already trimmed at write time in `attachVaultToGroup`). Tokens without a
+ * matching group are still surfaced — they show as orphans in the UI.
+ */
+function buildAttachedByLabel(vaultBaseUrl: string): Map<string, { folder: string; scope: string }[]> {
+  const target = vaultBaseUrl.replace(/\/+$/, '');
+  const folders = listGroupFolders();
+  const entries = listVaultAttachments(folders);
+  const byLabel = new Map<string, { folder: string; scope: string }[]>();
+  for (const e of entries) {
+    if (e.attachment.vaultBaseUrl.replace(/\/+$/, '') !== target) continue;
+    const list = byLabel.get(e.attachment.tokenLabel) ?? [];
+    list.push({ folder: e.folder, scope: e.attachment.scope });
+    byLabel.set(e.attachment.tokenLabel, list);
+  }
+  return byLabel;
+}
+
+export interface VaultsRouteContext {
+  pathname: string;
+  method: string;
+  url: URL;
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  /** Operator's full `Authorization` header value, forwarded to vault. */
+  authHeader: string;
+}
+
+export async function handleVaultsRoute(ctx: VaultsRouteContext): Promise<boolean> {
+  const { pathname, method, req, res, authHeader } = ctx;
+
+  if (pathname === '/api/vaults' && method === 'GET') {
+    try {
+      const vaults = await fetchHubVaults();
+      json(res, 200, { vaults });
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+    }
+    return true;
+  }
+
+  if (pathname === '/api/vaults/refresh' && method === 'POST') {
+    clearHubDiscoveryCache();
+    try {
+      const vaults = await fetchHubVaults();
+      json(res, 200, { vaults });
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+    }
+    return true;
+  }
+
+  // Token-id-bound routes — match before the parent /tokens path so the
+  // more-specific match wins.
+  const tokenById = pathname.match(/^\/api\/vaults\/([^/]+)\/tokens\/([^/]+)$/);
+  if (tokenById && method === 'DELETE') {
+    const name = decodeURIComponent(tokenById[1]);
+    const id = decodeURIComponent(tokenById[2]);
+    const baseUrl = await resolveVaultBaseUrl(name);
+    if (!baseUrl) {
+      error(res, 404, `vault not found: ${name}`);
+      return true;
+    }
+    const result = await forwardToVault({
+      method: 'DELETE',
+      vaultBaseUrl: baseUrl,
+      subpath: `/tokens/${encodeURIComponent(id)}`,
+      authHeader,
+    });
+    json(res, result.status, result.body);
+    return true;
+  }
+
+  const tokensList = pathname.match(/^\/api\/vaults\/([^/]+)\/tokens$/);
+  if (tokensList) {
+    const name = decodeURIComponent(tokensList[1]);
+    const baseUrl = await resolveVaultBaseUrl(name);
+    if (!baseUrl) {
+      error(res, 404, `vault not found: ${name}`);
+      return true;
+    }
+    if (method === 'GET') {
+      const result = await forwardToVault({
+        method: 'GET',
+        vaultBaseUrl: baseUrl,
+        subpath: '/tokens',
+        authHeader,
+      });
+      if (result.status >= 400) {
+        json(res, result.status, result.body);
+        return true;
+      }
+      // Merge attached-to-group derivation by tokenLabel. Vault returns
+      // `{tokens: [{id, label, ...}]}`; we add `attachedTo: [{folder, scope}]`
+      // to each row so the UI doesn't need a separate fetch.
+      const tokens = (result.body as { tokens?: VaultTokenRecord[] }).tokens ?? [];
+      const byLabel = buildAttachedByLabel(baseUrl);
+      const enriched = tokens.map((t) => ({
+        ...t,
+        attachedTo: byLabel.get(t.label) ?? [],
+      }));
+      json(res, 200, { tokens: enriched });
+      return true;
+    }
+    if (method === 'POST') {
+      let body: { label?: string; scopes?: unknown; expires_at?: string | null };
+      try {
+        body = await readJsonBody(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      const result = await forwardToVault({
+        method: 'POST',
+        vaultBaseUrl: baseUrl,
+        subpath: '/tokens',
+        authHeader,
+        body,
+      });
+      json(res, result.status, result.body);
+      return true;
+    }
+    error(res, 405, `method not allowed: ${method} ${pathname}`);
+    return true;
+  }
+
+  const detail = pathname.match(/^\/api\/vaults\/([^/]+)$/);
+  if (detail && method === 'GET') {
+    const name = decodeURIComponent(detail[1]);
+    let vaults: VaultListing[];
+    try {
+      vaults = await fetchHubVaults();
+    } catch (err) {
+      error(res, 502, err instanceof Error ? err.message : String(err));
+      return true;
+    }
+    const hit = vaults.find((v) => v.name === name);
+    if (!hit) {
+      error(res, 404, `vault not found: ${name}`);
+      return true;
+    }
+    const folders = listGroupFolders();
+    const entries = listVaultAttachments(folders).filter(
+      (e) => e.attachment.vaultBaseUrl.replace(/\/+$/, '') === hit.url.replace(/\/+$/, ''),
+    );
+    json(res, 200, {
+      vault: hit,
+      attachedGroups: entries.map((e) => ({
+        folder: e.folder,
+        mcpName: e.mcpName,
+        scope: e.attachment.scope,
+        tokenLabel: e.attachment.tokenLabel,
+        attachedAt: e.attachment.attachedAt,
+      })),
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -22,7 +22,6 @@
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 
 import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR } from '../config.js';
 import { openDb, type Database } from '../db/connection.js';
@@ -52,7 +51,6 @@ import {
   type AuthResult,
   type ClawScope,
 } from './auth.js';
-import { fetchHubVaults } from './hub-discovery.js';
 import { handleMcpHttp } from '../mcp/http.js';
 import { handleAppsRoute } from './routes/apps.js';
 import { handleApprovalsRoute } from './routes/approvals.js';
@@ -62,6 +60,8 @@ import { handleOauthProvidersRoute } from './routes/oauth-providers.js';
 import { handleSecretsRoute } from './routes/secrets.js';
 import { handleSessionsRoute } from './routes/sessions.js';
 import { handleSetupStatusRoute } from './routes/setup-status.js';
+import { handleVaultsRoute } from './routes/vaults.js';
+import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
 import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 import { wireDmToAgent } from './wire-channel.js';
@@ -134,39 +134,6 @@ function getAgentGroup(folder: string): AgentGroupView | null {
   } finally {
     db.close();
   }
-}
-
-/**
- * Shell out to `parachute vault tokens create`. Captures stdout, parses the
- * `pvt_…` line. Used by the attach flow so the user never types/pastes a
- * raw token through the UI.
- */
-function mintVaultToken(opts: { scope: VaultScope; label: string }): Promise<{ token: string; label: string }> {
-  return new Promise((resolve, reject) => {
-    const args = ['vault', 'tokens', 'create', '--scope', opts.scope, '--label', opts.label];
-    const proc = spawn('parachute', args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (chunk) => {
-      stdout += chunk.toString();
-    });
-    proc.stderr.on('data', (chunk) => {
-      stderr += chunk.toString();
-    });
-    proc.on('error', (err) => reject(err));
-    proc.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(`parachute vault tokens create exited ${code}: ${stderr.trim() || stdout.trim()}`));
-        return;
-      }
-      const m = stdout.match(/Token:\s+(pvt_[A-Za-z0-9_-]+)/);
-      if (!m) {
-        reject(new Error(`could not parse pvt_… from CLI output:\n${stdout}`));
-        return;
-      }
-      resolve({ token: m[1], label: opts.label });
-    });
-  });
 }
 
 const json = (res: http.ServerResponse, status: number, body: unknown): void => {
@@ -354,15 +321,27 @@ async function handleApi(
     return;
   }
 
-  if (pathname === '/api/vaults' && method === 'GET') {
-    if (!(await gate(req, res, SCOPE_CLAW_READ))) return;
+  if (pathname === '/api/vaults' || pathname.startsWith('/api/vaults/')) {
+    // /tokens and /tokens/:id forward to the vault — admin-gated. Refresh
+    // and detail views are claw:read. Refer to § API surface in
+    // docs/design/2026-04-29-vault-management-ui.md for the full table.
+    const isTokenPath = /\/tokens(\/[^/]+)?$/.test(pathname);
+    const required: ClawScope = isTokenPath ? SCOPE_CLAW_ADMIN : SCOPE_CLAW_READ;
+    if (!(await gate(req, res, required))) return;
     try {
-      const vaults = await fetchHubVaults();
-      json(res, 200, { vaults });
+      const handled = await handleVaultsRoute({
+        pathname,
+        method,
+        url,
+        req,
+        res,
+        authHeader: req.headers.authorization ?? '',
+      });
+      if (handled) return;
     } catch (err) {
-      error(res, 502, err instanceof Error ? err.message : String(err));
+      error(res, 500, err instanceof Error ? err.message : String(err));
+      return;
     }
-    return;
   }
 
   if (pathname === '/api/groups' && method === 'POST') {
@@ -406,15 +385,36 @@ async function handleApi(
           return;
         }
         const tokenLabel = body.vault.tokenLabel ?? `claw-${folder}`;
+        const vaultBaseUrl = body.vault.vaultBaseUrl ?? 'http://127.0.0.1:1940/vault/default';
         let token = body.vault.token;
         if (!token) {
-          const minted = await mintVaultToken({ scope, label: tokenLabel });
-          token = minted.token;
+          // Implicit mint: forward operator's JWT to the vault. The shell-out
+          // path that used to live here (`mintVaultToken`) is gone — see
+          // docs/design/2026-04-29-vault-management-ui.md § Admin auth model.
+          const minted = await mintVaultTokenHttp({
+            vaultBaseUrl,
+            authHeader: req.headers.authorization ?? '',
+            label: tokenLabel,
+            scopes: [scope],
+          });
+          if (minted.status >= 400) {
+            const msg =
+              (minted.body as { error?: string; message?: string }).message ??
+              (minted.body as { error?: string }).error ??
+              `vault returned ${minted.status}`;
+            error(res, minted.status, `vault token mint failed: ${msg}`);
+            return;
+          }
+          token = (minted.body as { token?: string }).token;
+          if (!token) {
+            error(res, 502, 'vault mint response missing token');
+            return;
+          }
           mintedVaultToken = true;
         }
         vaultArg = {
           scope,
-          vaultBaseUrl: body.vault.vaultBaseUrl,
+          vaultBaseUrl,
           tokenLabel,
           token,
           mcpName: body.vault.mcpName,
@@ -494,8 +494,25 @@ async function handleApi(
 
         let token = body.token;
         if (!token) {
-          const minted = await mintVaultToken({ scope, label: tokenLabel });
-          token = minted.token;
+          const minted = await mintVaultTokenHttp({
+            vaultBaseUrl,
+            authHeader: req.headers.authorization ?? '',
+            label: tokenLabel,
+            scopes: [scope],
+          });
+          if (minted.status >= 400) {
+            const msg =
+              (minted.body as { error?: string; message?: string }).message ??
+              (minted.body as { error?: string }).error ??
+              `vault returned ${minted.status}`;
+            error(res, minted.status, `vault token mint failed: ${msg}`);
+            return;
+          }
+          token = (minted.body as { token?: string }).token;
+          if (!token) {
+            error(res, 502, 'vault mint response missing token');
+            return;
+          }
         }
 
         attachVaultToGroup({
@@ -561,10 +578,65 @@ async function handleApi(
 
     if (sub === '/detach-vault' && method === 'POST') {
       try {
-        const body = await readJsonBody<{ mcpName?: string }>(req);
-        detachVaultFromGroup(folder, body.mcpName ?? DEFAULT_VAULT_MCP_NAME);
+        const body = await readJsonBody<{ mcpName?: string; revokeToken?: boolean }>(req);
+        const mcpName = body.mcpName ?? DEFAULT_VAULT_MCP_NAME;
+
+        // Optional revoke-on-detach: forward operator's JWT to vault. Read
+        // the attachment record before detaching so we still have its
+        // tokenLabel/vaultBaseUrl. We do NOT cross-resolve the vault name
+        // from the hub's well-known — the attachment carries the canonical
+        // base URL already, so we forward directly.
+        let revokedTokenId: string | null = null;
+        let revokeError: string | null = null;
+        if (body.revokeToken) {
+          const attachment = readVaultAttachment(folder, mcpName);
+          if (!attachment) {
+            error(res, 409, `cannot revoke: no vault attachment found for group ${folder}`);
+            return;
+          }
+          // Look up the token id by label — vault revoke is by id, not label.
+          const list = await forwardToVault({
+            method: 'GET',
+            vaultBaseUrl: attachment.vaultBaseUrl,
+            subpath: '/tokens',
+            authHeader: req.headers.authorization ?? '',
+          });
+          if (list.status >= 400) {
+            const msg =
+              (list.body as { error?: string; message?: string }).message ??
+              (list.body as { error?: string }).error ??
+              `vault returned ${list.status}`;
+            error(res, list.status, `vault token list failed: ${msg}`);
+            return;
+          }
+          const tokens = (list.body as { tokens?: { id: string; label: string }[] }).tokens ?? [];
+          const match = tokens.find((t) => t.label === attachment.tokenLabel);
+          if (!match) {
+            // Label has no matching token — already revoked or never minted.
+            // Continue with detach but report the discrepancy in the response.
+            revokeError = `no vault token matched label ${attachment.tokenLabel}`;
+          } else {
+            const del = await forwardToVault({
+              method: 'DELETE',
+              vaultBaseUrl: attachment.vaultBaseUrl,
+              subpath: `/tokens/${encodeURIComponent(match.id)}`,
+              authHeader: req.headers.authorization ?? '',
+            });
+            if (del.status >= 400) {
+              const msg =
+                (del.body as { error?: string; message?: string }).message ??
+                (del.body as { error?: string }).error ??
+                `vault returned ${del.status}`;
+              error(res, del.status, `vault revoke failed: ${msg}`);
+              return;
+            }
+            revokedTokenId = match.id;
+          }
+        }
+
+        detachVaultFromGroup(folder, mcpName);
         const updated = getAgentGroup(folder);
-        json(res, 200, { group: updated });
+        json(res, 200, { group: updated, revokedTokenId, revokeError });
       } catch (err) {
         error(res, 500, err instanceof Error ? err.message : String(err));
       }

--- a/src/web/vault-proxy.test.ts
+++ b/src/web/vault-proxy.test.ts
@@ -93,9 +93,7 @@ describe('forwardToVault', () => {
   });
 
   it('mirrors a 401 from the vault — caller surfaces it for consent prompt', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(jsonResponse(401, { error: 'missing vault:work:admin' }));
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(401, { error: 'missing vault:work:admin' }));
     const result = await forwardToVault({
       method: 'GET',
       vaultBaseUrl: 'https://h/vault/work',
@@ -121,9 +119,7 @@ describe('forwardToVault', () => {
   });
 
   it('handles a non-JSON body without throwing', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(new Response('<!DOCTYPE html>504 from edge', { status: 504 }));
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('<!DOCTYPE html>504 from edge', { status: 504 }));
     const result = await forwardToVault({
       method: 'GET',
       vaultBaseUrl: 'https://h/vault/work',

--- a/src/web/vault-proxy.test.ts
+++ b/src/web/vault-proxy.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Coverage for the JWT-forwarding helper that paraclaw uses to call vault
+ * REST endpoints with the operator's hub-issued session JWT
+ * (`docs/design/2026-04-29-vault-management-ui.md` § Admin auth model).
+ *
+ * The contract under test: pass through the Authorization header verbatim,
+ * surface vault status codes verbatim (401/403 must reach the browser so it
+ * can trigger an OAuth consent flow), parse JSON bodies, and turn network
+ * failures into a 502 — never a thrown exception, because the route handler
+ * mirrors `result.status` to the browser unmodified.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearHubDiscoveryCache } from './hub-discovery.js';
+import { forwardToVault, mintVaultTokenHttp, resolveVaultBaseUrl } from './vault-proxy.js';
+
+let prevHub: string | undefined;
+
+beforeEach(() => {
+  prevHub = process.env.PARACHUTE_HUB_ORIGIN;
+  delete process.env.PARACLAW_HUB_ORIGIN;
+  process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.example';
+  clearHubDiscoveryCache();
+});
+
+afterEach(() => {
+  if (prevHub === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = prevHub;
+  clearHubDiscoveryCache();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  const text = body === undefined ? '' : JSON.stringify(body);
+  return new Response(text, { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('forwardToVault', () => {
+  it('GETs the right URL with the operator JWT', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { tokens: [] }));
+    const result = await forwardToVault({
+      method: 'GET',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens',
+      authHeader: 'Bearer the-jwt',
+      fetchImpl,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ tokens: [] });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://h/vault/work/tokens',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer the-jwt',
+          Accept: 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('POSTs JSON body with content-type header', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(201, { id: 't_abc', token: 'pvt_x' }));
+    await forwardToVault({
+      method: 'POST',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens',
+      authHeader: 'Bearer x',
+      body: { label: 'test', scopes: ['vault:read'] },
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://h/vault/work/tokens',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ label: 'test', scopes: ['vault:read'] }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
+  it('strips a trailing slash off vaultBaseUrl so subpath joins cleanly', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    await forwardToVault({
+      method: 'GET',
+      vaultBaseUrl: 'https://h/vault/work/',
+      subpath: '/tokens',
+      authHeader: 'Bearer x',
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith('https://h/vault/work/tokens', expect.anything());
+  });
+
+  it('mirrors a 401 from the vault — caller surfaces it for consent prompt', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(401, { error: 'missing vault:work:admin' }));
+    const result = await forwardToVault({
+      method: 'GET',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens',
+      authHeader: 'Bearer x',
+      fetchImpl,
+    });
+    expect(result.status).toBe(401);
+    expect(result.body).toEqual({ error: 'missing vault:work:admin' });
+  });
+
+  it('returns a 502 with structured body when fetch throws', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await forwardToVault({
+      method: 'GET',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens',
+      authHeader: 'Bearer x',
+      fetchImpl,
+    });
+    expect(result.status).toBe(502);
+    expect(result.body).toMatchObject({ error: expect.stringContaining('ECONNREFUSED') });
+  });
+
+  it('handles a non-JSON body without throwing', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response('<!DOCTYPE html>504 from edge', { status: 504 }));
+    const result = await forwardToVault({
+      method: 'GET',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens',
+      authHeader: 'Bearer x',
+      fetchImpl,
+    });
+    expect(result.status).toBe(504);
+    expect(result.body).toMatchObject({ error: expect.stringContaining('non-JSON') });
+  });
+
+  it('handles an empty body by returning null', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    const result = await forwardToVault({
+      method: 'DELETE',
+      vaultBaseUrl: 'https://h/vault/work',
+      subpath: '/tokens/t_abc',
+      authHeader: 'Bearer x',
+      fetchImpl,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toBeNull();
+  });
+});
+
+describe('resolveVaultBaseUrl', () => {
+  it('returns the hub-published URL when the name matches', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        vaults: [
+          { name: 'work', url: 'https://h/vault/work', version: '0.4.7' },
+          { name: 'personal', url: 'https://h/vault/personal/', version: '0.4.7' },
+        ],
+      }),
+    );
+    expect(await resolveVaultBaseUrl('work', fetchImpl)).toBe('https://h/vault/work');
+  });
+
+  it('strips trailing slash from the hub-published URL', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        vaults: [{ name: 'personal', url: 'https://h/vault/personal/', version: '0.4.7' }],
+      }),
+    );
+    expect(await resolveVaultBaseUrl('personal', fetchImpl)).toBe('https://h/vault/personal');
+  });
+
+  it('returns null when the vault name is unknown', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, { vaults: [] }));
+    expect(await resolveVaultBaseUrl('ghost', fetchImpl)).toBeNull();
+  });
+});
+
+describe('mintVaultTokenHttp', () => {
+  it('POSTs to /tokens with label + scopes + null expires_at', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(201, { id: 't_x', token: 'pvt_x' }));
+    const result = await mintVaultTokenHttp({
+      vaultBaseUrl: 'https://h/vault/work',
+      authHeader: 'Bearer x',
+      label: 'claw-personal',
+      scopes: ['vault:read', 'vault:write'],
+      fetchImpl,
+    });
+    expect(result.status).toBe(201);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://h/vault/work/tokens',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          label: 'claw-personal',
+          scopes: ['vault:read', 'vault:write'],
+          expires_at: null,
+        }),
+      }),
+    );
+  });
+
+  it('passes expires_at through when provided', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(201, { id: 't_x', token: 'pvt_x' }));
+    await mintVaultTokenHttp({
+      vaultBaseUrl: 'https://h/vault/work',
+      authHeader: 'Bearer x',
+      label: 'short-lived',
+      scopes: ['vault:read'],
+      expiresAt: '2026-12-31T00:00:00Z',
+      fetchImpl,
+    });
+    const callArgs = fetchImpl.mock.calls[0]![1] as { body: string };
+    expect(JSON.parse(callArgs.body)).toMatchObject({ expires_at: '2026-12-31T00:00:00Z' });
+  });
+});

--- a/src/web/vault-proxy.ts
+++ b/src/web/vault-proxy.ts
@@ -1,0 +1,120 @@
+/**
+ * JWT-forwarding helper for paraclaw → vault HTTP calls.
+ *
+ * Per the chosen v1 admin auth model (Option C in
+ * `docs/design/2026-04-29-vault-management-ui.md` § Admin auth model):
+ * paraclaw forwards the *operator's* hub-issued session JWT to the vault
+ * unmodified. The vault validates `vault:<name>:admin` against the hub's
+ * JWKS — same path it uses for any hub-issued JWT — so paraclaw doesn't
+ * downgrade or re-issue.
+ *
+ * The helper is intentionally thin: name → URL resolution lives in the
+ * caller (route handlers do that via `fetchHubVaults()`); this just wraps
+ * fetch with the right headers and surfaces vault errors as structured
+ * results so the route handler can propagate the status verbatim.
+ */
+import { fetchHubVaults, type VaultListing, type FetchLike } from './hub-discovery.js';
+
+export interface VaultProxyOpts {
+  method: 'GET' | 'POST' | 'DELETE';
+  /** Vault base URL, no trailing slash, no `/tokens` suffix. */
+  vaultBaseUrl: string;
+  /** Sub-path, must start with `/` (e.g. `/tokens`, `/tokens/t_abc123def456`). */
+  subpath: string;
+  /** Operator's `Authorization: Bearer <jwt>` header value, forwarded as-is. */
+  authHeader: string;
+  /** Optional JSON body — POST only. */
+  body?: unknown;
+  /** Test seam. */
+  fetchImpl?: FetchLike;
+}
+
+export interface VaultProxyResult {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Forward a request to a vault and return the parsed result. Network errors
+ * surface as 502; HTTP errors come back with the vault's status so the route
+ * handler can mirror it (a 401 from vault means the caller's JWT is missing
+ * `vault:<name>:admin` — surface that to the browser to trigger consent).
+ */
+export async function forwardToVault(opts: VaultProxyOpts): Promise<VaultProxyResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url = `${opts.vaultBaseUrl.replace(/\/+$/, '')}${opts.subpath}`;
+  const headers: Record<string, string> = {
+    Authorization: opts.authHeader,
+    Accept: 'application/json',
+  };
+  const init: RequestInit = { method: opts.method, headers };
+  if (opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(opts.body);
+  }
+  let res: Response;
+  try {
+    res = await fetchImpl(url, init);
+  } catch (err) {
+    return {
+      status: 502,
+      body: { error: `vault unreachable: ${err instanceof Error ? err.message : String(err)}` },
+    };
+  }
+  let body: unknown = null;
+  const text = await res.text();
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { error: `vault returned non-JSON: ${text.slice(0, 200)}` };
+    }
+  }
+  return { status: res.status, body };
+}
+
+/**
+ * Resolve a vault name to its hub-published base URL. Returns null if the
+ * name doesn't match any registered vault — caller responds 404.
+ *
+ * The base URL is the well-known doc's `vault.url`, which is the
+ * public-routable form (e.g. `https://hub.tail.../vault/<name>`). Strip
+ * any trailing slash before returning so callers can append `/tokens`
+ * etc. without double-slashing.
+ */
+export async function resolveVaultBaseUrl(name: string, fetchImpl?: FetchLike): Promise<string | null> {
+  const vaults: VaultListing[] = await fetchHubVaults(fetchImpl);
+  const hit = vaults.find((v) => v.name === name);
+  if (!hit) return null;
+  return hit.url.replace(/\/+$/, '');
+}
+
+/**
+ * Mint a vault token via HTTP. Used both by the public `POST /api/vaults/
+ * /:name/tokens` endpoint and by the legacy implicit-mint paths in
+ * `/attach-vault` / `POST /api/groups` so the shell-out can go.
+ *
+ * Returns the vault's response verbatim (status + body) — the route handler
+ * decides what to surface to the browser.
+ */
+export async function mintVaultTokenHttp(opts: {
+  vaultBaseUrl: string;
+  authHeader: string;
+  label: string;
+  scopes: string[];
+  expiresAt?: string | null;
+  fetchImpl?: FetchLike;
+}): Promise<VaultProxyResult> {
+  return forwardToVault({
+    method: 'POST',
+    vaultBaseUrl: opts.vaultBaseUrl,
+    subpath: '/tokens',
+    authHeader: opts.authHeader,
+    body: {
+      label: opts.label,
+      scopes: opts.scopes,
+      expires_at: opts.expiresAt ?? null,
+    },
+    fetchImpl: opts.fetchImpl,
+  });
+}


### PR DESCRIPTION
## Summary

Phase 1 of the vault management UI backend per [docs/design/2026-04-29-vault-management-ui.md](https://github.com/ParachuteComputer/paraclaw/blob/main/docs/design/2026-04-29-vault-management-ui.md). Five new \`/api/vaults/*\` endpoints, a JWT-forwarding helper, the \`/detach-vault\` revoke extension, and the deletion of the \`parachute vault tokens create\` shell-out. Implements the chosen Option C admin auth model: paraclaw forwards the operator's hub-issued session JWT to the vault unmodified — the vault validates \`vault:<name>:admin\` against the hub's JWKS independently.

## Endpoints

| Method | Path | Purpose | Scope at paraclaw |
|---|---|---|---|
| GET | \`/api/vaults\` | well-known list | \`claw:read\` |
| POST | \`/api/vaults/refresh\` | clear discovery cache + refetch | \`claw:read\` |
| GET | \`/api/vaults/:name\` | detail + attached groups | \`claw:read\` |
| GET | \`/api/vaults/:name/tokens\` | list (with \`attachedTo\` enrichment by tokenLabel) | \`claw:admin\` |
| POST | \`/api/vaults/:name/tokens\` | mint | \`claw:admin\` |
| DELETE | \`/api/vaults/:name/tokens/:id\` | revoke | \`claw:admin\` |

Plus: \`POST /attach/:folder/detach-vault\` now accepts \`{revokeToken: boolean}\`. When set, paraclaw resolves the attachment's \`tokenLabel → token id\` against the vault, then DELETEs by id.

## Auth model

Operator JWT is forwarded verbatim. Paraclaw doesn't downgrade or re-issue. A 401/403 from the vault is mirrored back so the browser can trigger a consent prompt for the missing narrow scope. Network errors → 502 with a structured body. See \`src/web/vault-proxy.ts\` for the full helper.

## Tests

- 12 tests on the proxy primitives (\`src/web/vault-proxy.test.ts\`)
- 4 tests on \`listVaultAttachments\` (\`src/parachute/vault-mcp.test.ts\`)
- 11 tests on the route dispatcher (\`src/web/routes/vaults.test.ts\`) — covers the \`attachedTo\` merge, vault-not-found 404s, refresh cache invalidation, 401 mirror, 400 on bad JSON

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 359 tests pass (added 27)
- [x] \`cd container/agent-runner && bun test\` — 59 tests pass
- [ ] Manually exercise the new endpoints against a running vault before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)