### PR TITLE
Nit bundle: post-vault-mgmt PR review follow-ups (rc.20)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,16 @@ Instructions here...
 
 Test your contribution on a fresh clone before submitting. For skills, run the skill end-to-end and verify it works.
 
+### web/ui test harness
+
+The frontend bundle in `web/ui/` is intentionally outside the pnpm workspace (the `web:build` script uses `--ignore-workspace`), so a root-level `pnpm install` does **not** populate `web/ui/node_modules`. If you're running web/ui tests, install its deps first:
+
+```bash
+cd web/ui && pnpm install --ignore-workspace && pnpm test
+```
+
+Otherwise the runner exits with `ERR_MODULE_NOT_FOUND: @vitejs/plugin-react`.
+
 ## Pull Requests
 
 ### Before opening

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.19",
+  "version": "0.0.14-rc.20",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/channels/telegram-pairing.test.ts
+++ b/src/channels/telegram-pairing.test.ts
@@ -71,9 +71,15 @@ describe('createPairing', () => {
   });
 
   it('does not collide with active codes', async () => {
+    // Use distinct intents per pairing — `createPairing('main')` invalidates
+    // the previous pending 'main' so only one stays active at a time, which
+    // means the collision-avoidance loop is never actually exercised. With
+    // distinct intents all N stay pending and `generateCode` has to dodge
+    // every one. (Using a single intent with 20 iterations was a birthday-
+    // paradox flake — ~2% collision rate across 10k codes.)
     const codes = new Set<string>();
     for (let i = 0; i < 20; i++) {
-      const r = await createPairing('main');
+      const r = await createPairing({ kind: 'wire-to', folder: `g-${i}` });
       expect(codes.has(r.code)).toBe(false);
       codes.add(r.code);
     }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -623,7 +623,19 @@ async function handleApi(
             return;
           }
           const tokens = (list.body as { tokens?: { id: string; label: string }[] }).tokens ?? [];
-          const match = tokens.find((t) => t.label === attachment.tokenLabel);
+          const matches = tokens.filter((t) => t.label === attachment.tokenLabel);
+          // Vault labels are not unique at the protocol level. If two tokens
+          // share this label, picking the first is deterministic but silent —
+          // log so the operator has signal on the host side.
+          if (matches.length > 1) {
+            log.warn('vault detach: ambiguous token label, revoking first match', {
+              folder,
+              tokenLabel: attachment.tokenLabel,
+              matchCount: matches.length,
+              ids: matches.map((m) => m.id),
+            });
+          }
+          const match = matches[0] ?? null;
           if (!match) {
             // Label has no matching token — already revoked or never minted.
             // Continue with detach but report the discrepancy in the response.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -391,9 +391,17 @@ async function handleApi(
           // Implicit mint: forward operator's JWT to the vault. The shell-out
           // path that used to live here (`mintVaultToken`) is gone — see
           // docs/design/2026-04-29-vault-management-ui.md § Admin auth model.
+          // Defense-in-depth — gate() ahead of this should have rejected an
+          // unauth'd request, but if the header is somehow empty, fail loud
+          // here rather than forwarding `Authorization: ` to vault.
+          const authHeader = req.headers.authorization ?? '';
+          if (!authHeader) {
+            error(res, 401, 'auto-mint requires Authorization header');
+            return;
+          }
           const minted = await mintVaultTokenHttp({
             vaultBaseUrl,
-            authHeader: req.headers.authorization ?? '',
+            authHeader,
             label: tokenLabel,
             scopes: [scope],
           });
@@ -494,9 +502,14 @@ async function handleApi(
 
         let token = body.token;
         if (!token) {
+          const authHeader = req.headers.authorization ?? '';
+          if (!authHeader) {
+            error(res, 401, 'auto-mint requires Authorization header');
+            return;
+          }
           const minted = await mintVaultTokenHttp({
             vaultBaseUrl,
-            authHeader: req.headers.authorization ?? '',
+            authHeader,
             label: tokenLabel,
             scopes: [scope],
           });

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -25,6 +25,13 @@ vi.mock('./auth.ts', () => ({
 }));
 
 beforeEach(() => {
+  // Each test does `await import('./api.ts')` after stubbing fetch. Without
+  // resetModules, vitest hands back the already-evaluated module from the
+  // first test in the file, so later tests see the *first* test's stubbed
+  // fetch — leading to false greens or confusing failures when one body
+  // shape is tested while another should fire. Reset between tests so
+  // every dynamic import re-evaluates against the current global stub.
+  vi.resetModules();
   vi.mocked(auth.getAccessToken).mockReturnValue('cached-token');
   // Reject so the `await beginLogin(...)` in request<T> resolves the chain
   // and the caller's promise settles — letting us await + assert.

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -138,6 +138,12 @@ export function GroupDetail() {
     setSubmitting(true);
     setFlash(null);
     try {
+      // No `authExtraScopes` here on purpose — this surface isn't vault-
+      // scoped (the agent group may be attached to any vault) so we can't
+      // cleanly thread `vault:<name>:admin`. A 403 falls back to the broad
+      // re-auth set, which is the pre-paraclaw#56 behavior. The narrow-
+      // scope path lives on the per-vault detail page (VaultDetail.tsx),
+      // where the vault name is known at the call site.
       const result = await detachVault(folder);
       setGroup(result.group);
       setFlash({

--- a/web/ui/src/routes/VaultDetail.test.tsx
+++ b/web/ui/src/routes/VaultDetail.test.tsx
@@ -225,7 +225,7 @@ describe('VaultDetail — detach modal', () => {
       expect(api.detachVault).toHaveBeenCalledWith('research', {
         mcpName: 'parachute-vault',
         revokeToken: false,
-        authExtraScopes: ['vault:work:admin'],
+        authExtraScopes: undefined,
       });
     });
   });

--- a/web/ui/src/routes/VaultDetail.test.tsx
+++ b/web/ui/src/routes/VaultDetail.test.tsx
@@ -136,6 +136,52 @@ describe('VaultDetail — mint flow', () => {
   });
 });
 
+describe('VaultDetail — dismiss without copying', () => {
+  it('renders the warn-banner when the operator closes the card without copying', async () => {
+    const minted: api.MintedVaultToken = {
+      token: 'pvt_uncopied_secret',
+      id: 't_unc',
+      label: 'claw-uncopied',
+      scopes: ['vault:read'],
+      created_at: '2026-04-29T10:00:00Z',
+    };
+    vi.mocked(api.mintVaultToken).mockResolvedValue(minted);
+
+    const user = userEvent.setup();
+    renderAt('/vaults/work');
+
+    await waitFor(() => {
+      expect(screen.getByText('Mint new token')).toBeInTheDocument();
+    });
+
+    const labelInput = screen.getByLabelText('Label') as HTMLInputElement;
+    await user.clear(labelInput);
+    await user.type(labelInput, 'claw-uncopied');
+    await user.click(screen.getByRole('button', { name: 'Mint token' }));
+
+    // Plaintext appears in the copy-card
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('pvt_uncopied_secret')).toBeInTheDocument();
+    });
+
+    // Operator closes the card WITHOUT clicking Copy.
+    await user.click(screen.getByRole('button', { name: 'Close without copying' }));
+
+    // Warn-banner appears, naming the token by label, with both inline
+    // Revoke and Dismiss CTAs.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/was minted but you didn't copy the plaintext/),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Revoke claw-uncopied' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+
+    // Plaintext is gone from the DOM — vault stored only a hash.
+    expect(screen.queryByDisplayValue('pvt_uncopied_secret')).not.toBeInTheDocument();
+  });
+});
+
 describe('VaultDetail — revoke modal', () => {
   it('opens confirm modal with one-way copy and only revokes on explicit click', async () => {
     vi.mocked(api.revokeVaultToken).mockResolvedValue(undefined);

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -906,6 +906,7 @@ function DetachModal({
               onClick={() => void detach(false)}
               disabled={busy}
               autoFocus
+              style={{ cursor: 'default' }}
             >
               Keep token
             </button>

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -72,7 +72,13 @@ export function VaultDetail() {
   useEffect(() => {
     if (!name) return;
     let cancelled = false;
-    setState({ kind: 'loading' });
+    // Skip the loading-skeleton transition on reloads — keep the existing
+    // LoadedView mounted so its ephemeral local state (mintedDismissed,
+    // pre-targeted modals, etc.) survives the round-trip. Initial mount
+    // still shows the skeleton because state starts as { kind: 'loading' }.
+    setState((prev) =>
+      prev.kind === 'ok' || prev.kind === 'auth-gate' ? prev : { kind: 'loading' },
+    );
 
     (async () => {
       // Load detail (claw:read) and tokens (claw:admin + vault:<name>:admin)

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -222,7 +222,10 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
   const [detachTarget, setDetachTarget] = useState<VaultAttachedGroup | null>(null);
   const [minted, setMinted] = useState<MintedVaultToken | null>(null);
   const [mintedCopied, setMintedCopied] = useState(false);
-  const [mintedDismissed, setMintedDismissed] = useState<{ token: MintedVaultToken } | null>(null);
+  // Only id + label here — the full MintedVaultToken carries the plaintext,
+  // and we only need the label for display + id to look up the live
+  // VaultToken if the operator clicks the inline 'Revoke' shortcut.
+  const [mintedDismissed, setMintedDismissed] = useState<{ id: string; label: string } | null>(null);
 
   const onMinted = (token: MintedVaultToken) => {
     setMinted(token);
@@ -233,11 +236,23 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
 
   const onCloseMinted = (copied: boolean) => {
     if (minted && !copied) {
-      setMintedDismissed({ token: minted });
+      setMintedDismissed({ id: minted.id, label: minted.label });
     }
     setMinted(null);
     setMintedCopied(false);
     reload();
+  };
+
+  const onRevokeFromBanner = () => {
+    if (!mintedDismissed) return;
+    const live = state.tokens.find((t) => t.id === mintedDismissed.id);
+    // The reload() in onCloseMinted should have populated state.tokens with
+    // the new id; if it hasn't (race or vault hiccup), fall through silently
+    // — the operator can still revoke from the tokens list.
+    if (live) {
+      setRevokeTarget(live);
+      setMintedDismissed(null);
+    }
   };
 
   return (
@@ -263,10 +278,13 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
 
       {mintedDismissed && (
         <div className="warn-banner" style={{ marginTop: '1rem' }}>
-          Token <code>{mintedDismissed.token.label}</code> was minted but you didn't copy the
+          Token <code>{mintedDismissed.label}</code> was minted but you didn't copy the
           plaintext. The plaintext is gone — vault stores only a hash. Revoke this token now and
           mint a new one if you need access.
           <div className="actions" style={{ marginTop: '0.5rem' }}>
+            <button type="button" className="danger" onClick={onRevokeFromBanner}>
+              Revoke {mintedDismissed.label}
+            </button>
             <button
               type="button"
               className="secondary"

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -842,13 +842,15 @@ function DetachModal({
   const detach = async (revokeToken: boolean) => {
     setBusy(true);
     try {
-      // Thread the narrow per-vault admin scope so a 403 on the server-side
-      // revoke path triggers re-auth with the right scope (paraclaw#56) —
-      // only matters when revokeToken is true, but harmless otherwise.
+      // Thread the narrow per-vault admin scope only when we're actually
+      // calling vault — Keep-token (revokeToken=false) just hits the
+      // paraclaw-side claw:write check, which the broad re-auth set
+      // already covers. Asking for vault:<name>:admin on the Keep path
+      // would be a no-op extra scope on the consent screen.
       const result = await detachVault(target.folder, {
         mcpName: target.mcpName,
         revokeToken,
-        authExtraScopes: [`vault:${vaultName}:admin`],
+        authExtraScopes: revokeToken ? [`vault:${vaultName}:admin`] : undefined,
       });
       onClose({
         group: result.group.folder,


### PR DESCRIPTION
## Summary

Bundle of 9 nit fixes filed during reviews of PR #41 / #46 / #48 / #57 (Phase 3 vault management). Per-issue commits, single PR, bumped to `0.0.14-rc.20`.

## Fixes (12 commits)

### Backend (paraclaw#41 era)
- **paraclaw#43** — `vault: guard empty authHeader before auto-mint` — `src/web/server.ts` two implicit-mint paths now reject explicitly with 401 when `Authorization` is absent, instead of forwarding empty creds to vault.
- **paraclaw#42** — `vault: warn on duplicate token labels in detach+revoke` — switched `find` → `filter` and emit a `log.warn` on multi-match before revoking the first; surfaces the ambiguity instead of silently picking one.

### Tests / flake (paraclaw#46 era)
- **paraclaw#47** — `tests: fix flaky telegram-pairing collision test` — root-cause was that `createPairing('main')` invalidates the previous pending `'main'` pairing, so the collision-avoidance loop in `generateCode` was never exercised; the test was just rolling 20 random 4-digit codes (~2% birthday-paradox flake). Now uses distinct intents per iteration so all 20 stay pending.

### Frontend Phase 3 (paraclaw#48 era)
- **paraclaw#51** — `docs: web/ui test-harness bootstrap` — CONTRIBUTING.md notes the `cd web/ui && pnpm install --ignore-workspace && pnpm test` step (web/ui is intentionally outside the pnpm workspace).
- **paraclaw#49** — `ui: cursor: default on Keep-token button` — modal default-action button no longer raises a pointer cursor incongruously.
- **paraclaw#52 + paraclaw#50** — `ui: tighten mintedDismissed state + add inline Revoke shortcut` — `mintedDismissed` now stores `{ id, label }` rather than the full `MintedVaultToken` (less plaintext on the heap), and the warn-banner gets an inline `Revoke {label}` CTA so the operator doesn't have to scroll to the tokens table.
- **paraclaw#53** — `ui-tests: cover dismiss-without-copy warn-banner` — closes the test gap between the existing 'mint + copy' happy-path and the dismiss-without-copy recovery flow.
- **paraclaw#50/#52 follow-up** — `ui: skip loading skeleton on reload so LoadedView state survives` — surfaced by the #53 test: `reload()` was setting parent state back to `{ kind: 'loading' }`, unmounting `LoadedView` and wiping `mintedDismissed` (banner was effectively dead code). Guard the loading transition: keep existing data on screen during refetch.

### PR #57 era
- **paraclaw#58** — `ui: comment GroupDetail detach intent re: authExtraScopes` — explains why GroupDetail's detach call doesn't pass `authExtraScopes` (vault name not known at this surface).
- **paraclaw#59** — `ui: drop authExtraScopes on Keep-token detach` — only thread `vault:<name>:admin` when `revokeToken=true`; Keep-token never touches the vault, so the narrow scope hint over-asks.
- **paraclaw#60** — `ui-tests: vi.resetModules() in api.test.ts beforeEach` — each test does dynamic `await import('./api.ts')` after stubbing fetch; without resetModules, vitest hands back the cached module from the first test.

## Deferred (per team-lead's brief — bigger than nit-scale)

- **paraclaw#44** — cache attached-by-label across detach+revoke calls. Real perf win but needs a small store with TTL; not nit-scale.
- **paraclaw#45** — test the detach+revoke 'label gone' branch. Needs handler extraction or full e2e scaffolding from server.ts; the existing `vaults.test.ts` doesn't cover the `attach-vault` / `detach-vault` paths, so adding this test would require non-trivial test infra.

## Gate counts

- **host** `pnpm test`: **41 files / 360 tests passed** (1.64s)
- **host** `pnpm typecheck`: clean
- **host** `pnpm lint`: clean
- **web/ui** `pnpm test`: **2 files / 13 tests passed** (993ms; +1 test for #53)
- **web/ui** `pnpm typecheck`: clean
- **web/ui** `pnpm build`: clean (`365.40 kB` → `106.17 kB` gzip)

## Version

`0.0.14-rc.19` → `0.0.14-rc.20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)