### PR TITLE
fix: thread per-vault scope through attach + create re-auth (paraclaw#65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.21",
+  "version": "0.0.14-rc.22",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -128,6 +128,69 @@ describe('detachVault — auth gate on 403', () => {
   });
 });
 
+describe('attachVault — auth gate on 403', () => {
+  it('threads authExtraScopes from caller through to beginLogin (paraclaw#65)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(403, {
+        error: "vault token mint failed: This endpoint requires the 'vault:techne:admin' scope",
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.attachVault(
+        'techne',
+        { scope: 'vault:read', vaultBaseUrl: 'https://example/vault/techne' },
+        { authExtraScopes: ['vault:techne:admin'] },
+      ),
+    ).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(['vault:techne:admin']);
+  });
+
+  it('omits scope hint when caller did not supply one', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "vault token mint failed: This endpoint requires the 'vault:techne:admin' scope",
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.attachVault('techne', { scope: 'vault:read', vaultBaseUrl: 'https://example/vault/techne' }),
+    ).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('createGroup — auth gate on 403', () => {
+  it('threads authExtraScopes when create-with-attach 403s on vault scope (paraclaw#65)', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(403, {
+        error: "vault token mint failed: This endpoint requires the 'vault:techne:admin' scope",
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await expect(
+      api.createGroup(
+        {
+          name: 'Techne',
+          folder: 'techne',
+          vault: { scope: 'vault:read', vaultBaseUrl: 'https://example/vault/techne' },
+        },
+        { authExtraScopes: ['vault:techne:admin'] },
+      ),
+    ).rejects.toThrow(/beginLogin called/);
+
+    expect(auth.beginLogin).toHaveBeenCalledWith(['vault:techne:admin']);
+  });
+});
+
 describe('non-scope 403 does NOT trigger re-auth', () => {
   it('throws HttpError(403) when body is unrelated', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, { error: 'forbidden' }));

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -217,11 +217,22 @@ export interface CreateGroupInput {
   };
 }
 
-export async function createGroup(input: CreateGroupInput): Promise<{
+export async function createGroup(
+  input: CreateGroupInput,
+  // Same scope-threading rationale as `attachVault`: when `input.vault` is
+  // set, the create handler runs the implicit-mint via the operator's JWT
+  // and 403s if it lacks `vault:<name>:admin`. NewGroupWizard knows the
+  // picked vault name and threads it; an attach-less create can omit it.
+  options: { authExtraScopes?: string[] } = {},
+): Promise<{
   group: AgentGroupView;
   mintedVaultToken: boolean;
 }> {
-  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(`/groups`, { method: 'POST', json: input });
+  return request<{ group: AgentGroupView; mintedVaultToken: boolean }>(`/groups`, {
+    method: 'POST',
+    json: input,
+    authExtraScopes: options.authExtraScopes,
+  });
 }
 
 // --- Vaults ---
@@ -320,10 +331,17 @@ export async function attachVault(
     token?: string;
     mcpName?: string;
   },
+  // The server-side `/attach-vault` handler forwards the operator's JWT to
+  // the vault for the implicit-mint step. If the JWT is missing
+  // `vault:<name>:admin`, the vault 403s — and a re-auth without the narrow
+  // scope just loops (paraclaw#56). Callers that know the picked vault name
+  // (GroupDetail, NewGroupWizard) thread it here so consent grants the
+  // right scope.
+  options: { authExtraScopes?: string[] } = {},
 ): Promise<{ group: AgentGroupView; mintedToken: boolean }> {
   return request<{ group: AgentGroupView; mintedToken: boolean }>(
     `/groups/${encodeURIComponent(folder)}/attach-vault`,
-    { method: 'POST', json: input },
+    { method: 'POST', json: input, authExtraScopes: options.authExtraScopes },
   );
 }
 

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -80,12 +80,24 @@ export function GroupDetail() {
     setSubmitting(true);
     setFlash(null);
     try {
-      const result = await attachVault(folder, {
-        scope,
-        vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
-        tokenLabel: tokenLabel.trim() || undefined,
-        token: pasteToken.trim() || undefined,
-      });
+      // Thread the picked vault name into re-auth on 403. The server's
+      // implicit-mint forwards our JWT to the vault, which 403s on missing
+      // `vault:<name>:admin` — without this hint, beginLogin would re-auth
+      // with broad scopes only, the new JWT would still lack the narrow
+      // scope, and we'd loop. (Detach below intentionally omits this — the
+      // detach path doesn't know its target vault from the call site.)
+      const result = await attachVault(
+        folder,
+        {
+          scope,
+          vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
+          tokenLabel: tokenLabel.trim() || undefined,
+          token: pasteToken.trim() || undefined,
+        },
+        {
+          authExtraScopes: pickedVaultName ? [`vault:${pickedVaultName}:admin`] : undefined,
+        },
+      );
       setGroup(result.group);
       setFlash({
         kind: 'ok',

--- a/web/ui/src/routes/NewGroupWizard.tsx
+++ b/web/ui/src/routes/NewGroupWizard.tsx
@@ -101,19 +101,28 @@ export function NewGroupWizard() {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const result = await createGroup({
-        name: name.trim(),
-        folder,
-        instructions: instructions.trim() || undefined,
-        vault: attachVault
-          ? {
-              scope,
-              vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
-              tokenLabel: tokenLabel.trim() || undefined,
-              token: pasteToken.trim() || undefined,
-            }
-          : undefined,
-      });
+      const result = await createGroup(
+        {
+          name: name.trim(),
+          folder,
+          instructions: instructions.trim() || undefined,
+          vault: attachVault
+            ? {
+                scope,
+                vaultBaseUrl: vaultBaseUrl.trim().replace(/\/+$/, ''),
+                tokenLabel: tokenLabel.trim() || undefined,
+                token: pasteToken.trim() || undefined,
+              }
+            : undefined,
+        },
+        {
+          // Same scope-threading as GroupDetail's attach: the create handler
+          // forwards our JWT to the vault for the implicit-mint, and a 403
+          // without this hint would loop on re-auth (paraclaw#56).
+          authExtraScopes:
+            attachVault && pickedVaultName ? [`vault:${pickedVaultName}:admin`] : undefined,
+        },
+      );
       navigate(`/groups/${encodeURIComponent(result.group.folder)}`);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

Fixes a live bug where Aaron's vault-attach (and create-with-attach) silently fails after the OAuth re-consent loop: the page returns from consent and the vault still shows unattached.

## The 403 → consent → no-replay loop

1. UI POSTs `/api/groups/:folder/attach-vault` with the user's broad JWT (`claw:admin claw:write vault:read vault:write`).
2. Paraclaw's `/attach-vault` handler forwards that JWT to the vault's `/tokens` mint endpoint.
3. The vault checks for `vault:<name>:admin` on the JWT — not present — and returns `403 { error: "This endpoint requires the 'vault:techne:admin' scope" }`.
4. The frontend's `request<T>` matches the scope-mismatch body, calls `clearTokens()`, then `beginLogin(extraScopes)` which `window.location.replace`s to consent.
5. **Bug:** `attachVault()` in `web/ui/src/lib/api.ts` did not thread `authExtraScopes`, so step 4 fired with `extraScopes = undefined`. The new JWT issued post-consent still lacks `vault:techne:admin`, **and** the original POST was abandoned by the redirect with no resume mechanism — so even if the new JWT had the scope, nothing replays.
6. User lands back on the page with broader-but-still-insufficient scopes, no attach POST in flight, and the UI shows "no vault attached."

`mintVaultToken` and `revokeVaultToken` already threaded scope through (paraclaw#56). `attachVault` and `createGroup` were missed — same JWT-forward shape, same gap.

## What this PR changes

1. **`attachVault()` in `web/ui/src/lib/api.ts:314`** — adds `options?: { authExtraScopes?: string[] }`, forwards into `request<T>`. Same pattern as the existing mint/revoke/detach helpers.
2. **`GroupDetail.tsx:onAttach`** — passes `authExtraScopes: pickedVaultName ? [\`vault:${pickedVaultName}:admin\`] : undefined`. Also fixes a misplaced comment that was justifying the no-scope detach path; rewrites it to contrast attach (always needs the scope) vs detach (only needs scope if `revokeToken`).
3. **NewGroupWizard create-with-attach** — confirmed the same shape: `POST /api/groups` with `vault: {...}` triggers the same server-side mint via the operator's JWT (`src/web/server.ts:370-445`). `createGroup()` got the same `options.authExtraScopes` treatment, and `NewGroupWizard.tsx:onCreate` threads `pickedVaultName` through.
4. **Regression tests** — three new vitest cases in `web/ui/src/lib/api.test.ts` covering (a) `attachVault` threads the scope, (b) `attachVault` omits when caller didn't supply, (c) `createGroup` threads the scope on the create-with-attach path. Same factory-per-call fetchMock shape as the existing detach tests.

## Followup (not in this PR)

Filed #64 — the resume-after-consent UX gap. Even with this fix, after consent the user has to click Attach again because the original POST is abandoned by `window.location.replace`. A `sessionStorage` intent record + replay-on-callback would close that loop across attach/mint/revoke/create-with-attach.

## Gates

| Gate | Result |
|---|---|
| `pnpm typecheck` (host) | clean |
| `pnpm test` (host) | 41 files / 360 tests, all green |
| `cd web/ui && pnpm typecheck` | clean |
| `cd web/ui && pnpm test` | 2 files / 17 tests (was 14, +3 for paraclaw#65), all green |
| `cd web/ui && pnpm build` | 365.66 kB → 106.26 kB gzip, clean |
| `pnpm lint` (host) | 144 problems / 8 errors — pre-existing baseline on main, unchanged. Web/ui changes aren't covered by host's `eslint src/` script. |

## Version

`0.0.14-rc.21` → `0.0.14-rc.22`.

Closes #65. References #64, #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)