### PR TITLE
Phase 2 frontend: vault management index page (paraclaw#38)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.14",
+  "version": "0.0.14-rc.15",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { OAuthCallback } from "./routes/OAuthCallback.tsx";
 import { SecretsList } from "./routes/SecretsList.tsx";
 import { SessionsList } from "./routes/SessionsList.tsx";
 import { SetupWizard } from "./routes/SetupWizard.tsx";
+import { VaultsList } from "./routes/VaultsList.tsx";
 
 export function App() {
   // The OAuth callback page is intentionally chrome-free — the user is
@@ -35,6 +36,7 @@ export function App() {
         <Link to="/">Agent groups</Link>
         <Link to="/sessions">Sessions</Link>
         <Link to="/channels">Channels</Link>
+        <Link to="/vaults">Vaults</Link>
         <Link to="/secrets">Secrets</Link>
         <Link to="/apps">Apps</Link>
         <Link to="/approvals">Approvals</Link>
@@ -52,6 +54,16 @@ export function App() {
         <Route path="/" element={<GroupList />} />
         <Route path="/secrets" element={<SecretsList />} />
         <Route path="/sessions" element={<SessionsList />} />
+        <Route path="/vaults" element={<VaultsList />} />
+        <Route
+          path="/vaults/:name"
+          element={
+            <div className="empty">
+              Vault detail + mint flow lands in Phase 3 (paraclaw#38).{' '}
+              <Link to="/vaults">Back to vaults</Link>
+            </div>
+          }
+        />
         <Route path="/channels" element={<ChannelsList />} />
         <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -222,6 +222,62 @@ export async function listVaults(): Promise<VaultListing[]> {
   return r.vaults;
 }
 
+/**
+ * POST /api/vaults/refresh — clears the 30s discovery cache and re-fetches
+ * the well-known list. The Refresh button on `/vaults` calls this when the
+ * operator just installed a new vault and doesn't want to wait out the cache.
+ */
+export async function refreshVaults(): Promise<VaultListing[]> {
+  const r = await request<{ vaults: VaultListing[] }>('/vaults/refresh', { method: 'POST', json: {} });
+  return r.vaults;
+}
+
+export interface VaultAttachedGroup {
+  folder: string;
+  mcpName: string;
+  scope: string;
+  tokenLabel: string;
+  attachedAt: string;
+}
+
+export interface VaultDetail {
+  vault: VaultListing;
+  attachedGroups: VaultAttachedGroup[];
+}
+
+/** GET /api/vaults/:name — listing entry + attached-group derivation. claw:read. */
+export async function getVaultDetail(name: string): Promise<VaultDetail> {
+  return request<VaultDetail>(`/vaults/${encodeURIComponent(name)}`);
+}
+
+/**
+ * Tolerant token-count probe for the index page. Returns null when the
+ * operator's session JWT lacks `vault:<name>:admin` (the vault 401s) so the
+ * row can render a placeholder instead of trapping the user in a re-auth
+ * loop — the consent prompt is meant to fire on the detail page, not here.
+ * Bypasses `request<T>` on purpose; do not reuse for endpoints that should
+ * surface auth errors.
+ */
+export async function tryListVaultTokenCount(name: string): Promise<number | null> {
+  const bearer = getAccessToken();
+  if (!bearer) return null;
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/vaults/${encodeURIComponent(name)}/tokens`, {
+      headers: { Accept: 'application/json', Authorization: `Bearer ${bearer}` },
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  try {
+    const body = (await res.json()) as { tokens?: unknown[] };
+    return Array.isArray(body.tokens) ? body.tokens.length : 0;
+  } catch {
+    return null;
+  }
+}
+
 export async function attachVault(
   folder: string,
   input: {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -228,7 +228,7 @@ export async function listVaults(): Promise<VaultListing[]> {
  * operator just installed a new vault and doesn't want to wait out the cache.
  */
 export async function refreshVaults(): Promise<VaultListing[]> {
-  const r = await request<{ vaults: VaultListing[] }>('/vaults/refresh', { method: 'POST', json: {} });
+  const r = await request<{ vaults: VaultListing[] }>('/vaults/refresh', { method: 'POST' });
   return r.vaults;
 }
 
@@ -251,30 +251,45 @@ export async function getVaultDetail(name: string): Promise<VaultDetail> {
 }
 
 /**
- * Tolerant token-count probe for the index page. Returns null when the
- * operator's session JWT lacks `vault:<name>:admin` (the vault 401s) so the
- * row can render a placeholder instead of trapping the user in a re-auth
- * loop — the consent prompt is meant to fire on the detail page, not here.
- * Bypasses `request<T>` on purpose; do not reuse for endpoints that should
- * surface auth errors.
+ * Discriminated result of a tolerant token-count probe — distinguishes
+ * "operator hasn't consented to vault:<name>:admin yet" (the case we want
+ * to render as a row-level "—" with a Manage hint) from "vault is down or
+ * the request blew up" (a generic error sentinel). Without the split, a
+ * 500 would label as `unauthorized` and lie to the operator about why
+ * the count is missing.
  */
-export async function tryListVaultTokenCount(name: string): Promise<number | null> {
+export type TokenCountProbe =
+  | { kind: 'count'; value: number }
+  | { kind: 'unauthorized' }
+  | { kind: 'error' };
+
+/**
+ * Tolerant token-count probe for the index page. Bypasses `request<T>` on
+ * purpose — a 401/403 here means the session JWT is missing the per-vault
+ * narrow scope, not that the session itself is dead, and we don't want to
+ * trap the operator in a re-auth loop before they can even see what
+ * vaults exist. Consent prompt fires on the detail page (Phase 3).
+ *
+ * Do not reuse this helper for endpoints that should surface auth errors.
+ */
+export async function tryListVaultTokenCount(name: string): Promise<TokenCountProbe> {
   const bearer = getAccessToken();
-  if (!bearer) return null;
+  if (!bearer) return { kind: 'error' };
   let res: Response;
   try {
     res = await fetch(`${API_BASE}/vaults/${encodeURIComponent(name)}/tokens`, {
       headers: { Accept: 'application/json', Authorization: `Bearer ${bearer}` },
     });
   } catch {
-    return null;
+    return { kind: 'error' };
   }
-  if (!res.ok) return null;
+  if (res.status === 401 || res.status === 403) return { kind: 'unauthorized' };
+  if (!res.ok) return { kind: 'error' };
   try {
     const body = (await res.json()) as { tokens?: unknown[] };
-    return Array.isArray(body.tokens) ? body.tokens.length : 0;
+    return { kind: 'count', value: Array.isArray(body.tokens) ? body.tokens.length : 0 };
   } catch {
-    return null;
+    return { kind: 'error' };
   }
 }
 

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -24,10 +24,20 @@ import {
   listVaults,
   refreshVaults,
   tryListVaultTokenCount,
+  type TokenCountProbe,
   type VaultListing,
 } from '../lib/api.ts';
 
-type CountState = number | null | 'unauthorized';
+/**
+ * `null` is in-flight (initial load before the per-row enrichment Promise
+ * settles). `'unauthorized'` only fires for the token-count column when
+ * the vault returns 401/403 — i.e. the operator hasn't consented to
+ * `vault:<name>:admin` yet — and renders a Manage-to-grant hint.
+ * `'error'` is the catch-all for everything else (network blip, 5xx,
+ * malformed body) so we don't mislabel a server failure as an auth
+ * problem the operator can fix by clicking Manage.
+ */
+type CountState = number | null | 'unauthorized' | 'error';
 
 interface VaultRow {
   vault: VaultListing;
@@ -61,14 +71,14 @@ export function VaultsList() {
             if (r.vault.name !== name) return r;
             return {
               ...r,
+              // getVaultDetail only requires `claw:read`, which the session
+              // already has if the operator hit /vaults at all. A 401/403
+              // here would be re-auth'd by `request<T>` before throwing,
+              // so a rejected promise is a 5xx / network blip — not an
+              // auth issue. Don't mislabel it as unauthorized.
               attachedGroupsCount:
-                detail.status === 'fulfilled' ? detail.value.attachedGroups.length : 'unauthorized',
-              tokenCount:
-                count.status === 'fulfilled'
-                  ? count.value === null
-                    ? 'unauthorized'
-                    : count.value
-                  : 'unauthorized',
+                detail.status === 'fulfilled' ? detail.value.attachedGroups.length : 'error',
+              tokenCount: tokenProbeToCountState(count),
             };
           }),
         };
@@ -100,7 +110,21 @@ export function VaultsList() {
       })
       .catch((err) => {
         if (cancelled) return;
-        setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+        const message = err instanceof Error ? err.message : String(err);
+        if (isRefresh) {
+          // Refresh-while-data-shown: don't blow the page away. Keep the
+          // (now-stale) table visible and surface the failure as a banner
+          // above it so the operator can read the cause and retry. If the
+          // page was already in `error` (initial load failed and user hit
+          // Retry), update the error message in place so the full-page
+          // error UI reflects the latest cause instead of a stale one.
+          setRefreshError(message);
+          setState((prev) => (prev.kind === 'error' ? { kind: 'error', message } : prev));
+        } else {
+          // Initial load with no data yet — full-page error is the
+          // honest state; nothing to preserve.
+          setState({ kind: 'error', message });
+        }
       })
       .finally(() => {
         if (cancelled) return;
@@ -225,11 +249,25 @@ function VaultRowView({ row }: { row: VaultRow }) {
   );
 }
 
+function tokenProbeToCountState(
+  result: PromiseSettledResult<TokenCountProbe>,
+): CountState {
+  if (result.status === 'rejected') return 'error';
+  switch (result.value.kind) {
+    case 'count':
+      return result.value.value;
+    case 'unauthorized':
+      return 'unauthorized';
+    case 'error':
+      return 'error';
+  }
+}
+
 function CountBadge({ label, value }: { label: string; value: CountState }) {
   if (value === null) {
     return (
       <span className="tag muted" title={`Loading ${label}…`}>
-        {label}: …
+        {`${label}: …`}
       </span>
     );
   }
@@ -242,9 +280,16 @@ function CountBadge({ label, value }: { label: string; value: CountState }) {
         className="tag muted"
         title={`Click Manage to grant vault:${label} access.`}
       >
-        {label}: —
+        {`${label}: —`}
       </span>
     );
   }
-  return <span className="tag muted">{label}: {value}</span>;
+  if (value === 'error') {
+    return (
+      <span className="tag muted" title={`Couldn't load ${label} — vault may be down. Click Refresh from hub or Manage to retry.`}>
+        {`${label}: ?`}
+      </span>
+    );
+  }
+  return <span className="tag muted">{`${label}: ${value}`}</span>;
 }

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -1,0 +1,250 @@
+/**
+ * /vaults — vault management index page (Phase 2 of paraclaw#38).
+ *
+ * One row per vault from the hub's well-known discovery doc, with
+ * attached-group + token-count summaries pulled from the new /api/vaults
+ * proxy endpoints. Clicking ▸ Manage drills into /vaults/<name> for the
+ * detail/mint/revoke surface (Phase 3 — placeholder route for now).
+ *
+ * Token-count probes hit `GET /api/vaults/:name/tokens`, which forwards
+ * the operator's session JWT to the vault and requires a per-vault
+ * `vault:<name>:admin` scope. The probe is tolerant — a 401/403 renders
+ * "—" so an operator who hasn't consented to that scope yet can still
+ * see the index. The consent prompt fires on the detail page (Phase 3),
+ * not here, where it would trap users in a re-auth loop before they
+ * could even see what vaults exist.
+ *
+ * State shape mirrors SecretsList.tsx (loading | ok | error tagged
+ * union) for visual + interaction consistency.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  getVaultDetail,
+  listVaults,
+  refreshVaults,
+  tryListVaultTokenCount,
+  type VaultListing,
+} from '../lib/api.ts';
+
+type CountState = number | null | 'unauthorized';
+
+interface VaultRow {
+  vault: VaultListing;
+  attachedGroupsCount: CountState;
+  tokenCount: CountState;
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; rows: VaultRow[] }
+  | { kind: 'error'; message: string };
+
+export function VaultsList() {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [reloadCounter, setReloadCounter] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const enrichRow = useCallback(
+    async (name: string, isCancelled: () => boolean) => {
+      const [detail, count] = await Promise.allSettled([
+        getVaultDetail(name),
+        tryListVaultTokenCount(name),
+      ]);
+      if (isCancelled()) return;
+      setState((prev) => {
+        if (prev.kind !== 'ok') return prev;
+        return {
+          kind: 'ok',
+          rows: prev.rows.map((r) => {
+            if (r.vault.name !== name) return r;
+            return {
+              ...r,
+              attachedGroupsCount:
+                detail.status === 'fulfilled' ? detail.value.attachedGroups.length : 'unauthorized',
+              tokenCount:
+                count.status === 'fulfilled'
+                  ? count.value === null
+                    ? 'unauthorized'
+                    : count.value
+                  : 'unauthorized',
+            };
+          }),
+        };
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const isCancelled = () => cancelled;
+    const isRefresh = reloadCounter > 0;
+    const fetcher = isRefresh ? refreshVaults : listVaults;
+
+    fetcher()
+      .then((vaults) => {
+        if (cancelled) return;
+        setState({
+          kind: 'ok',
+          rows: vaults.map((v) => ({
+            vault: v,
+            attachedGroupsCount: null,
+            tokenCount: null,
+          })),
+        });
+        for (const v of vaults) {
+          void enrichRow(v.name, isCancelled);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+      })
+      .finally(() => {
+        if (cancelled) return;
+        if (isRefresh) setRefreshing(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadCounter, enrichRow]);
+
+  const onRefresh = () => {
+    setRefreshError(null);
+    setRefreshing(true);
+    setReloadCounter((n) => n + 1);
+  };
+
+  if (state.kind === 'loading') {
+    return (
+      <div>
+        <h2>Vaults</h2>
+        <ul className="skeleton-list" aria-busy="true">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div>
+        <h2>Vaults</h2>
+        <div className="error-banner">
+          Couldn't load vaults: <code>{state.message}</code>
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
+          <button onClick={onRefresh} disabled={refreshing}>
+            {refreshing ? 'Refreshing…' : 'Refresh from hub'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Vaults ({state.rows.length})</h2>
+        <button onClick={onRefresh} disabled={refreshing}>
+          {refreshing ? 'Refreshing…' : 'Refresh from hub'}
+        </button>
+      </div>
+
+      <p className="muted">
+        Vaults registered with this hub at <code>/.well-known/parachute.json</code>. The
+        list is cached in paraclaw for 30 seconds; <strong>Refresh from hub</strong> bypasses
+        the cache and re-fetches.
+      </p>
+
+      {refreshError && <div className="error-banner">{refreshError}</div>}
+
+      {state.rows.length === 0 ? (
+        <div className="empty empty-rich">
+          <p className="empty-headline">No vaults yet.</p>
+          <p className="muted">
+            Install one with <code>parachute install vault</code> on the host this hub runs on,
+            then click <strong>Refresh from hub</strong> above.
+          </p>
+          <p style={{ marginTop: '0.75rem' }}>
+            <a
+              href="https://github.com/ParachuteComputer/parachute-vault#install"
+              target="_blank"
+              rel="noreferrer"
+            >
+              How to install a vault →
+            </a>
+          </p>
+        </div>
+      ) : (
+        <div style={{ marginTop: '1rem' }}>
+          {state.rows.map((r) => (
+            <VaultRowView key={r.vault.name} row={r} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VaultRowView({ row }: { row: VaultRow }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '1rem',
+        padding: '0.75rem 1rem',
+        background: 'white',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        marginBottom: '0.5rem',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <code style={{ fontSize: '0.95em' }}>{row.vault.name}</code>
+          <span className="tag muted" title="Vault version reported by the hub">
+            v{row.vault.version}
+          </span>
+          <CountBadge label="tokens" value={row.tokenCount} />
+          <CountBadge label="attached" value={row.attachedGroupsCount} />
+        </div>
+        <div className="dim" style={{ marginTop: '0.25rem', wordBreak: 'break-all' }}>
+          <code>{row.vault.url}</code>
+        </div>
+      </div>
+      <Link to={`/vaults/${encodeURIComponent(row.vault.name)}`} className="secondary">
+        ▸ Manage
+      </Link>
+    </div>
+  );
+}
+
+function CountBadge({ label, value }: { label: string; value: CountState }) {
+  if (value === null) {
+    return (
+      <span className="tag muted" title={`Loading ${label}…`}>
+        {label}: …
+      </span>
+    );
+  }
+  if (value === 'unauthorized') {
+    // vault:<name>:admin scope is granted on the detail page — until then,
+    // the index can't read the vault's token list. Don't break the whole
+    // page over a single missing per-vault scope.
+    return (
+      <span
+        className="tag muted"
+        title={`Click Manage to grant vault:${label} access.`}
+      >
+        {label}: —
+      </span>
+    );
+  }
+  return <span className="tag muted">{label}: {value}</span>;
+}


### PR DESCRIPTION
## Summary
Phase 2 of paraclaw#38 — adds the `/vaults` index route on top of the Phase 1 backend (#41).

- New route: `/claw/vaults` → list of every vault the hub publishes via `/.well-known/parachute.json`, with attached-group + token counts pulled from the Phase 1 endpoints.
- Header `Refresh from hub` button → `POST /api/vaults/refresh` (bypasses the 30s discovery cache).
- Per-row `▸ Manage` link → `/claw/vaults/<name>` (placeholder route — Phase 3 will fill it in with detail / mint / revoke).
- Empty state links to `parachute-vault` README install section.
- Bumps `0.0.14-rc.14` → `0.0.14-rc.15`.

## Design notes
- **State shape mirrors `SecretsList.tsx`** (`loading | ok | error` tagged union, `useEffect` with cancellation flag) for visual + interaction consistency.
- **Per-row enrichment is async + tolerant.** Vaults paint immediately with `…` placeholders; counts fill in via `Promise.allSettled` so a slow vault doesn't block the rest of the table.
- **Token-count probe is intentionally tolerant** of 401/403 — bypasses `request<T>`'s re-auth path and renders `—` instead. The `vault:<name>:admin` consent prompt is meant to fire on the detail page in Phase 3, where the user has explicit intent (clicked Manage). Triggering it on the index would trap operators in a re-auth loop before they can even see what vaults exist. Documented in the new `tryListVaultTokenCount` JSDoc.
- **Bundle still mount-aware** — all three new helpers go through the existing `API_BASE` derivation, so the build at `/claw/` and the dev mount both work.

## What's in the diff
- `web/ui/src/lib/api.ts` (+56 LOC): `refreshVaults`, `getVaultDetail`, `tryListVaultTokenCount` + types.
- `web/ui/src/routes/VaultsList.tsx` (+250 LOC): the index page itself.
- `web/ui/src/App.tsx` (+12 LOC): route registration + nav link + `/vaults/:name` placeholder.
- `package.json`: rc.14 → rc.15.

## What's NOT in this PR (Phase 3)
- `/claw/vaults/<name>` detail page — currently a placeholder div.
- Token list, mint form, one-time copy card, revoke flow.
- Detach-with-revoke modal, group cross-links.

## Tests
No frontend tests added. `web/ui/` has no test framework (zero `*.test.tsx` files; no vitest/testing-library in `web/ui/package.json`). Standing up vitest + jsdom + RTL just for this one route felt like infrastructure scope creep mid-phase; matched the existing pattern instead. Happy to add if reviewer wants.

Verified by:
- `pnpm typecheck` (host) — green
- `pnpm typecheck` (web/ui) — green
- `pnpm web:build` — green; `verify-base` confirms `/claw/`-prefixed assets
- `pnpm test` — 359 passed, 41 files (Phase 1 backend tests still pass)
- Manual end-to-end browser verification deferred to Aaron — tentacles can't drive a browser. Hub + vault setup is in place from PR #41 manual exercise.

Lint shows 8 errors, all pre-existing on main (untouched files: `static-serve.ts`, `apps.ts`, `oauth/flow.ts`, etc.). No new lint regressions.

## Test plan
- [ ] Aaron loads `https://parachute.taildf9ce2.ts.net/claw/vaults` in browser
- [ ] `techne` row shows up with version + URL
- [ ] Token count either shows a number or `—` (tolerant fallback)
- [ ] Attached-groups count shows the right number for any group already attached to `techne`
- [ ] `Refresh from hub` button fires `POST /api/vaults/refresh` and re-paints
- [ ] `▸ Manage` navigates to `/claw/vaults/techne` placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)