### PR TITLE
feat(ui): /channels/new fast-path for additional channels (paraclaw#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,18 +71,18 @@ Exactly one writer per file — no cross-mount lock contention. Heartbeat is a f
 | `src/user-dm.ts` | Cold-DM resolution + `user_dms` cache |
 | `src/group-init.ts` | Per-agent-group filesystem scaffold (CLAUDE.md, skills, agent-runner-src overlay) |
 | `src/db/` | DB layer — agent_groups, messaging_groups, sessions, user_roles, user_dms, pending_*, migrations |
-| `src/channels/` | Channel adapter infra (registry, Chat SDK bridge); specific channel adapters are skill-installed from the `channels` branch |
+| `src/channels/` | Channel adapter infra (registry, Chat SDK bridge) plus the trunk-baked Discord and Telegram adapters; other channels are skill-installed from the `channels` branch |
 | `src/providers/` | Host-side provider container-config (`claude` baked in; `opencode` etc. installed from the `providers` branch) |
 | `container/agent-runner/src/` | Agent-runner: poll loop, formatter, provider abstraction, MCP tools, destinations |
 | `container/skills/` | Container skills mounted into every agent session |
 | `groups/<folder>/` | Per-agent-group filesystem (CLAUDE.md, skills, per-group `agent-runner-src/` overlay) |
 | `scripts/init-first-agent.ts` | Bootstrap the first DM-wired agent (used by `/init-first-agent` skill) |
 
-## Channels and Providers (skill-installed)
+## Channels and Providers
 
-Trunk does not ship any specific channel adapter or non-default agent provider. The codebase is the registry/infra; the actual adapters and providers live on long-lived sibling branches and get copied in by skills:
+Trunk bakes in the two adapters needed for the `/channels/new` fast path — **Discord** (`src/channels/discord.ts`) and **Telegram** (`src/channels/telegram.ts`) — along with their token validators (`src/web/{discord,telegram}-validate.ts`) and the `POST /api/channels/{adapter}/test` route. Anything else lives on long-lived sibling branches and is copied in by skills:
 
-- **`channels` branch** — Discord, Slack, Telegram, WhatsApp, Teams, Linear, GitHub, iMessage, Webex, Resend, Matrix, Google Chat, WhatsApp Cloud (+ helpers, tests, channel-specific setup steps). Installed via `/add-<channel>` skills.
+- **`channels` branch** — Slack, WhatsApp, Teams, Linear, GitHub, iMessage, Webex, Resend, Matrix, Google Chat, WhatsApp Cloud (+ helpers, tests, channel-specific setup steps). Installed via `/add-<channel>` skills.
 - **`providers` branch** — OpenCode (and any future non-default agent providers). Installed via `/add-opencode`.
 
 Each `/add-<name>` skill is idempotent: `git fetch origin <branch>` → copy module(s) into the standard paths → append a self-registration import to the relevant barrel → `pnpm install <pkg>@<pinned-version>` → build.

--- a/docs/audit/2026-04-30-channel-endpoint-audit.md
+++ b/docs/audit/2026-04-30-channel-endpoint-audit.md
@@ -1,0 +1,36 @@
+# Channel endpoint audit (paraclaw#67, Phase 2 prep)
+
+**Date:** 2026-04-30
+**Scope:** what server endpoints exist for channel install/test/wire on `main` vs. what the design doc and the abandoned `feat/setup-wizard-discord` branch assumed.
+
+The Phase 1 design doc flagged `/api/setup/install-channel` and `/api/channels/{adapter}/test` as "unclear-but-noted." This audit resolves them before impl begins so we don't write code that duplicates or contradicts existing surface.
+
+## Findings
+
+### 1. The validate/test handlers do not exist on `main`
+
+`POST /api/channels/discord/test` and `POST /api/channels/telegram/test` are referenced by the wizard's `WireChannelStep` only via the wizard's *idempotent shortcut* (which assumes the adapter is already installed). On main, `src/web/server.ts` does not register either route. The handlers were written on `feat/setup-wizard-discord` under the old `web/server/src/` layout (pre-reorg) and were never ported.
+
+The validator modules themselves (`discord-validate.ts`, `telegram-validate.ts`) and their tests are clean, well-typed, and portable. They will be lifted verbatim into `src/web/` as Phase 2 commit 2.
+
+### 2. The install-channel orchestrator is obsolete
+
+The 341-line `install-channel.ts` orchestrator on `feat/setup-wizard-discord` shells out to `.claude/skills/add-discord` / `add-telegram` to materialize an adapter. As of `main`:
+
+- `src/channels/discord.ts` and `src/channels/telegram.ts` are **trunk-baked** — present at install time, no skill installation needed.
+- `.claude/skills/add-discord` and `.claude/skills/add-telegram` no longer exist.
+- The setup wizard's "install channel" step is a no-op for both, masked by an idempotent shortcut.
+
+Implication for Phase 2: we do **not** need to port install-channel. The new `/channels/new` page can skip the install step entirely for trunk-baked adapters. Slack/WhatsApp/Teams remain "coming soon" and disabled in `ChannelPickStep.tsx`; their install path will be designed when those ship.
+
+### 3. Open question O1 ("reuse wizard install step") doesn't bind
+
+Aaron approved O1 in design review, but on the ground there is nothing to reuse: discord/telegram are already installed when the user lands, and slack/whatsapp aren't in scope. The new `/channels/new` page should hide the install section entirely for the supported adapters and surface a "coming soon" affordance for the rest.
+
+### 4. CLAUDE.md is stale on adapter packaging
+
+The repo-root `CLAUDE.md` states "trunk does not ship any specific channel adapter." That was true pre-reorg; it is not true today. Discord and Telegram are baked into the trunk install. Not fixed in this audit (out of scope), but flagging for a cleanup pass.
+
+## Phase 2 scope (narrowed)
+
+Result of the audit: Phase 2 is **server-light** (validators + 2 routes, ~395 LOC including tests, no DB migration) and **UI-bulky** (new page, descriptor table, picker extraction, ChannelsList re-link, wizard refactor). Single PR, per-feature commits.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.23",
+  "version": "0.0.14-rc.24",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/web/discord-validate.test.ts
+++ b/src/web/discord-validate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Discord token validator covers the four outcomes the wizard cares about:
+ *   1. Valid bot token → identity returned.
+ *   2. 401 from Discord → friendly "rejected token" error.
+ *   3. 200 from Discord but `bot=false` → reject (we require bots).
+ *   4. Network error → 502 surfacing the underlying message.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { validateDiscordBotToken } from './discord-validate.js';
+
+function makeFetchStub(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 401);
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Unauthorized',
+    json: async () => body,
+  } as Response) as unknown as typeof fetch;
+}
+
+describe('validateDiscordBotToken', () => {
+  it('returns identity for a valid bot token', async () => {
+    const stub = makeFetchStub({ id: '1491573333382523708', username: 'parabot', discriminator: '0', bot: true });
+    const result = await validateDiscordBotToken('test-token', stub);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.identity.id).toBe('1491573333382523708');
+      expect(result.identity.username).toBe('parabot');
+      expect(result.identity.bot).toBe(true);
+    }
+    expect(stub).toHaveBeenCalledWith(
+      'https://discord.com/api/v10/users/@me',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bot test-token' }),
+      }),
+    );
+  });
+
+  it('rejects 401 from Discord with an actionable message', async () => {
+    const stub = makeFetchStub({}, { ok: false, status: 401 });
+    const result = await validateDiscordBotToken('bad', stub);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toMatch(/discord rejected/i);
+    }
+  });
+
+  it('rejects user tokens (bot=false)', async () => {
+    const stub = makeFetchStub({ id: '123', username: 'human', bot: false });
+    const result = await validateDiscordBotToken('user-token', stub);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/not a bot/i);
+    }
+  });
+
+  it('returns 502 on network error', async () => {
+    const stub = vi.fn().mockRejectedValue(new Error('ENOTFOUND')) as unknown as typeof fetch;
+    const result = await validateDiscordBotToken('whatever', stub);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/ENOTFOUND/);
+    }
+  });
+
+  it('rejects empty token without calling Discord', async () => {
+    const stub = vi.fn();
+    const result = await validateDiscordBotToken('   ', stub as unknown as typeof fetch);
+    expect(result.ok).toBe(false);
+    expect(stub).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/discord-validate.ts
+++ b/src/web/discord-validate.ts
@@ -1,0 +1,88 @@
+/**
+ * Validate a Discord bot token by calling Discord's `/users/@me`.
+ *
+ * The setup wizard captures a bot token from the operator and needs to verify
+ * three things before persisting it: the token authenticates, the account is
+ * a bot, and we know the bot's user id (which becomes the basis of
+ * `discord:@me:<userId>` for the proactive DM-channel wiring).
+ *
+ * Discord returns 401 for an invalid token; on 200 the body contains
+ * `{ id, username, discriminator?, bot, ... }` per the v10 reference. We do
+ * not require any extra OAuth scopes — bot tokens carry implicit identity.
+ *
+ * The fetch is injectable for tests; in production it shells through the
+ * default global `fetch`. Errors are returned, not thrown — the caller
+ * surfaces them as 4xx to the wizard step UI.
+ */
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export interface DiscordIdentity {
+  id: string;
+  username: string;
+  discriminator: string | null;
+  bot: boolean;
+}
+
+export type DiscordValidateResult =
+  | { ok: true; identity: DiscordIdentity }
+  | { ok: false; status: number; error: string };
+
+interface DiscordUserBody {
+  id?: unknown;
+  username?: unknown;
+  discriminator?: unknown;
+  bot?: unknown;
+}
+
+export async function validateDiscordBotToken(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DiscordValidateResult> {
+  const trimmed = token.trim();
+  if (!trimmed) return { ok: false, status: 400, error: 'token is empty' };
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${DISCORD_API}/users/@me`, {
+      headers: {
+        Authorization: `Bot ${trimmed}`,
+        Accept: 'application/json',
+      },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: `discord unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (res.status === 401) {
+    return { ok: false, status: 401, error: 'discord rejected token (401 Unauthorized)' };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      error: `discord ${res.status} ${res.statusText}`,
+    };
+  }
+
+  const body = (await res.json()) as DiscordUserBody;
+  if (typeof body.id !== 'string' || typeof body.username !== 'string') {
+    return { ok: false, status: 502, error: 'discord returned malformed user body' };
+  }
+  if (body.bot !== true) {
+    return { ok: false, status: 400, error: 'token is not a bot token (user.bot=false)' };
+  }
+
+  return {
+    ok: true,
+    identity: {
+      id: body.id,
+      username: body.username,
+      discriminator: typeof body.discriminator === 'string' ? body.discriminator : null,
+      bot: true,
+    },
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -234,13 +234,21 @@ async function handleApi(
   // to HTTP 400 so the SPA's auth wrapper doesn't mistake an upstream
   // identity rejection for our hub-JWT being expired and trigger a
   // re-auth loop. Body still carries the precise validator status field.
-  if (method === 'POST' && (pathname === '/api/channels/discord/test' || pathname === '/api/channels/telegram/test')) {
+  if (method === 'POST' && /^\/api\/channels\/[^/]+\/test$/.test(pathname)) {
     if (!(await gate(req, res, SCOPE_CLAW_WRITE))) return;
+    const adapter = pathname.split('/')[3];
+    if (adapter !== 'discord' && adapter !== 'telegram') {
+      // Without this branch, slack/whatsapp/etc fall through to the
+      // /api/channels/:id CRUD block and the operator sees a misleading
+      // "channel wire not found" instead of a clean unknown-adapter 404.
+      error(res, 404, `unknown adapter: ${adapter}`);
+      return;
+    }
     try {
       const body = await readJsonBody<{ token?: string }>(req);
       const token = body.token ?? '';
       const result =
-        pathname === '/api/channels/discord/test'
+        adapter === 'discord'
           ? await validateDiscordBotToken(token)
           : await validateTelegramBotToken(token);
       const httpStatus = result.ok ? 200 : result.status === 401 ? 400 : result.status;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -229,10 +229,12 @@ async function handleApi(
   // Token validation — pre-install, no DB writes, the wizard hits this from
   // /channels/new before persisting anything. claw:write is enough; the
   // /api/channels/* CRUD block below is admin-gated and would over-reject.
-  if (
-    method === 'POST' &&
-    (pathname === '/api/channels/discord/test' || pathname === '/api/channels/telegram/test')
-  ) {
+  //
+  // We remap a validator status of 401 ("bot token rejected by upstream")
+  // to HTTP 400 so the SPA's auth wrapper doesn't mistake an upstream
+  // identity rejection for our hub-JWT being expired and trigger a
+  // re-auth loop. Body still carries the precise validator status field.
+  if (method === 'POST' && (pathname === '/api/channels/discord/test' || pathname === '/api/channels/telegram/test')) {
     if (!(await gate(req, res, SCOPE_CLAW_WRITE))) return;
     try {
       const body = await readJsonBody<{ token?: string }>(req);
@@ -241,7 +243,8 @@ async function handleApi(
         pathname === '/api/channels/discord/test'
           ? await validateDiscordBotToken(token)
           : await validateTelegramBotToken(token);
-      json(res, result.ok ? 200 : result.status, result);
+      const httpStatus = result.ok ? 200 : result.status === 401 ? 400 : result.status;
+      json(res, httpStatus, result);
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));
     }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -248,9 +248,7 @@ async function handleApi(
       const body = await readJsonBody<{ token?: string }>(req);
       const token = body.token ?? '';
       const result =
-        adapter === 'discord'
-          ? await validateDiscordBotToken(token)
-          : await validateTelegramBotToken(token);
+        adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       const httpStatus = result.ok ? 200 : result.status === 401 ? 400 : result.status;
       json(res, httpStatus, result);
     } catch (err) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -66,6 +66,8 @@ import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 import { wireDmToAgent } from './wire-channel.js';
 import { getChannelAdapter } from '../channels/channel-registry.js';
+import { validateDiscordBotToken } from './discord-validate.js';
+import { validateTelegramBotToken } from './telegram-validate.js';
 
 const PROJECT_ROOT = process.cwd();
 const UI_DIST = path.resolve(PROJECT_ROOT, 'web/ui/dist');
@@ -222,6 +224,28 @@ async function handleApi(
       error(res, 500, err instanceof Error ? err.message : String(err));
       return;
     }
+  }
+
+  // Token validation — pre-install, no DB writes, the wizard hits this from
+  // /channels/new before persisting anything. claw:write is enough; the
+  // /api/channels/* CRUD block below is admin-gated and would over-reject.
+  if (
+    method === 'POST' &&
+    (pathname === '/api/channels/discord/test' || pathname === '/api/channels/telegram/test')
+  ) {
+    if (!(await gate(req, res, SCOPE_CLAW_WRITE))) return;
+    try {
+      const body = await readJsonBody<{ token?: string }>(req);
+      const token = body.token ?? '';
+      const result =
+        pathname === '/api/channels/discord/test'
+          ? await validateDiscordBotToken(token)
+          : await validateTelegramBotToken(token);
+      json(res, result.ok ? 200 : result.status, result);
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
   }
 
   if (pathname === '/api/channels' || pathname.startsWith('/api/channels/')) {

--- a/src/web/telegram-validate.test.ts
+++ b/src/web/telegram-validate.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Token validation paths for Telegram. Mirror of discord-validate.test.ts so
+ * the same wizard surface can render either result with one error shape.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { validateTelegramBotToken } from './telegram-validate.js';
+
+const VALID_TOKEN = '1234567890:ABCdefGhIJklmnopQRsTUvwxyz0123456789';
+
+function fakeFetch(impl: (url: string) => { status?: number; body: unknown }): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const { status = 200, body } = impl(url);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+describe('validateTelegramBotToken', () => {
+  it('rejects an empty token without fetching', async () => {
+    const result = await validateTelegramBotToken(
+      '   ',
+      (() => {
+        throw new Error('fetch should not be called');
+      }) as unknown as typeof fetch,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/empty/);
+    }
+  });
+
+  it('rejects a malformed token shape without fetching', async () => {
+    const result = await validateTelegramBotToken(
+      'not-a-real-token',
+      (() => {
+        throw new Error('fetch should not be called');
+      }) as unknown as typeof fetch,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/format invalid/);
+    }
+  });
+
+  it('returns identity on success', async () => {
+    const fetchImpl = fakeFetch(() => ({
+      status: 200,
+      body: {
+        ok: true,
+        result: { id: 6037840640, username: 'andy_bot', first_name: 'Andy', is_bot: true },
+      },
+    }));
+    const result = await validateTelegramBotToken(VALID_TOKEN, fetchImpl);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.identity.id).toBe(6037840640);
+      expect(result.identity.username).toBe('andy_bot');
+      expect(result.identity.firstName).toBe('Andy');
+      expect(result.identity.isBot).toBe(true);
+    }
+  });
+
+  it('rejects when telegram returns ok:false', async () => {
+    const fetchImpl = fakeFetch(() => ({
+      status: 401,
+      body: { ok: false, error_code: 401, description: 'Unauthorized' },
+    }));
+    const result = await validateTelegramBotToken(VALID_TOKEN, fetchImpl);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toMatch(/rejected token/i);
+    }
+  });
+
+  it('rejects a non-bot account', async () => {
+    const fetchImpl = fakeFetch(() => ({
+      status: 200,
+      body: {
+        ok: true,
+        result: { id: 1, username: 'human', first_name: 'Real Person', is_bot: false },
+      },
+    }));
+    const result = await validateTelegramBotToken(VALID_TOKEN, fetchImpl);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/not a bot/i);
+    }
+  });
+
+  it('returns 502 when telegram is unreachable', async () => {
+    const fetchImpl = (async () => {
+      throw new TypeError('network down');
+    }) as unknown as typeof fetch;
+    const result = await validateTelegramBotToken(VALID_TOKEN, fetchImpl);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/unreachable/);
+    }
+  });
+
+  it('returns 502 on malformed result body', async () => {
+    const fetchImpl = fakeFetch(() => ({
+      status: 200,
+      body: { ok: true, result: {} },
+    }));
+    const result = await validateTelegramBotToken(VALID_TOKEN, fetchImpl);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/malformed/);
+    }
+  });
+});

--- a/src/web/telegram-validate.test.ts
+++ b/src/web/telegram-validate.test.ts
@@ -21,12 +21,9 @@ function fakeFetch(impl: (url: string) => { status?: number; body: unknown }): t
 
 describe('validateTelegramBotToken', () => {
   it('rejects an empty token without fetching', async () => {
-    const result = await validateTelegramBotToken(
-      '   ',
-      (() => {
-        throw new Error('fetch should not be called');
-      }) as unknown as typeof fetch,
-    );
+    const result = await validateTelegramBotToken('   ', (() => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(400);
@@ -35,12 +32,9 @@ describe('validateTelegramBotToken', () => {
   });
 
   it('rejects a malformed token shape without fetching', async () => {
-    const result = await validateTelegramBotToken(
-      'not-a-real-token',
-      (() => {
-        throw new Error('fetch should not be called');
-      }) as unknown as typeof fetch,
-    );
+    const result = await validateTelegramBotToken('not-a-real-token', (() => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(400);

--- a/src/web/telegram-validate.ts
+++ b/src/web/telegram-validate.ts
@@ -1,0 +1,107 @@
+/**
+ * Validate a Telegram bot token by calling Telegram's `/getMe`.
+ *
+ * The setup wizard captures a bot token from the operator and needs to verify
+ * three things before persisting it: the token authenticates, the account is
+ * a bot (`is_bot=true`), and we know the bot's @username for the wizard's
+ * "now go DM @<username>" instruction in the test-message step.
+ *
+ * Telegram returns `{ ok: true, result: { id, username, first_name, is_bot, ... } }`
+ * on success; on auth failure the body is `{ ok: false, error_code: 401, description }`.
+ * Network failures bubble up as 502 with a clear unreachable message — same
+ * shape as discord-validate.ts so the wizard can render either with one
+ * surface.
+ *
+ * We also enforce the BotFather token shape (`<digits>:<35+ chars>`) before
+ * calling out: a clearly malformed token wastes a network round-trip and
+ * Telegram's 401 response is less useful than a local "token format invalid".
+ *
+ * The fetch is injectable for tests; in production it shells through the
+ * default global `fetch`.
+ */
+const TELEGRAM_API = 'https://api.telegram.org';
+const TOKEN_SHAPE = /^[0-9]+:[A-Za-z0-9_-]{35,}$/;
+
+export interface TelegramIdentity {
+  id: number;
+  username: string;
+  firstName: string;
+  isBot: boolean;
+}
+
+export type TelegramValidateResult =
+  | { ok: true; identity: TelegramIdentity }
+  | { ok: false; status: number; error: string };
+
+interface TelegramGetMeBody {
+  ok?: unknown;
+  result?: {
+    id?: unknown;
+    username?: unknown;
+    first_name?: unknown;
+    is_bot?: unknown;
+  };
+  description?: unknown;
+}
+
+export async function validateTelegramBotToken(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TelegramValidateResult> {
+  const trimmed = token.trim();
+  if (!trimmed) return { ok: false, status: 400, error: 'token is empty' };
+  if (!TOKEN_SHAPE.test(trimmed)) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'token format invalid (expected <digits>:<35+ chars>, e.g. 123456:ABCdef…)',
+    };
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${TELEGRAM_API}/bot${trimmed}/getMe`, {
+      headers: { Accept: 'application/json' },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      error: `telegram unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Telegram returns 401/404 for bad tokens but always with a JSON body.
+  // Parse first, then decide.
+  let body: TelegramGetMeBody;
+  try {
+    body = (await res.json()) as TelegramGetMeBody;
+  } catch {
+    return { ok: false, status: 502, error: `telegram returned non-JSON body (HTTP ${res.status})` };
+  }
+
+  if (body.ok !== true) {
+    const desc = typeof body.description === 'string' ? body.description : `HTTP ${res.status}`;
+    // 401 is the canonical "bad token" — surface as 401 for the wizard step.
+    const status = res.status === 401 || res.status === 404 ? 401 : res.status || 400;
+    return { ok: false, status, error: `telegram rejected token: ${desc}` };
+  }
+
+  const r = body.result;
+  if (!r || typeof r.id !== 'number' || typeof r.username !== 'string' || typeof r.first_name !== 'string') {
+    return { ok: false, status: 502, error: 'telegram returned malformed getMe body' };
+  }
+  if (r.is_bot !== true) {
+    return { ok: false, status: 400, error: 'token is not a bot token (result.is_bot=false)' };
+  }
+
+  return {
+    ok: true,
+    identity: {
+      id: r.id,
+      username: r.username,
+      firstName: r.first_name,
+      isBot: true,
+    },
+  };
+}

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { SessionsList } from "./routes/SessionsList.tsx";
 import { SetupWizard } from "./routes/SetupWizard.tsx";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
+import { WireChannelPage } from "./routes/WireChannelPage.tsx";
 
 export function App() {
   // The OAuth callback page is intentionally chrome-free — the user is
@@ -58,6 +59,7 @@ export function App() {
         <Route path="/vaults" element={<VaultsList />} />
         <Route path="/vaults/:name" element={<VaultDetail />} />
         <Route path="/channels" element={<ChannelsList />} />
+        <Route path="/channels/new" element={<WireChannelPage />} />
         <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />
         <Route path="/setup" element={<SetupWizard />} />

--- a/web/ui/src/components/AgentGroupPicker.tsx
+++ b/web/ui/src/components/AgentGroupPicker.tsx
@@ -1,0 +1,263 @@
+/**
+ * Picker that resolves an agent group — either an existing one (selected
+ * from the list) or a new one created inline. Lifted out of the setup
+ * wizard's step-6 component so the new /channels/new page can reuse the
+ * same UX without duplicating the folder-availability + slug-suggestion
+ * dance.
+ *
+ * The wizard's AgentGroupStep now thin-wraps this picker; the surface
+ * isn't aware of wizard steps, just "give me a group, then call onPicked".
+ *
+ * What this component is NOT:
+ *   - A vault-attach UI. Vault attach is offered on the group's detail page
+ *     after creation. Keeping the picker minimal means the wire-channel
+ *     flow stays under a minute.
+ *   - A pre-existing group editor. Click-through to /groups/:folder for that.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  checkFolderAvailability,
+  createGroup,
+  fetchFolderSuggestion,
+  listGroups,
+  type AgentGroupView,
+  type FolderAvailability,
+} from '../lib/api.ts';
+
+type Mode = 'pick' | 'create';
+
+export interface PickedGroup {
+  id: string;
+  folder: string;
+  name: string;
+}
+
+export interface AgentGroupPickerProps {
+  /** Called once a group is picked or created. The caller decides what's next. */
+  onPicked: (group: PickedGroup) => void;
+  /** When true, hides the "Pick existing" affordance — used in flows that
+   *  always want a fresh group. Default: false (offer pick when groups exist). */
+  forceCreate?: boolean;
+  /** Optional initial mode preference; ignored when there are 0 existing groups. */
+  initialMode?: Mode;
+}
+
+export function AgentGroupPicker({ onPicked, forceCreate = false, initialMode }: AgentGroupPickerProps) {
+  const [groups, setGroups] = useState<AgentGroupView[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>(initialMode ?? 'pick');
+
+  useEffect(() => {
+    let cancelled = false;
+    listGroups()
+      .then((g) => {
+        if (cancelled) return;
+        setGroups(g);
+        if (g.length === 0 || forceCreate) setMode('create');
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [forceCreate]);
+
+  if (loadError) {
+    return (
+      <div className="error-banner">
+        Couldn't load groups: <code>{loadError}</code>
+      </div>
+    );
+  }
+  if (!groups) {
+    return (
+      <ul className="skeleton-list" aria-busy="true">
+        <li className="skeleton skeleton-row" />
+      </ul>
+    );
+  }
+
+  const onPick = (g: AgentGroupView) => onPicked({ id: g.id, folder: g.folder, name: g.name });
+
+  return (
+    <div>
+      {!forceCreate && groups.length > 0 && (
+        <div className="row" style={{ marginTop: '0.5rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button className={mode === 'pick' ? '' : 'secondary'} onClick={() => setMode('pick')}>
+              Pick existing ({groups.length})
+            </button>
+            <button className={mode === 'create' ? '' : 'secondary'} onClick={() => setMode('create')}>
+              Create new
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mode === 'pick' && groups.length > 0 && (
+        <ul style={{ listStyle: 'none', padding: 0, marginTop: '0.5rem' }}>
+          {groups.map((g) => (
+            <li key={g.id} style={{ padding: '0.6rem 0', borderBottom: '1px solid var(--border)' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '0.75rem',
+                }}
+              >
+                <div>
+                  <strong>{g.name}</strong> <code className="dim">{g.folder}</code>
+                  {g.vault && (
+                    <span className="tag" style={{ marginLeft: '0.5rem' }}>
+                      {g.vault.scope}
+                    </span>
+                  )}
+                </div>
+                <button onClick={() => onPick(g)}>Use this group</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {mode === 'create' && <CreateGroupInline onCreated={onPicked} />}
+    </div>
+  );
+}
+
+function CreateGroupInline({ onCreated }: { onCreated: (g: PickedGroup) => void }) {
+  const [name, setName] = useState('');
+  const [folder, setFolder] = useState('');
+  const [folderTouched, setFolderTouched] = useState(false);
+  const [folderCheck, setFolderCheck] = useState<FolderAvailability | null>(null);
+  const [folderChecking, setFolderChecking] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-suggest folder slug from name.
+  useEffect(() => {
+    if (folderTouched) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setFolder('');
+      return;
+    }
+    let cancelled = false;
+    fetchFolderSuggestion(trimmed)
+      .then((slug) => !cancelled && !folderTouched && setFolder(slug))
+      .catch(() => {
+        // Suggestion failure is non-fatal; operator can type their own slug.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, folderTouched]);
+
+  // Debounced folder availability.
+  const checkTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!folder) {
+      setFolderCheck(null);
+      return;
+    }
+    if (checkTimer.current) clearTimeout(checkTimer.current);
+    setFolderChecking(true);
+    checkTimer.current = setTimeout(async () => {
+      try {
+        setFolderCheck(await checkFolderAvailability(folder));
+      } catch (err) {
+        setFolderCheck({
+          slug: folder,
+          valid: false,
+          available: false,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setFolderChecking(false);
+      }
+    }, 250);
+    return () => {
+      if (checkTimer.current) clearTimeout(checkTimer.current);
+    };
+  }, [folder]);
+
+  const onFolderChange = useCallback((next: string) => {
+    setFolderTouched(true);
+    setFolder(next);
+  }, []);
+
+  const ready =
+    name.trim().length > 0 &&
+    folder.length > 0 &&
+    folderCheck?.valid === true &&
+    folderCheck?.available === true;
+
+  const onCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!ready) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const r = await createGroup({ name: name.trim(), folder });
+      onCreated({ id: r.group.id, folder: r.group.folder, name: r.group.name });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onCreate} style={{ marginTop: '0.5rem' }}>
+      <div className="row">
+        <label htmlFor="newName">Name</label>
+        <input
+          id="newName"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Forge"
+          autoFocus
+        />
+      </div>
+      <div className="row">
+        <label htmlFor="newFolder">Folder slug</label>
+        <input
+          id="newFolder"
+          type="text"
+          value={folder}
+          onChange={(e) => onFolderChange(e.target.value)}
+          placeholder="e.g. forge"
+        />
+        {folder && folderChecking && (
+          <p className="dim">
+            Checking <code>{folder}</code>…
+          </p>
+        )}
+        {folder && !folderChecking && folderCheck && !folderCheck.valid && (
+          <p className="wizard-folder-error">{folderCheck.reason ?? 'Invalid slug.'}</p>
+        )}
+        {folder && !folderChecking && folderCheck && folderCheck.valid && !folderCheck.available && (
+          <p className="wizard-folder-error">{folderCheck.reason ?? 'Already taken.'}</p>
+        )}
+        {folder && !folderChecking && folderCheck && folderCheck.valid && folderCheck.available && (
+          <p className="wizard-folder-ok">
+            <code>groups/{folder}/</code> is available.
+          </p>
+        )}
+      </div>
+      <p className="dim">
+        Vault attach skipped here — you can do it from the group's detail page after setup. Keeps this flow short.
+      </p>
+      {error && <div className="error-banner">{error}</div>}
+      <div className="actions" style={{ marginTop: '0.75rem' }}>
+        <button type="submit" disabled={!ready || submitting}>
+          {submitting ? 'Creating…' : 'Create + use this group'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/ui/src/components/setup/AgentGroupStep.tsx
+++ b/web/ui/src/components/setup/AgentGroupStep.tsx
@@ -7,77 +7,22 @@
  *       them and let them select one — the wire-channel step works the
  *       same way regardless of how the group was created.
  *
- *   (b) Create a new group inline. We don't reuse <NewGroupWizard /> as a
- *       sub-component because its three-step internal navigation would
- *       fight the parent wizard's step indicator. Instead we render a
- *       trimmed inline form (name + folder + auto-suggested folder) and
- *       create immediately. Vault attach is offered but defaults to
- *       "skip — attach later" to keep the setup wizard fast; the
- *       operator can attach a vault from the group detail page.
+ *   (b) Create a new group inline. Vault attach is offered on the group
+ *       detail page after setup, not here, to keep the wizard fast.
  *
- * Once a group exists / is selected, we stamp `agentGroupFolder` and
- * `agentGroupName` on the wizard state and advance.
+ * The picker UI is shared with /channels/new — both are thin wrappers
+ * around <AgentGroupPicker />. Once a group is picked / created, we
+ * stamp `agentGroupFolder` and `agentGroupName` on the wizard state and
+ * advance.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  checkFolderAvailability,
-  createGroup,
-  fetchFolderSuggestion,
-  listGroups,
-  type AgentGroupView,
-  type FolderAvailability,
-} from '../../lib/api.ts';
+import { AgentGroupPicker, type PickedGroup } from '../AgentGroupPicker.tsx';
 import type { StepProps } from './types.ts';
 
-type Mode = 'pick' | 'create';
-
-export function AgentGroupStep({ state, patchState, next, back }: StepProps) {
-  const [groups, setGroups] = useState<AgentGroupView[] | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [mode, setMode] = useState<Mode>('pick');
-
-  useEffect(() => {
-    let cancelled = false;
-    listGroups()
-      .then((g) => {
-        if (cancelled) return;
-        setGroups(g);
-        // Default mode based on what's there.
-        if (g.length === 0) setMode('create');
-      })
-      .catch((err) => {
-        if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const onPick = (g: AgentGroupView) => {
+export function AgentGroupStep({ patchState, next, back }: StepProps) {
+  const onPicked = (g: PickedGroup) => {
     patchState({ agentGroupFolder: g.folder, agentGroupName: g.name });
     next();
   };
-
-  if (loadError) {
-    return (
-      <>
-        <h3>Agent group</h3>
-        <div className="error-banner">Couldn't load groups: <code>{loadError}</code></div>
-        <div className="actions" style={{ marginTop: '1rem' }}>
-          <button className="secondary" onClick={back}>Back</button>
-        </div>
-      </>
-    );
-  }
-
-  if (!groups) {
-    return (
-      <>
-        <h3>Agent group</h3>
-        <ul className="skeleton-list" aria-busy="true"><li className="skeleton skeleton-row" /></ul>
-      </>
-    );
-  }
 
   return (
     <>
@@ -86,162 +31,13 @@ export function AgentGroupStep({ state, patchState, next, back }: StepProps) {
         The agent group is the entity your bot represents. Pick an existing one or create a new one.
       </p>
 
-      {groups.length > 0 && (
-        <div className="row" style={{ marginTop: '0.5rem' }}>
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <button className={mode === 'pick' ? '' : 'secondary'} onClick={() => setMode('pick')}>
-              Pick existing ({groups.length})
-            </button>
-            <button className={mode === 'create' ? '' : 'secondary'} onClick={() => setMode('create')}>
-              Create new
-            </button>
-          </div>
-        </div>
-      )}
-
-      {mode === 'pick' && groups.length > 0 && (
-        <ul style={{ listStyle: 'none', padding: 0, marginTop: '0.5rem' }}>
-          {groups.map((g) => (
-            <li key={g.id} style={{ padding: '0.6rem 0', borderBottom: '1px solid var(--border)' }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.75rem' }}>
-                <div>
-                  <strong>{g.name}</strong> <code className="dim">{g.folder}</code>
-                  {g.vault && <span className="tag" style={{ marginLeft: '0.5rem' }}>{g.vault.scope}</span>}
-                </div>
-                <button onClick={() => onPick(g)}>Use this group</button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {mode === 'create' && <CreateGroupInline state={state} patchState={patchState} next={next} />}
+      <AgentGroupPicker onPicked={onPicked} />
 
       <div className="actions" style={{ marginTop: '1rem' }}>
-        <button className="secondary" onClick={back}>Back</button>
-      </div>
-    </>
-  );
-}
-
-function CreateGroupInline({
-  patchState,
-  next,
-}: {
-  state: StepProps['state'];
-  patchState: StepProps['patchState'];
-  next: StepProps['next'];
-}) {
-  const [name, setName] = useState('');
-  const [folder, setFolder] = useState('');
-  const [folderTouched, setFolderTouched] = useState(false);
-  const [folderCheck, setFolderCheck] = useState<FolderAvailability | null>(null);
-  const [folderChecking, setFolderChecking] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Auto-suggest folder slug from name.
-  useEffect(() => {
-    if (folderTouched) return;
-    const trimmed = name.trim();
-    if (!trimmed) {
-      setFolder('');
-      return;
-    }
-    let cancelled = false;
-    fetchFolderSuggestion(trimmed)
-      .then((slug) => !cancelled && !folderTouched && setFolder(slug))
-      .catch(() => {
-        // Suggestion failure is non-fatal.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [name, folderTouched]);
-
-  // Debounced folder availability.
-  const checkTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    if (!folder) {
-      setFolderCheck(null);
-      return;
-    }
-    if (checkTimer.current) clearTimeout(checkTimer.current);
-    setFolderChecking(true);
-    checkTimer.current = setTimeout(async () => {
-      try {
-        setFolderCheck(await checkFolderAvailability(folder));
-      } catch (err) {
-        setFolderCheck({
-          slug: folder,
-          valid: false,
-          available: false,
-          reason: err instanceof Error ? err.message : String(err),
-        });
-      } finally {
-        setFolderChecking(false);
-      }
-    }, 250);
-    return () => {
-      if (checkTimer.current) clearTimeout(checkTimer.current);
-    };
-  }, [folder]);
-
-  const onFolderChange = useCallback((next: string) => {
-    setFolderTouched(true);
-    setFolder(next);
-  }, []);
-
-  const ready =
-    name.trim().length > 0 && folder.length > 0 && folderCheck?.valid === true && folderCheck?.available === true;
-
-  const onCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!ready) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const r = await createGroup({ name: name.trim(), folder });
-      patchState({ agentGroupFolder: r.group.folder, agentGroupName: r.group.name });
-      next();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <form onSubmit={onCreate} style={{ marginTop: '0.5rem' }}>
-      <div className="row">
-        <label htmlFor="newName">Name</label>
-        <input id="newName" type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Forge" autoFocus />
-      </div>
-      <div className="row">
-        <label htmlFor="newFolder">Folder slug</label>
-        <input id="newFolder" type="text" value={folder} onChange={(e) => onFolderChange(e.target.value)} placeholder="e.g. forge" />
-        {folder && folderChecking && <p className="dim">Checking <code>{folder}</code>…</p>}
-        {folder && !folderChecking && folderCheck && !folderCheck.valid && (
-          <p className="wizard-folder-error">{folderCheck.reason ?? 'Invalid slug.'}</p>
-        )}
-        {folder && !folderChecking && folderCheck && folderCheck.valid && !folderCheck.available && (
-          <p className="wizard-folder-error">{folderCheck.reason ?? 'Already taken.'}</p>
-        )}
-        {folder && !folderChecking && folderCheck && folderCheck.valid && folderCheck.available && (
-          <p className="wizard-folder-ok">
-            <code>groups/{folder}/</code> is available.
-          </p>
-        )}
-      </div>
-      <p className="dim">
-        Vault attach skipped here — you can do it from the group's detail page after setup. Keeps this flow short.
-      </p>
-      {error && <div className="error-banner">{error}</div>}
-      <div className="actions" style={{ marginTop: '0.75rem' }}>
-        <button type="submit" disabled={!ready || submitting}>
-          {submitting ? 'Creating…' : 'Create + use this group'}
+        <button className="secondary" onClick={back}>
+          Back
         </button>
       </div>
-    </form>
+    </>
   );
 }

--- a/web/ui/src/components/setup/types.ts
+++ b/web/ui/src/components/setup/types.ts
@@ -90,7 +90,7 @@ export const ADAPTER_LABELS: Record<ChannelAdapter, string> = {
   telegram: 'Telegram',
 };
 
-export const SETUP_STORAGE_KEY = 'paraclaw.setupWizard.v1';
+export const SETUP_STORAGE_KEY = 'paraclaw.setupWizard.v2';
 
 export interface StepProps {
   state: SetupState;

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -226,3 +226,36 @@ describe('happy path — 200 returns parsed body and skips auth', () => {
     expect(auth.beginLogin).not.toHaveBeenCalled();
   });
 });
+
+describe('wireChannelToGroup — body contract with server', () => {
+  // Server keys on `channelType` (matches DB column + WireDmInput). Helper
+  // accepts `channel` for ergonomics; this test pins the wire boundary so
+  // a future rename can't silently regress to "channelType must be …" 400s.
+  it('serializes input.channel as channelType in the request body', async () => {
+    const result = {
+      messagingGroupId: 'mg_1',
+      messagingGroupAgentId: 'mga_1',
+      platformId: 'telegram:42',
+      created: { messagingGroup: true, wiring: true },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, result));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await api.wireChannelToGroup('forge', {
+      channel: 'telegram',
+      botUserId: '42',
+      displayName: 'Forge DM',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      channelType: 'telegram',
+      botUserId: '42',
+      displayName: 'Forge DM',
+    });
+    expect(body.channel).toBeUndefined();
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -951,8 +951,15 @@ export async function wireChannelToGroup(
   folder: string,
   input: { channel: ChannelKind; botUserId: string; displayName?: string },
 ): Promise<WireChannelResult> {
+  // Server's body parser keys on `channelType` (matches the DB column
+  // and the wire-channel.ts WireDmInput interface). The helper accepts
+  // `channel` for caller ergonomics — translate at the wire boundary.
   return request<WireChannelResult>(`/groups/${encodeURIComponent(folder)}/wire-channel`, {
     method: 'POST',
-    json: input,
+    json: {
+      channelType: input.channel,
+      botUserId: input.botUserId,
+      displayName: input.displayName,
+    },
   });
 }

--- a/web/ui/src/lib/channel-adapters.ts
+++ b/web/ui/src/lib/channel-adapters.ts
@@ -1,0 +1,134 @@
+/**
+ * Channel adapter descriptors.
+ *
+ * The /channels/new page and the setup wizard both need the same handful of
+ * facts about each supported adapter: how to validate a bot token, what the
+ * platform_id looks like, what to ask the operator for, and where to send
+ * them for token-procurement docs. This table is the single source of those
+ * facts so a new adapter (slack, whatsapp, …) lands as a one-file addition,
+ * not a sprawl of switch statements across components.
+ *
+ * Two arrays:
+ *   SUPPORTED_ADAPTERS   — currently installable on the trunk install
+ *   COMING_SOON_ADAPTERS — visible in the picker as "coming soon" affordances
+ *                          per design 2026-04-30 §"adapter parity"
+ *
+ * If you add a row here you also need to extend the wire-channel + validator
+ * routes server-side; the descriptor is the *UI* contract, not the schema.
+ */
+import {
+  testDiscordToken,
+  testTelegramToken,
+  type DiscordIdentity,
+  type TelegramIdentity,
+} from './api.ts';
+
+export type ChannelAdapter = 'discord' | 'telegram';
+
+export interface ResolvedIdentity {
+  /** Bot's user id at the upstream platform, normalized to string. */
+  id: string;
+  /** Bot's @-handle / username for "DM @<bot>" copy. */
+  username: string;
+}
+
+/**
+ * What the operator needs to provide on the new-channel page in addition to
+ * the bot token. Today only Telegram has a non-empty list (the operator's
+ * own user id is needed because Telegram DMs are chat-routed).
+ */
+export interface OperatorInputField {
+  key: 'operatorUserId';
+  label: string;
+  hint: string;
+  /** Where to send the operator to find this value, if anywhere. */
+  helpHref?: string;
+  /** Pattern for client-side validation (kept loose; server is the gate). */
+  pattern: RegExp;
+}
+
+export interface ChannelAdapterDescriptor {
+  key: ChannelAdapter;
+  label: string;
+  blurb: string;
+  /** Path on the upstream platform's API the validator hits — for display copy. */
+  upstreamProbePath: string;
+  /** Where the operator gets the bot token. */
+  tokenHelp: { title: string; href: string };
+  /** Validate a token; throws on rejection. The body in the throw carries the user-facing error. */
+  validate: (token: string) => Promise<ResolvedIdentity>;
+  /** Adapter-specific extra fields the wiring step needs from the operator. */
+  operatorFields: OperatorInputField[];
+  /**
+   * Build the messaging-group `platform_id` shown as a preview before wiring.
+   * `botUserId` is the validate() id; `operatorUserId` is from operatorFields.
+   */
+  platformIdPreview: (args: { botUserId: string | null; operatorUserId: string | null }) => string;
+  /**
+   * The id that gets POST-ed to /groups/:folder/wire-channel as `botUserId`.
+   * Discord uses the bot's snowflake (DMs are addressee-routed). Telegram
+   * uses the OPERATOR's user id (DMs are chat-routed). Both ride the same
+   * wire field name — the server's wire-channel.ts knows which one is which
+   * based on `channelType`.
+   */
+  wireIdFor: (args: { botUserId: string | null; operatorUserId: string | null }) => string | null;
+}
+
+export interface ComingSoonAdapter {
+  key: string;
+  label: string;
+  blurb: string;
+}
+
+export const SUPPORTED_ADAPTERS: ChannelAdapterDescriptor[] = [
+  {
+    key: 'telegram',
+    label: 'Telegram',
+    blurb: 'Easiest first run — BotFather + @userinfobot, ~1 minute.',
+    upstreamProbePath: '/getMe',
+    tokenHelp: { title: '@BotFather → /newbot', href: 'https://t.me/BotFather' },
+    validate: async (token: string): Promise<ResolvedIdentity> => {
+      const r: { identity: TelegramIdentity } = await testTelegramToken(token);
+      return { id: String(r.identity.id), username: r.identity.username };
+    },
+    operatorFields: [
+      {
+        key: 'operatorUserId',
+        label: 'Your Telegram user id',
+        hint: 'DM @userinfobot to get yours. Telegram routes DMs by chat id (= your user id).',
+        helpHref: 'https://t.me/userinfobot',
+        pattern: /^[0-9]+$/,
+      },
+    ],
+    platformIdPreview: ({ operatorUserId }) =>
+      `telegram:${operatorUserId ?? '(no user id)'}`,
+    wireIdFor: ({ operatorUserId }) => operatorUserId,
+  },
+  {
+    key: 'discord',
+    label: 'Discord',
+    blurb: 'DM your bot or @-mention it in a server.',
+    upstreamProbePath: '/users/@me',
+    tokenHelp: {
+      title: 'Discord developer portal → Bot → Token',
+      href: 'https://discord.com/developers/applications',
+    },
+    validate: async (token: string): Promise<ResolvedIdentity> => {
+      const r: { identity: DiscordIdentity } = await testDiscordToken(token);
+      return { id: r.identity.id, username: r.identity.username };
+    },
+    operatorFields: [],
+    platformIdPreview: ({ botUserId }) => `discord:@me:${botUserId ?? '(no bot id)'}`,
+    wireIdFor: ({ botUserId }) => botUserId,
+  },
+];
+
+export const COMING_SOON_ADAPTERS: ComingSoonAdapter[] = [
+  { key: 'slack', label: 'Slack', blurb: 'Workspace bot — coming soon.' },
+  { key: 'whatsapp', label: 'WhatsApp', blurb: 'Cloud API — coming soon.' },
+  { key: 'teams', label: 'Microsoft Teams', blurb: 'Coming soon.' },
+];
+
+export function findAdapter(key: string): ChannelAdapterDescriptor | null {
+  return SUPPORTED_ADAPTERS.find((a) => a.key === key) ?? null;
+}

--- a/web/ui/src/routes/ChannelsList.tsx
+++ b/web/ui/src/routes/ChannelsList.tsx
@@ -127,15 +127,15 @@ export function ChannelsList() {
     <div>
       <div className="list-header">
         <h2>Channel wirings ({state.wires.length})</h2>
-        <Link to="/setup">
+        <Link to="/channels/new">
           <button className="secondary">+ Wire a new channel</button>
         </Link>
       </div>
 
       <p className="muted">
         Each wire binds a messaging thread (DM, channel, chat) to an agent group with routing rules. New wirings go
-        through the <Link to="/setup">setup wizard</Link> so the channel token can be validated and the platform id
-        captured.
+        through the <Link to="/channels/new">wire-channel page</Link> so the channel token can be validated and the
+        platform id captured.
       </p>
 
       {actionError && <div className="error-banner">{actionError}</div>}
@@ -144,7 +144,7 @@ export function ChannelsList() {
         <div className="empty empty-rich" style={{ marginTop: '1rem' }}>
           <p className="empty-headline">No channels wired yet.</p>
           <p className="muted">
-            Run <Link to="/setup">/setup</Link> to install + wire Discord or Telegram.
+            <Link to="/channels/new">Wire a new channel</Link> to route Discord or Telegram DMs into an agent group.
           </p>
         </div>
       )}

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -1,0 +1,370 @@
+/**
+ * /channels/new — wire a new channel to an agent group on a single page.
+ *
+ * The setup wizard's eight-step march is the right shape for *first* boot
+ * (prereqs / install / hub / vault / agent group / wire / test). It's the
+ * wrong shape for the operator's *second* channel: by then prereqs are
+ * met, the adapter is installed, an agent group exists, and the only
+ * unknown is the bot token + (for telegram) the operator's user id.
+ *
+ * This page is intentionally one form, three sections:
+ *   1. Pick adapter (discord / telegram, plus disabled "coming soon" rows)
+ *   2. Bot identity (paste token → validate → show identity)
+ *   3. Agent group (existing or create, via shared <AgentGroupPicker />)
+ *
+ * Wiring is the final action button, enabled only when all three are
+ * satisfied. After a successful wire we render a confirmation panel with
+ * the platform_id and a link back to /channels.
+ *
+ * State is local-only — no localStorage, no /api/setup/status involvement.
+ * If the user navigates away mid-flow, they restart cleanly. The setup
+ * wizard remains the resumable surface; this page is the "fast path".
+ */
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { AgentGroupPicker, type PickedGroup } from '../components/AgentGroupPicker.tsx';
+import {
+  COMING_SOON_ADAPTERS,
+  SUPPORTED_ADAPTERS,
+  type ChannelAdapter,
+  type ResolvedIdentity,
+} from '../lib/channel-adapters.ts';
+import { wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
+
+export function WireChannelPage() {
+  const [adapterKey, setAdapterKey] = useState<ChannelAdapter | null>(null);
+  const adapter = useMemo(
+    () => SUPPORTED_ADAPTERS.find((a) => a.key === adapterKey) ?? null,
+    [adapterKey],
+  );
+
+  const [token, setToken] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [validateError, setValidateError] = useState<string | null>(null);
+  const [identity, setIdentity] = useState<ResolvedIdentity | null>(null);
+
+  const [operatorUserId, setOperatorUserId] = useState('');
+
+  const [picked, setPicked] = useState<PickedGroup | null>(null);
+
+  const [wiring, setWiring] = useState(false);
+  const [wireResult, setWireResult] = useState<WireChannelResult | null>(null);
+  const [wireError, setWireError] = useState<string | null>(null);
+
+  const onPickAdapter = (key: ChannelAdapter) => {
+    if (key === adapterKey) return;
+    setAdapterKey(key);
+    setToken('');
+    setIdentity(null);
+    setValidateError(null);
+    setOperatorUserId('');
+  };
+
+  const onValidate = async () => {
+    if (!adapter || !token.trim()) return;
+    setValidating(true);
+    setValidateError(null);
+    try {
+      const r = await adapter.validate(token.trim());
+      setIdentity(r);
+      setToken('');
+    } catch (err) {
+      setValidateError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  const operatorFieldOk =
+    !adapter ||
+    adapter.operatorFields.every((f) => {
+      if (f.key === 'operatorUserId') return f.pattern.test(operatorUserId.trim());
+      return false;
+    });
+
+  const wireId = adapter
+    ? adapter.wireIdFor({
+        botUserId: identity?.id ?? null,
+        operatorUserId: operatorUserId.trim() || null,
+      })
+    : null;
+
+  const platformIdPreview = adapter
+    ? adapter.platformIdPreview({
+        botUserId: identity?.id ?? null,
+        operatorUserId: operatorUserId.trim() || null,
+      })
+    : null;
+
+  const canWire = !!adapter && !!identity && operatorFieldOk && !!picked && !!wireId && !wiring;
+
+  const onWire = async () => {
+    if (!canWire || !adapter || !picked || !wireId) return;
+    setWiring(true);
+    setWireError(null);
+    try {
+      const r = await wireChannelToGroup(picked.folder, {
+        channel: adapter.key,
+        botUserId: wireId,
+        displayName: `${picked.name} DM`,
+      });
+      setWireResult(r);
+    } catch (err) {
+      setWireError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWiring(false);
+    }
+  };
+
+  if (wireResult) {
+    return (
+      <div>
+        <h2>Channel wired</h2>
+        <p className="muted">
+          {adapter?.label} DM is now routed to <code>{picked?.name}</code>. Send a DM to{' '}
+          <code>@{identity?.username}</code> to test.
+        </p>
+        <div className="empty empty-rich" style={{ marginTop: '0.75rem' }}>
+          <p className="empty-headline" style={{ margin: 0 }}>
+            {wireResult.created.wiring ? 'Wired.' : 'Already wired — kept existing rows.'}
+          </p>
+          <p className="muted" style={{ marginTop: '0.4rem', fontSize: '0.85rem' }}>
+            messaging_group_id: <code>{wireResult.messagingGroupId}</code>
+            <br />
+            messaging_group_agent_id: <code>{wireResult.messagingGroupAgentId}</code>
+            <br />
+            platform_id: <code>{wireResult.platformId}</code>
+          </p>
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
+          <Link to="/channels">
+            <button>Back to channels</button>
+          </Link>
+          <Link to={`/groups/${encodeURIComponent(picked?.folder ?? '')}`}>
+            <button className="secondary">Open agent group</button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Wire a new channel</h2>
+        <Link to="/channels">
+          <button className="secondary">Cancel</button>
+        </Link>
+      </div>
+      <p className="muted">
+        Pick an adapter, validate the bot token, choose an agent group. The setup wizard is for
+        first-boot only — this is the fast path for adding a second (or third…) channel.
+      </p>
+
+      <Section step={1} title="Pick adapter">
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+            gap: '0.75rem',
+            marginTop: '0.5rem',
+          }}
+        >
+          {SUPPORTED_ADAPTERS.map((a) => (
+            <AdapterCard
+              key={a.key}
+              label={a.label}
+              blurb={a.blurb}
+              available
+              selected={a.key === adapterKey}
+              onPick={() => onPickAdapter(a.key)}
+            />
+          ))}
+          {COMING_SOON_ADAPTERS.map((a) => (
+            <AdapterCard key={a.key} label={a.label} blurb={a.blurb} available={false} />
+          ))}
+        </div>
+      </Section>
+
+      {adapter && (
+        <Section step={2} title={`Bot identity — ${adapter.label}`}>
+          <p className="dim" style={{ marginTop: 0 }}>
+            We hit <code>{adapter.upstreamProbePath}</code> to confirm the token authenticates and the account
+            is a bot. Get a token from{' '}
+            <a href={adapter.tokenHelp.href} target="_blank" rel="noreferrer">
+              {adapter.tokenHelp.title}
+            </a>
+            .
+          </p>
+
+          {identity ? (
+            <div className="empty empty-rich" style={{ marginTop: '0.5rem' }}>
+              <p className="empty-headline" style={{ margin: 0 }}>
+                Bot identified: <code>@{identity.username}</code>{' '}
+                <span className="dim">
+                  (id <code>{identity.id}</code>)
+                </span>
+              </p>
+              <button
+                className="secondary"
+                style={{ marginTop: '0.5rem' }}
+                onClick={() => {
+                  setIdentity(null);
+                  setToken('');
+                }}
+              >
+                Re-validate with a different token
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="row" style={{ marginTop: '0.5rem' }}>
+                <label htmlFor="botToken">Bot token</label>
+                <input
+                  id="botToken"
+                  type="password"
+                  autoComplete="off"
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  placeholder="paste bot token"
+                />
+              </div>
+              {validateError && <div className="error-banner">{validateError}</div>}
+              <div className="actions" style={{ marginTop: '0.5rem' }}>
+                <button onClick={onValidate} disabled={!token.trim() || validating}>
+                  {validating ? 'Validating…' : 'Validate token'}
+                </button>
+              </div>
+            </>
+          )}
+
+          {identity &&
+            adapter.operatorFields.map((f) => (
+              <div key={f.key} className="row" style={{ marginTop: '0.75rem' }}>
+                <label htmlFor={f.key}>{f.label}</label>
+                <input
+                  id={f.key}
+                  type="text"
+                  inputMode="numeric"
+                  value={operatorUserId}
+                  onChange={(e) => setOperatorUserId(e.target.value)}
+                  placeholder="123456789"
+                />
+                <p className="dim" style={{ marginTop: '0.25rem', fontSize: '0.8rem' }}>
+                  {f.hint}
+                  {f.helpHref && (
+                    <>
+                      {' '}
+                      <a href={f.helpHref} target="_blank" rel="noreferrer">
+                        Help
+                      </a>
+                    </>
+                  )}
+                </p>
+              </div>
+            ))}
+        </Section>
+      )}
+
+      {adapter && identity && operatorFieldOk && (
+        <Section step={3} title="Agent group">
+          {picked ? (
+            <div className="empty empty-rich" style={{ marginTop: '0.5rem' }}>
+              <p className="empty-headline" style={{ margin: 0 }}>
+                <strong>{picked.name}</strong>{' '}
+                <code className="dim">{picked.folder}</code>
+              </p>
+              <button
+                className="secondary"
+                style={{ marginTop: '0.5rem' }}
+                onClick={() => setPicked(null)}
+              >
+                Change group
+              </button>
+            </div>
+          ) : (
+            <AgentGroupPicker onPicked={setPicked} />
+          )}
+        </Section>
+      )}
+
+      {adapter && identity && operatorFieldOk && picked && (
+        <Section step={4} title="Wire">
+          <p className="muted">
+            Synthesizes the DM platform id <code>{platformIdPreview}</code> and inserts the
+            messaging_groups + messaging_group_agents rows. After wiring, the first DM lands in your
+            group instead of being silently dropped by the unwired-channel guard.
+          </p>
+          {wireError && <div className="error-banner">{wireError}</div>}
+          <div className="actions" style={{ marginTop: '0.5rem' }}>
+            <button onClick={onWire} disabled={!canWire}>
+              {wiring ? 'Wiring…' : `Wire ${adapter.label} DM to ${picked.name}`}
+            </button>
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  step,
+  title,
+  children,
+}: {
+  step: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ marginTop: '1.5rem' }}>
+      <h3 style={{ margin: 0 }}>
+        <span className="dim" style={{ marginRight: '0.5rem' }}>
+          {step}.
+        </span>
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function AdapterCard({
+  label,
+  blurb,
+  available,
+  selected = false,
+  onPick,
+}: {
+  label: string;
+  blurb: string;
+  available: boolean;
+  selected?: boolean;
+  onPick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={!available}
+      onClick={() => available && onPick?.()}
+      className="secondary"
+      style={{
+        textAlign: 'left',
+        padding: '1rem',
+        border: selected ? '2px solid var(--accent)' : '1px solid var(--border)',
+        background: selected ? 'var(--accent-soft)' : 'white',
+        opacity: available ? 1 : 0.5,
+        cursor: available ? 'pointer' : 'not-allowed',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <strong>{label}</strong>
+        {!available && <span className="tag muted">coming soon</span>}
+      </div>
+      <p className="dim" style={{ margin: '0.4rem 0 0', fontSize: '0.85rem' }}>
+        {blurb}
+      </p>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 of paraclaw#67 (B1 of B1+B2 split) — replaces the eight-step setup wizard with a single-page form for the operator's *second* channel and onward. **UI overhaul only.** Multi-bot dynamic register-bot is the stacked follow-up (B2).

The wizard's eight-step march is right for first boot (prereqs / install / hub / vault / agent group / wire / test). It's the wrong shape for the second channel: by then prereqs are met, the adapter is installed, an agent group exists, and the only unknowns are the bot token + (for Telegram) the operator's user id.

`/channels/new` is one form, three sections, one wire button:

1. **Pick adapter** — discord / telegram, plus disabled "coming soon" rows for slack / whatsapp / teams
2. **Bot identity** — paste token → server validates against `/users/@me` (Discord) or `/getMe` (Telegram) → identity panel; for Telegram the operator also provides their own user id
3. **Agent group** — existing or create-inline, via the new shared `<AgentGroupPicker />` component (extracted from the wizard's step-6 so the wizard now thin-wraps it)

State is local-only — no localStorage, no `/api/setup/status` involvement. If the user navigates away mid-flow they restart cleanly. The setup wizard remains the resumable surface for first boot.

### Server changes

- New validators: `src/web/discord-validate.ts`, `src/web/telegram-validate.ts` (lifted verbatim from the abandoned `feat/setup-wizard-discord` branch + tests).
- New routes: `POST /api/channels/{discord,telegram}/test` — gated on `claw:write`. Validator returns 401 on rejected token, but the route remaps that to HTTP 400 to avoid colliding with the SPA's auth-expiry re-auth flow on 401.

### Audit

`docs/audit/2026-04-30-channel-endpoint-audit.md` documents the four findings that narrowed the scope: validate/test handlers didn't exist on main, install-channel orchestrator is dead (file as follow-up cleanup), O1 doesn't bind, CLAUDE.md adapter-packaging claim is stale.

### Out of scope (deliberately)

- **Multi-bot dynamic register-bot is the stacked B2 follow-up** — `feat/multi-bot-channel-wiring` branches off this PR's head and lands the dynamic registry hook + `POST /api/channels/{adapter}/register-bot` endpoint + multi-bot routing tests.
- Install-channel orchestrator cleanup (will file a follow-up issue post-merge, citing the audit doc).
- Test-message panel post-wire — current confirmation panel is a copy-pastable platform_id + group link, which is enough.

### Rebase note

This branch was rebased onto post-A `night/paraclaw-rebirth` (`130528a`) and force-pushed:

- Dropped the stale `b372fc2` rc.22→rc.23 bump (PR A already shipped rc.23).
- New final commit `763c8ed` bumps rc.23→rc.24.
- Reviewer's two trivial nits from the prior round (clean unknown-adapter 404, CLAUDE.md trunk-baked claim refresh) remain folded as `80ea230`.

### Versioning

Bumps `0.0.14-rc.23 → 0.0.14-rc.24`.

## Test plan

- [x] Host typecheck: `pnpm typecheck` — clean
- [x] Host tests: `pnpm test` — 399/399 pass (45 files)
- [x] UI typecheck: `cd web/ui && pnpm typecheck` — clean
- [x] Prettier: `pnpm format:check` — clean
- [ ] Browser exercise (reviewer + Aaron): load `/claw/channels/new`, walk pick-adapter → token-validate → group-pick → wire path on a fresh install; confirm the wired channel appears in `/claw/channels` and a DM lands in the agent group

🤖 Generated with [Claude Code](https://claude.com/claude-code)