### PR TITLE
Auth-gate vault mutation 403s with narrow per-vault scope (paraclaw#56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.18",
+  "version": "0.0.14-rc.19",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -1,0 +1,158 @@
+/**
+ * api.ts unit tests — focused on the auth-gate behavior of `request<T>`.
+ * The vault token-mgmt helpers (mint/revoke/detach) thread an
+ * `authExtraScopes` hint so that a 403 scope-mismatch from the back-end
+ * triggers re-auth with the narrow per-vault scope appended, not just the
+ * broad REQUESTED_SCOPES set (paraclaw#56).
+ *
+ * Strategy: mock `auth.ts` so we can assert the exact arguments to
+ * beginLogin / refreshAccessToken / clearTokens; mock `fetch` to shape the
+ * wire response (200 / 403 with scope-mismatch body / 403 with unrelated
+ * body). beginLogin in production never returns (it does
+ * window.location.replace), so we mock it to *reject* — that lets the
+ * `await beginLogin(...)` inside request<T> propagate, and we assert on
+ * what it was called with.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as auth from './auth.ts';
+
+vi.mock('./auth.ts', () => ({
+  beginLogin: vi.fn(),
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(() => 'cached-token'),
+  refreshAccessToken: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(auth.getAccessToken).mockReturnValue('cached-token');
+  // Reject so the `await beginLogin(...)` in request<T> resolves the chain
+  // and the caller's promise settles — letting us await + assert.
+  vi.mocked(auth.beginLogin).mockRejectedValue(new Error('beginLogin called (test)'));
+  vi.mocked(auth.refreshAccessToken).mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('mintVaultToken — auth gate on 403', () => {
+  it('passes vault:<name>:admin to beginLogin when the vault returns scope-mismatch', async () => {
+    // Factory-per-call: a Response body is single-consume, so a single
+    // mockResolvedValue would let isScopeMismatch.clone().text() drain the
+    // body for the first test and leave a stale Response with an empty
+    // body for any subsequent code path.
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(403, { error: "This endpoint requires the 'vault:work:admin' scope" }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.mintVaultToken('work', { label: 'claw-x', scopes: ['vault:read'] }),
+    ).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.clearTokens).toHaveBeenCalled();
+    expect(auth.beginLogin).toHaveBeenCalledWith(['vault:work:admin']);
+  });
+});
+
+describe('revokeVaultToken — auth gate on 403', () => {
+  it('passes vault:<name>:admin to beginLogin', async () => {
+    // Factory-per-call: a Response body is single-consume, so a single
+    // mockResolvedValue would let isScopeMismatch.clone().text() drain the
+    // body for the first test and leave a stale Response with an empty
+    // body for any subsequent code path.
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(403, { error: "This endpoint requires the 'vault:work:admin' scope" }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(api.revokeVaultToken('work', 't_abc')).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(['vault:work:admin']);
+  });
+});
+
+describe('detachVault — auth gate on 403', () => {
+  it('threads authExtraScopes from caller through to beginLogin', async () => {
+    // Factory-per-call: a Response body is single-consume, so a single
+    // mockResolvedValue would let isScopeMismatch.clone().text() drain the
+    // body for the first test and leave a stale Response with an empty
+    // body for any subsequent code path.
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(403, { error: "This endpoint requires the 'vault:work:admin' scope" }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.detachVault('research', {
+        mcpName: 'parachute-vault',
+        revokeToken: true,
+        authExtraScopes: ['vault:work:admin'],
+      }),
+    ).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(['vault:work:admin']);
+  });
+
+  it('omits scope hint when caller did not supply one', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, { error: 'This endpoint requires the claw:admin scope' }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(api.detachVault('research', { revokeToken: false })).rejects.toThrow(
+      /beginLogin called/,
+    );
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('non-scope 403 does NOT trigger re-auth', () => {
+  it('throws HttpError(403) when body is unrelated', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, { error: 'forbidden' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.mintVaultToken('work', { label: 'x', scopes: ['vault:read'] }),
+    ).rejects.toMatchObject({
+      name: 'HttpError',
+      status: 403,
+    });
+    expect(auth.beginLogin).not.toHaveBeenCalled();
+    expect(auth.clearTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('happy path — 200 returns parsed body and skips auth', () => {
+  it('mintVaultToken returns the parsed MintedVaultToken', async () => {
+    const minted = {
+      token: 'pvt_secret',
+      id: 't_new',
+      label: 'claw-x',
+      scopes: ['vault:read'],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, minted));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    const result = await api.mintVaultToken('work', { label: 'claw-x', scopes: ['vault:read'] });
+
+    expect(result).toEqual(minted);
+    expect(auth.beginLogin).not.toHaveBeenCalled();
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -81,14 +81,16 @@ async function doFetch(
 }
 
 // Hub's scope-validation 403 (cli#71) responds with a body like
-// `{"error":"This endpoint requires the claw:admin scope"}`. We match the
-// substring rather than the exact phrase so a future copy tweak doesn't
-// silently disable re-auth. Reads via .clone() so readError() can still
-// consume the original body if the caller falls through to throw.
+// `{"error":"This endpoint requires the claw:admin scope"}`; the vault
+// uses single-quoted scope names: `requires the 'vault:work:admin' scope
+// (or 'vault:work:admin')`. We match either quoting so paraclaw#56's
+// vault path doesn't slip past the gate. Reads via .clone() so
+// readError() can still consume the original body if the caller falls
+// through to throw.
 async function isScopeMismatch(res: Response): Promise<boolean> {
   try {
     const text = await res.clone().text();
-    return /requires the [\w:]+ scope/.test(text);
+    return /requires the ['"]?[\w:]+['"]? scope/.test(text);
   } catch {
     return false;
   }
@@ -122,11 +124,25 @@ export class HttpError extends Error {
   }
 }
 
-export async function request<T>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> {
+/**
+ * `authExtraScopes` is forwarded to `beginLogin` if this call triggers a
+ * re-auth (401-after-refresh-failure or 403 scope-mismatch). Use it on
+ * endpoints that gate on a per-resource narrow scope the broad
+ * REQUESTED_SCOPES set doesn't carry — e.g. vault token mgmt requires
+ * `vault:<name>:admin` on top of `claw:admin`. Without this hint the
+ * re-auth would loop with the same broad-only JWT (paraclaw#56).
+ */
+export interface RequestInitWithAuth extends RequestInit {
+  json?: unknown;
+  authExtraScopes?: string[];
+}
+
+export async function request<T>(path: string, init?: RequestInitWithAuth): Promise<T> {
+  const extraScopes = init?.authExtraScopes;
   let bearer = getAccessToken();
   if (!bearer) {
     // No token at all — kick off the OAuth dance. beginLogin() never returns.
-    await beginLogin();
+    await beginLogin(extraScopes);
   }
   let res = await doFetch(path, init, bearer);
   if (res.status === 401) {
@@ -138,7 +154,7 @@ export async function request<T>(path: string, init?: RequestInit & { json?: unk
     if (res.status === 401) {
       // Refresh failed or post-refresh still 401 — drop tokens and re-auth.
       clearTokens();
-      await beginLogin();
+      await beginLogin(extraScopes);
     }
   }
   // 403 with a scope-mismatch body means the cached token was minted before
@@ -146,10 +162,12 @@ export async function request<T>(path: string, init?: RequestInit & { json?: unk
   // users were stuck behind a manual `localStorage.clear()` after the Phase 1
   // wizard bumped REQUESTED_SCOPES to include claw:admin. Refresh won't help
   // (refresh tokens carry the original scope set), so drop straight to
-  // re-auth — beginLogin() will request the new scope set.
+  // re-auth — beginLogin() will request the new scope set, plus any
+  // narrow per-resource scope the caller threaded via authExtraScopes
+  // (paraclaw#56).
   if (res.status === 403 && (await isScopeMismatch(res))) {
     clearTokens();
-    await beginLogin();
+    await beginLogin(extraScopes);
   }
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
@@ -325,11 +343,16 @@ export interface DetachVaultResult {
 
 export async function detachVault(
   folder: string,
-  options: { mcpName?: string; revokeToken?: boolean } = {},
+  options: { mcpName?: string; revokeToken?: boolean; authExtraScopes?: string[] } = {},
 ): Promise<DetachVaultResult> {
+  // `authExtraScopes` is opt-in: the route key is the agent-group folder, so
+  // the helper itself doesn't know the target vault. Callers on a vault-scoped
+  // page (VaultDetail) pass `[\`vault:\${name}:admin\`]` so a 403 from the
+  // server-side revoke step triggers a narrow-scoped re-auth (paraclaw#56).
   return request<DetachVaultResult>(`/groups/${encodeURIComponent(folder)}/detach-vault`, {
     method: 'POST',
     json: { mcpName: options.mcpName, revokeToken: options.revokeToken === true },
+    authExtraScopes: options.authExtraScopes,
   });
 }
 
@@ -394,15 +417,20 @@ export interface MintedVaultToken {
 }
 
 export async function mintVaultToken(name: string, input: MintVaultTokenInput): Promise<MintedVaultToken> {
+  // Vault enforces `vault:<name>:admin` on this endpoint; thread it through
+  // so a 403 scope-mismatch triggers re-auth with the narrow scope appended,
+  // not just the broad REQUESTED_SCOPES set (paraclaw#56).
   return request<MintedVaultToken>(`/vaults/${encodeURIComponent(name)}/tokens`, {
     method: 'POST',
     json: input,
+    authExtraScopes: [`vault:${name}:admin`],
   });
 }
 
 export async function revokeVaultToken(name: string, id: string): Promise<void> {
   return request<void>(`/vaults/${encodeURIComponent(name)}/tokens/${encodeURIComponent(id)}`, {
     method: 'DELETE',
+    authExtraScopes: [`vault:${name}:admin`],
   });
 }
 

--- a/web/ui/src/routes/VaultDetail.test.tsx
+++ b/web/ui/src/routes/VaultDetail.test.tsx
@@ -192,6 +192,7 @@ describe('VaultDetail — detach modal', () => {
       expect(api.detachVault).toHaveBeenCalledWith('research', {
         mcpName: 'parachute-vault',
         revokeToken: true,
+        authExtraScopes: ['vault:work:admin'],
       });
     });
   });
@@ -224,6 +225,7 @@ describe('VaultDetail — detach modal', () => {
       expect(api.detachVault).toHaveBeenCalledWith('research', {
         mcpName: 'parachute-vault',
         revokeToken: false,
+        authExtraScopes: ['vault:work:admin'],
       });
     });
   });

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -322,6 +322,7 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
 
       {detachTarget && (
         <DetachModal
+          vaultName={name}
           target={detachTarget}
           onClose={(result) => {
             setDetachTarget(null);
@@ -817,10 +818,12 @@ interface DetachOutcome {
 }
 
 function DetachModal({
+  vaultName,
   target,
   onClose,
   onError,
 }: {
+  vaultName: string;
   target: VaultAttachedGroup;
   onClose: (result: DetachOutcome | null) => void;
   onError: (message: string) => void;
@@ -839,9 +842,13 @@ function DetachModal({
   const detach = async (revokeToken: boolean) => {
     setBusy(true);
     try {
+      // Thread the narrow per-vault admin scope so a 403 on the server-side
+      // revoke path triggers re-auth with the right scope (paraclaw#56) —
+      // only matters when revokeToken is true, but harmless otherwise.
       const result = await detachVault(target.folder, {
         mcpName: target.mcpName,
         revokeToken,
+        authExtraScopes: [`vault:${vaultName}:admin`],
       });
       onClose({
         group: result.group.folder,


### PR DESCRIPTION
Closes paraclaw#56.

## Problem

Mint / revoke / detach-with-revoke from `/claw/vaults/:name` hit vault 403 with body `requires the 'vault:<name>:admin' scope` when the operator's JWT carries the broad `vault:*` set but no narrow per-vault admin. paraclaw surfaced the message verbatim — the operator had no path forward except `localStorage.clear()`.

The page-load gate (paraclaw#38 Phase 3) already handles this correctly via the `auth-gate` state. The mutation paths short-circuited it because `request<T>` already detects scope-mismatch 403s but called `beginLogin()` without `extraScopes`, so re-auth landed the same broad JWT and looped.

## Fix

Two changes in `web/ui/src/lib/api.ts`:

1. **Thread `authExtraScopes?: string[]`** through `request<T>` and forward to `beginLogin()` on the 401-after-refresh-failure and 403 scope-mismatch paths. Vault token-mgmt helpers (`mintVaultToken`, `revokeVaultToken`, `detachVault` via opt-in option) pass `[\`vault:\${name}:admin\`]`.
2. **Loosen the scope-mismatch regex** from `[\w:]+` to `['"]?[\w:]+['"]?` so it matches the vault server's single-quoted format. The original regex missed vault errors entirely — that's the second half of the bug.

`VaultDetail.tsx` threads the vault `name` to `DetachModal` so the detach call passes the narrow scope.

## Test addition

New `web/ui/src/lib/api.test.ts` exercises `request<T>` end-to-end against a mocked fetch + auth: each mutation helper threads the right scope to `beginLogin`, and non-scope 403s still throw `HttpError` without triggering re-auth.

## Gates

- web/ui `pnpm test` — **12 passed (12)**
- web/ui `pnpm typecheck` — clean
- web/ui `pnpm build` — clean (`365.15 kB` bundle, `/claw/`-prefixed)
- host `pnpm test` — **360 passed (41 files)**
- host `pnpm typecheck` — clean
- host `pnpm lint` — **144 problems (8 errors, 136 warnings)** — pre-existing baseline; lint targets `src/` only and this PR touches only `web/ui/`

## Version

`0.0.14-rc.18` → `0.0.14-rc.19`.

## Test plan

- [ ] On `/claw/vaults/<name>` with a JWT lacking `vault:<name>:admin`, click Mint → operator is bounced to `/oauth/authorize` with the narrow scope appended → after consent, mint succeeds.
- [ ] Same flow with Revoke and Detach + revoke.
- [ ] Non-scope 403 (e.g. paraclaw-side claw:admin missing) still surfaces as a banner without bouncing to OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)