### PR TITLE
Hot-fix migration 025 — toggle foreign_keys connection-scope (paraclaw#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.15",
+  "version": "0.0.14-rc.17",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/migrations/025-secret-mode-check.test.ts
+++ b/src/db/migrations/025-secret-mode-check.test.ts
@@ -17,25 +17,107 @@ afterEach(() => {
 describe('migration 025 — secret_mode CHECK constraint', () => {
   it('preserves rows already in agent_groups across the table recreate', () => {
     // Apply everything up through 024, leaving 025 unrun. Insert a row
-    // with the pre-025 shape (no CHECK constraint). Then run 025 directly
-    // and confirm the row survives the DROP-and-RENAME dance.
-    //
-    // The migration runner wraps each migration in a transaction so
-    // `PRAGMA defer_foreign_keys = TRUE` defers FK checks until commit;
-    // we replicate that wrapping here, otherwise the DROP TABLE
-    // agent_groups would trip the FKs on sessions/secrets/etc.
+    // with the pre-025 shape (no CHECK constraint). Then run 025 the
+    // way the runner runs it (FKs off connection-scope, then a tx
+    // around `up`) and confirm the row survives the DROP-and-RENAME.
     const db = applyMigrationsExcept([migration025]);
     db.prepare(
       `INSERT INTO agent_groups (id, name, folder, agent_provider, secret_mode, created_at)
        VALUES (?, ?, ?, NULL, 'all', datetime('now'))`,
     ).run('keepme', 'keepme', 'keepme');
 
-    db.transaction(() => migration025.up(db))();
+    db.exec('PRAGMA foreign_keys = OFF');
+    try {
+      db.transaction(() => migration025.up(db))();
+    } finally {
+      db.exec('PRAGMA foreign_keys = ON');
+    }
 
     const row = db.prepare(`SELECT * FROM agent_groups WHERE id = ?`).get('keepme') as {
       secret_mode: string;
     };
     expect(row.secret_mode).toBe('all');
+  });
+
+  it('survives an orphan FK row in a referencing table (paraclaw#54)', () => {
+    // Production-flavored regression: real installs carry pre-FK-era
+    // orphan rows (e.g. a `sessions.agent_group_id` whose parent was
+    // never inserted or got dropped). Migration 025's first cut used
+    // `defer_foreign_keys = TRUE`, which delays the FK check to commit
+    // and then trips it on the orphan, taking the whole boot down with
+    // a `FOREIGN KEY constraint failed` Startup error. Plant the
+    // production-shaped triple — real parent, valid child pointing at
+    // it, AND orphan child pointing at a never-existed parent — and
+    // run 025 the way the runner runs it. Empirically, the deferred
+    // check only fires when the renamed parent has live referencing
+    // children, so the orphan-only fixture isn't enough; a bare orphan
+    // slips past `defer_foreign_keys=TRUE`.
+    const db = applyMigrationsExcept([migration025]);
+
+    // Real parent + valid child (the natural way, FKs ON).
+    db.prepare(
+      `INSERT INTO agent_groups (id, name, folder, agent_provider, secret_mode, created_at)
+       VALUES (?, ?, ?, NULL, 'all', datetime('now'))`,
+    ).run('g-real', 'g-real', 'g-real');
+    db.prepare(
+      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, status, created_at)
+       VALUES (?, ?, NULL, NULL, 'active', datetime('now'))`,
+    ).run('valid-session', 'g-real');
+
+    // Orphan child: foreign_keys is ON by default in test DBs
+    // (initTestDb), so flip it off to plant one. This mirrors how the
+    // orphan appeared on Aaron's DB — early-era operations under
+    // foreign_keys = OFF, never reconciled.
+    db.exec('PRAGMA foreign_keys = OFF');
+    db.prepare(
+      `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, status, created_at)
+       VALUES (?, ?, NULL, NULL, 'active', datetime('now'))`,
+    ).run('orphan-session', 'never-existed-agent-group');
+    db.exec('PRAGMA foreign_keys = ON');
+
+    // Verify the FK violation is real *before* running the migration —
+    // i.e. the fixture would actually trip a deferred check.
+    const violationsBefore = db.prepare(`PRAGMA foreign_key_check`).all() as {
+      table: string;
+      rowid: number;
+      parent: string;
+      fkid: number;
+    }[];
+    expect(violationsBefore.some((v) => v.table === 'sessions' && v.parent === 'agent_groups')).toBe(true);
+
+    // Run 025 via the real runner so the disableForeignKeys flag is
+    // exercised end-to-end. Drop the fake-applied marker first so the
+    // runner picks it up.
+    db.prepare('DELETE FROM schema_version WHERE name = ?').run('secret-mode-check');
+    expect(() => runMigrations(db)).not.toThrow();
+
+    // Both children are still there, the parent survived the recreate,
+    // the migration recorded itself, and the CHECK constraint is in
+    // place.
+    const orphan = db.prepare(`SELECT id, agent_group_id FROM sessions WHERE id = ?`).get('orphan-session') as {
+      id: string;
+      agent_group_id: string;
+    };
+    expect(orphan).toEqual({ id: 'orphan-session', agent_group_id: 'never-existed-agent-group' });
+    const valid = db.prepare(`SELECT id, agent_group_id FROM sessions WHERE id = ?`).get('valid-session') as {
+      id: string;
+      agent_group_id: string;
+    };
+    expect(valid).toEqual({ id: 'valid-session', agent_group_id: 'g-real' });
+    const parent = db.prepare(`SELECT id FROM agent_groups WHERE id = ?`).get('g-real') as { id: string };
+    expect(parent?.id).toBe('g-real');
+    const applied = db.prepare(`SELECT name FROM schema_version WHERE name = ?`).get('secret-mode-check') as {
+      name: string;
+    };
+    expect(applied?.name).toBe('secret-mode-check');
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO agent_groups (id, name, folder, agent_provider, secret_mode, created_at)
+           VALUES (?, ?, ?, NULL, 'bogus', datetime('now'))`,
+        )
+        .run('badmode-after-fix', 'badmode-after-fix', 'badmode-after-fix'),
+    ).toThrow(/CHECK constraint/i);
   });
 
   it('rejects out-of-range writes', () => {

--- a/src/db/migrations/025-secret-mode-check.ts
+++ b/src/db/migrations/025-secret-mode-check.ts
@@ -7,9 +7,17 @@
  *
  * SQLite doesn't allow `ALTER TABLE … ADD CHECK`. The only path is the
  * recreate-and-rename dance: build the new table with the CHECK inline,
- * copy the rows, drop the old, rename in place. `defer_foreign_keys`
- * lets the dance happen inside the migration's wrapping transaction —
- * `PRAGMA foreign_keys=OFF` would be silently ignored mid-txn.
+ * copy the rows, drop the old, rename in place.
+ *
+ * paraclaw#54: the first cut used `PRAGMA defer_foreign_keys = TRUE`,
+ * which only postpones the FK check to commit-time. On a real install
+ * with a pre-FK-enforcement orphan row in a referencing table (a
+ * `sessions.agent_group_id` whose parent was dropped before FKs were
+ * enforced), the deferred check at COMMIT scans the renamed table and
+ * trips on the orphan, taking boot down. The structural fix is
+ * `PRAGMA foreign_keys = OFF` connection-scope, which SQLite forbids
+ * changing mid-txn — so the toggle has to live in the runner, not here.
+ * `disableForeignKeys: true` opts this migration into that wrapper.
  */
 import type { Database } from '../connection.js';
 import type { Migration } from './index.js';
@@ -17,10 +25,9 @@ import type { Migration } from './index.js';
 export const migration025: Migration = {
   version: 25,
   name: 'secret-mode-check',
+  disableForeignKeys: true,
   up(db: Database) {
     db.exec(`
-      PRAGMA defer_foreign_keys = TRUE;
-
       CREATE TABLE agent_groups_new (
         id               TEXT PRIMARY KEY,
         name             TEXT NOT NULL,

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -104,9 +104,11 @@ export function runMigrations(db: Database): void {
     try {
       db.transaction(() => {
         m.up(db);
-        const next = (db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as {
-          v: number;
-        }).v;
+        const next = (
+          db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as {
+            v: number;
+          }
+        ).v;
         db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
           next,
           m.name,

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -29,6 +29,24 @@ export interface Migration {
   version: number;
   name: string;
   up: (db: Database) => void;
+  /**
+   * Set true for migrations that recreate a parent table (the SQLite
+   * "build new + copy + drop + rename" dance). The runner toggles
+   * `PRAGMA foreign_keys = OFF` connection-scope BEFORE entering the
+   * wrapping transaction and re-enables it after.
+   *
+   * `PRAGMA defer_foreign_keys = TRUE` is NOT enough — it only delays
+   * the FK check to commit-time, where any pre-existing orphan row in a
+   * referencing table (e.g. a dangling `sessions.agent_group_id` left
+   * over from pre-FK-enforcement days) will still fail the migration on
+   * a real install. SQLite forbids changing `foreign_keys` mid-txn, so
+   * the toggle has to live in the runner, not the migration body.
+   *
+   * Migrations setting this MUST NOT introduce new orphan rows; the
+   * fix-existing-orphans question is separate (and out of scope for a
+   * schema-shape migration like 025).
+   */
+  disableForeignKeys?: boolean;
 }
 
 const migrations: Migration[] = [
@@ -82,16 +100,22 @@ export function runMigrations(db: Database): void {
   log.info('Running migrations', { count: pending.length });
 
   for (const m of pending) {
-    db.transaction(() => {
-      m.up(db);
-      const next = (db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as { v: number })
-        .v;
-      db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
-        next,
-        m.name,
-        new Date().toISOString(),
-      );
-    })();
+    if (m.disableForeignKeys) db.exec('PRAGMA foreign_keys = OFF');
+    try {
+      db.transaction(() => {
+        m.up(db);
+        const next = (db.prepare('SELECT COALESCE(MAX(version), 0) + 1 AS v FROM schema_version').get() as {
+          v: number;
+        }).v;
+        db.prepare('INSERT INTO schema_version (version, name, applied) VALUES (?, ?, ?)').run(
+          next,
+          m.name,
+          new Date().toISOString(),
+        );
+      })();
+    } finally {
+      if (m.disableForeignKeys) db.exec('PRAGMA foreign_keys = ON');
+    }
     log.info('Migration applied', { name: m.name });
   }
 }


### PR DESCRIPTION
## Summary

P0 hot-fix for paraclaw#54. Aaron's install crashes on boot with `FOREIGN KEY constraint failed` because migration 025 uses `PRAGMA defer_foreign_keys = TRUE`, which only delays the FK check to commit-time. On a real install with a pre-FK-enforcement orphan in `sessions.agent_group_id`, the deferred check fires at COMMIT, scans the renamed `agent_groups`, and trips on the orphan.

The structural fix is the SQLite-blessed shape for the recreate-and-rename dance: `PRAGMA foreign_keys = OFF` connection-scope. SQLite forbids changing `foreign_keys` mid-txn, so the toggle has to live in the runner, not in the migration body.

- `Migration` interface gains `disableForeignKeys?: boolean` with JSDoc explaining why `defer_foreign_keys` is insufficient.
- Runner toggles `PRAGMA foreign_keys = OFF` BEFORE entering the wrapping txn and back ON after.
- Migration 025 sets the flag and drops the inline `defer_foreign_keys` pragma; the table recreate body is unchanged.
- New regression fixture in `025-secret-mode-check.test.ts`: real parent + valid child + orphan child. Empirically, the deferred check only fires when the renamed parent has live referencing rows — a bare orphan slips past `defer_foreign_keys=TRUE`. Verified by re-introducing the buggy form and confirming the new test fails with `FOREIGN KEY constraint failed`.

Bumps `0.0.14-rc.15` → `0.0.14-rc.17` (rc.16 reserved for #48).

## Gates

- `pnpm test` — **360/360 passed** (41 files)
- `pnpm typecheck` — clean
- `pnpm lint` — 144 issues (8 errors / 136 warnings), **identical baseline on `main`**; none in changed files
- `pnpm build` — clean

## Test plan

- [x] New orphan-FK regression test passes against the fix
- [x] Same test fails (with the production error shape) when migration 025 is reverted to the buggy `defer_foreign_keys` form
- [x] Existing 3 tests in `025-secret-mode-check.test.ts` still pass
- [x] Full host suite green
- [ ] Aaron bun-links the branch and confirms his install boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)