### PR TITLE
Disable inline Revoke when token missing from live list (paraclaw#62)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.20",
+  "version": "0.0.14-rc.21",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/web/ui/src/routes/VaultDetail.test.tsx
+++ b/web/ui/src/routes/VaultDetail.test.tsx
@@ -180,6 +180,58 @@ describe('VaultDetail — dismiss without copying', () => {
     // Plaintext is gone from the DOM — vault stored only a hash.
     expect(screen.queryByDisplayValue('pvt_uncopied_secret')).not.toBeInTheDocument();
   });
+
+  it('disables the inline Revoke button when the token is not in the live list (paraclaw#62)', async () => {
+    // Race / id-mismatch path: operator dismisses without copying, but the
+    // post-mint reload returns a tokens list that doesn't include the new
+    // id (vault hiccup, server-side rename, etc.). The CTA must visibly
+    // disable rather than silently no-op on click.
+    const minted: api.MintedVaultToken = {
+      token: 'pvt_lost_secret',
+      id: 't_lost',
+      label: 'claw-lost',
+      scopes: ['vault:read'],
+      created_at: '2026-04-30T10:00:00Z',
+    };
+    vi.mocked(api.mintVaultToken).mockResolvedValue(minted);
+    // First call (initial render) returns the seeded sampleTokens; every
+    // subsequent call (the post-mint reload) returns an empty list, so the
+    // banner's `live` lookup misses.
+    vi.mocked(api.listVaultTokens)
+      .mockReset()
+      .mockResolvedValueOnce(sampleTokens)
+      .mockResolvedValue([]);
+
+    const user = userEvent.setup();
+    renderAt('/vaults/work');
+
+    await waitFor(() => {
+      expect(screen.getByText('Mint new token')).toBeInTheDocument();
+    });
+
+    const labelInput = screen.getByLabelText('Label') as HTMLInputElement;
+    await user.clear(labelInput);
+    await user.type(labelInput, 'claw-lost');
+    await user.click(screen.getByRole('button', { name: 'Mint token' }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('pvt_lost_secret')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Close without copying' }));
+
+    // Wait for the post-dismiss reload to settle so the empty tokens list
+    // is reflected in `state.tokens`.
+    await waitFor(() => {
+      expect(screen.queryByText(/Tokens \(1\)/)).not.toBeInTheDocument();
+    });
+
+    const revokeBtn = screen.getByRole('button', { name: 'Revoke claw-lost' });
+    expect(revokeBtn).toBeDisabled();
+    expect(revokeBtn).toHaveAttribute(
+      'title',
+      'Token no longer in current list — see tokens table below',
+    );
+  });
 });
 
 describe('VaultDetail — revoke modal', () => {

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -249,14 +249,18 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
     reload();
   };
 
+  // Derive the live VaultToken for the banner's inline Revoke CTA. Computed
+  // outside the handler so the JSX can disable the button + show a tooltip
+  // when the lookup misses (race vs. reload, or vault renamed the id post-
+  // mint). Without this guard, clicking the button is inert and the operator
+  // sees no feedback.
+  const liveDismissedToken = mintedDismissed
+    ? (state.tokens.find((t) => t.id === mintedDismissed.id) ?? null)
+    : null;
+
   const onRevokeFromBanner = () => {
-    if (!mintedDismissed) return;
-    const live = state.tokens.find((t) => t.id === mintedDismissed.id);
-    // The reload() in onCloseMinted should have populated state.tokens with
-    // the new id; if it hasn't (race or vault hiccup), fall through silently
-    // — the operator can still revoke from the tokens list.
-    if (live) {
-      setRevokeTarget(live);
+    if (liveDismissedToken) {
+      setRevokeTarget(liveDismissedToken);
       setMintedDismissed(null);
     }
   };
@@ -288,7 +292,17 @@ function LoadedView({ name, state, reload }: LoadedViewProps) {
           plaintext. The plaintext is gone — vault stores only a hash. Revoke this token now and
           mint a new one if you need access.
           <div className="actions" style={{ marginTop: '0.5rem' }}>
-            <button type="button" className="danger" onClick={onRevokeFromBanner}>
+            <button
+              type="button"
+              className="danger"
+              onClick={onRevokeFromBanner}
+              disabled={!liveDismissedToken}
+              title={
+                liveDismissedToken
+                  ? undefined
+                  : 'Token no longer in current list — see tokens table below'
+              }
+            >
               Revoke {mintedDismissed.label}
             </button>
             <button


### PR DESCRIPTION
## Summary

Reviewer follow-up from PR #61 on the warn-banner inline Revoke CTA. When the post-mint reload doesn't surface the new token id (race or vault-side rename), `live` was undefined and clicking `Revoke {label}` was inert — operator saw no feedback. Per #62, leaning **option 2**: disable the button + tooltip when the token isn't in the live list.

## Fix

- Hoist the live-token lookup out of the click handler into a derived `liveDismissedToken` computed at render time, so JSX and the handler share one nullable.
- `disabled={!liveDismissedToken}` on the button, plus a `title` attribute pointing the operator to the tokens table when the lookup misses.

## Test

- New `it('disables the inline Revoke button when the token is not in the live list (paraclaw#62)')` mocks `listVaultTokens` with `mockReset().mockResolvedValueOnce(sampleTokens).mockResolvedValue([])` so the initial render sees tokens but every reload after the mint returns empty.
- Asserts the button has `disabled` and the fallback `title` text.

## Gates

- web/ui `pnpm test`: 2 files / 14 tests passed (was 13)
- host `pnpm test`: 41 files / 360 tests passed
- host `pnpm typecheck`: clean
- host `pnpm lint`: clean
- web/ui `pnpm typecheck`: clean
- web/ui `pnpm build`: clean (365.49 kB → 106.21 kB gzip)

## Version

0.0.14-rc.20 → 0.0.14-rc.21

Closes #62