### PR TITLE
feat: multi-bot dynamic register-bot (paraclaw#67 B2, stacked on #69)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ The frontend bundle in `web/ui/` is intentionally outside the pnpm workspace (th
 cd web/ui && pnpm install --ignore-workspace && pnpm test
 ```
 
-Otherwise the runner exits with `ERR_MODULE_NOT_FOUND: @vitejs/plugin-react`.
+Otherwise the test runner exits with a missing-dependency error (the exact symptom — module-not-found on `@vitejs/plugin-react`, missing test framework, etc. — depends on which entry point your package manager hits first).
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.24",
+  "version": "0.0.14-rc.25",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -178,9 +178,35 @@ export interface ChannelAdapter {
 /** Factory function that creates a channel adapter (returns null if credentials missing). */
 export type ChannelAdapterFactory = () => ChannelAdapter | null | Promise<ChannelAdapter | null>;
 
+/**
+ * Build an adapter from a stored secret. Channel modules implement this so
+ * the registry's secrets-backed startup scan and the dynamic register-bot
+ * endpoint can spawn additional bot adapters beyond the `.env`-defined
+ * primary, without channel-registry needing to know per-channel internals.
+ *
+ * Receives the full secret name (e.g. `CHANNEL_BOT_TOKEN:discord:9128…`)
+ * and its plaintext value (the bot token). Adapters that need more than
+ * just a token (Discord needs `applicationId`) parse it out of the name's
+ * trailing segment, which by convention is the bot's identity.
+ *
+ * Returns the adapter ready for `setup()`; the caller wires up host
+ * callbacks. Returns null if the secret can't produce a viable adapter
+ * (e.g. token rejected by the platform); callers log + skip.
+ */
+export type ChannelSpawnFromSecret = (secretName: string, secretValue: string) => Promise<ChannelAdapter | null>;
+
 /** Registration entry for a channel adapter. */
 export interface ChannelRegistration {
   factory: ChannelAdapterFactory;
+  /**
+   * Optional. Channels that support multi-bot operation expose this so the
+   * registry can spawn additional bots from `CHANNEL_BOT_TOKEN:<channel>:*`
+   * secrets at boot time and on-demand via the register-bot HTTP endpoint.
+   *
+   * Channels without it support exactly one bot per install (the
+   * `.env`-defined primary).
+   */
+  spawnFromSecret?: ChannelSpawnFromSecret;
   containerConfig?: {
     mounts?: Array<{ hostPath: string; containerPath: string; readonly: boolean }>;
     env?: Record<string, string>;

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -233,3 +233,157 @@ describe('channel + router integration', () => {
     expect((mockAdapter.delivered[0].content as { text: string }).text).toBe('Agent response');
   });
 });
+
+describe('multi-bot routing via dynamic register-bot', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const { initTestDb, runMigrations } = await import('../db/index.js');
+    const db = initTestDb();
+    runMigrations(db);
+    const { _resetActiveAdaptersForTest } = await import('./channel-registry.js');
+    _resetActiveAdaptersForTest();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../db/index.js');
+    const { _resetActiveAdaptersForTest } = await import('./channel-registry.js');
+    _resetActiveAdaptersForTest();
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('registers two bots on the same channel-type and routes by botId', async () => {
+    const {
+      registerChannelAdapter,
+      registerBotAdapter,
+      initChannelAdapters,
+      getActiveAdapters,
+      getChannelAdapter,
+      getChannelAdapterForPlatformId,
+    } = await import('./channel-registry.js');
+    const { encodePlatformId } = await import('../platform-id.js');
+
+    // Channel that supports multi-bot — spawnFromSecret returns a fresh
+    // adapter whose botId is parsed from the secret name's trailing segment.
+    // Mirrors discord.ts's spawnFromSecret shape; telegram would call getMe
+    // but we keep the test in-memory.
+    registerChannelAdapter('multi-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('multi-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    // Init with no .env-backed primary, then dynamically register two bots.
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    const a = await registerBotAdapter('multi-mock', 'CHANNEL_BOT_TOKEN:multi-mock:bot-A', 'token-A');
+    const b = await registerBotAdapter('multi-mock', 'CHANNEL_BOT_TOKEN:multi-mock:bot-B', 'token-B');
+    expect(a?.botId).toBe('bot-A');
+    expect(b?.botId).toBe('bot-B');
+
+    // Both adapters live, keyed independently.
+    const active = getActiveAdapters().filter((x) => x.channelType === 'multi-mock');
+    expect(active).toHaveLength(2);
+    expect(active.map((x) => x.botId).sort()).toEqual(['bot-A', 'bot-B']);
+
+    // v2 platform_id's bot segment selects the right adapter.
+    const pidA = encodePlatformId('multi-mock', 'bot-A', 'chat-1');
+    const pidB = encodePlatformId('multi-mock', 'bot-B', 'chat-1');
+    expect(getChannelAdapterForPlatformId('multi-mock', pidA)).toBe(a);
+    expect(getChannelAdapterForPlatformId('multi-mock', pidB)).toBe(b);
+
+    // Channel-type-only lookup picks one (not deterministic which) — that
+    // path is for legacy v1 ids only; prove it doesn't throw.
+    expect(getChannelAdapter('multi-mock')).toBeDefined();
+  });
+
+  it('register-bot is idempotent on (channelType, botId)', async () => {
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } = await import(
+      './channel-registry.js'
+    );
+
+    registerChannelAdapter('idem-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('idem-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    const first = await registerBotAdapter('idem-mock', 'CHANNEL_BOT_TOKEN:idem-mock:bot-X', 'token-X');
+    const second = await registerBotAdapter('idem-mock', 'CHANNEL_BOT_TOKEN:idem-mock:bot-X', 'token-X-rotated');
+    expect(first?.botId).toBe('bot-X');
+    expect(second).toBe(first);
+    const active = getActiveAdapters().filter((x) => x.channelType === 'idem-mock');
+    expect(active).toHaveLength(1);
+  });
+
+  it('register-bot throws on a channel without spawnFromSecret', async () => {
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters } = await import('./channel-registry.js');
+
+    registerChannelAdapter('single-only', { factory: () => null });
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+    await expect(registerBotAdapter('single-only', 'CHANNEL_BOT_TOKEN:single-only:x', 'tok')).rejects.toThrow(
+      /multi-bot/,
+    );
+  });
+
+  it('spawnSecretsBackedBots brings up persisted bots after restart', async () => {
+    const {
+      registerChannelAdapter,
+      initChannelAdapters,
+      spawnSecretsBackedBots,
+      getActiveAdapters,
+      _resetActiveAdaptersForTest,
+    } = await import('./channel-registry.js');
+    const { putSecret } = await import('../secrets/index.js');
+
+    registerChannelAdapter('boot-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('boot-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    // Persist two tokens as if a previous boot had registered them.
+    putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-1', 'tok-1', { kind: 'channel-token', agent_group_id: null });
+    putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-2', 'tok-2', { kind: 'channel-token', agent_group_id: null });
+
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    // Simulate restart: clear actives, then run the boot scan.
+    _resetActiveAdaptersForTest();
+    await spawnSecretsBackedBots();
+    const active = getActiveAdapters().filter((x) => x.channelType === 'boot-mock');
+    expect(active.map((x) => x.botId).sort()).toEqual(['bot-1', 'bot-2']);
+  });
+});

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -307,9 +307,8 @@ describe('multi-bot routing via dynamic register-bot', () => {
   });
 
   it('register-bot is idempotent on (channelType, botId)', async () => {
-    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } = await import(
-      './channel-registry.js'
-    );
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } =
+      await import('./channel-registry.js');
 
     registerChannelAdapter('idem-mock', {
       factory: () => null,

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -103,7 +103,6 @@ describe('channel registry', () => {
     });
 
     await initChannelAdapters(() => ({
-      conversations: [],
       onInbound: () => {},
       onInboundEvent: () => {},
       onMetadata: () => {},
@@ -207,7 +206,6 @@ describe('channel + router integration', () => {
     });
 
     await initChannelAdapters(() => ({
-      conversations: [],
       onInbound: () => {},
       onInboundEvent: () => {},
       onMetadata: () => {},

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -96,11 +96,7 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
  * {@link initChannelAdapters} and the dynamic register helpers share so
  * boot-time and runtime adds get identical resilience semantics.
  */
-async function setupAdapterWithRetry(
-  adapter: ChannelAdapter,
-  setup: ChannelSetup,
-  label: string,
-): Promise<void> {
+async function setupAdapterWithRetry(adapter: ChannelAdapter, setup: ChannelSetup, label: string): Promise<void> {
   let attempt = 0;
   while (true) {
     try {

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -7,6 +7,7 @@
 import type { ChannelAdapter, ChannelRegistration, ChannelSetup } from './adapter.js';
 import { log } from '../log.js';
 import { decodePlatformIdAs } from '../platform-id.js';
+import { listSecrets, getSecret } from '../secrets/index.js';
 
 const SETUP_RETRY_DELAYS_MS = [2000, 5000, 10000];
 
@@ -27,6 +28,15 @@ const registry = new Map<string, ChannelRegistration>();
  * botId.
  */
 const activeAdapters = new Map<string, ChannelAdapter>();
+
+/**
+ * Cached host-callbacks builder, set by {@link initChannelAdapters} the
+ * first time it runs. Reused by {@link spawnSecretsBackedBots} (boot scan)
+ * and {@link registerBotAdapter} (dynamic per-bot adds via the HTTP
+ * register-bot endpoint) so every adapter — primary or dynamic — wires
+ * inbound through the same router callbacks.
+ */
+let cachedSetupFn: ((adapter: ChannelAdapter) => ChannelSetup) | null = null;
 
 function adapterKey(channelType: string, botId: string | null | undefined): string {
   return `${channelType}\0${botId ?? ''}`;
@@ -82,10 +92,44 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
 }
 
 /**
+ * Run an adapter's setup with NetworkError retry — the same retry loop both
+ * {@link initChannelAdapters} and the dynamic register helpers share so
+ * boot-time and runtime adds get identical resilience semantics.
+ */
+async function setupAdapterWithRetry(
+  adapter: ChannelAdapter,
+  setup: ChannelSetup,
+  label: string,
+): Promise<void> {
+  let attempt = 0;
+  while (true) {
+    try {
+      await adapter.setup(setup);
+      return;
+    } catch (err) {
+      if (isNetworkError(err) && attempt < SETUP_RETRY_DELAYS_MS.length) {
+        const delay = SETUP_RETRY_DELAYS_MS[attempt]!;
+        log.warn('Channel adapter setup failed with network error, retrying', {
+          channel: label,
+          attempt: attempt + 1,
+          delayMs: delay,
+          err: err.message,
+        });
+        await sleep(delay);
+        attempt += 1;
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
  * Instantiate and set up all registered channel adapters.
  * Skips adapters that return null (missing credentials).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
+  cachedSetupFn = setupFn;
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
@@ -94,32 +138,11 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
         continue;
       }
 
-      const setup = setupFn(adapter);
       // Transient network failures during adapter init (e.g. Telegram deleteWebhook
       // hitting a DNS hiccup at boot) would otherwise leave the channel permanently
       // dead until manual restart. Retry only on NetworkError so misconfigs (bad
       // tokens, etc.) still fail fast.
-      let attempt = 0;
-      while (true) {
-        try {
-          await adapter.setup(setup);
-          break;
-        } catch (err) {
-          if (isNetworkError(err) && attempt < SETUP_RETRY_DELAYS_MS.length) {
-            const delay = SETUP_RETRY_DELAYS_MS[attempt]!;
-            log.warn('Channel adapter setup failed with network error, retrying', {
-              channel: name,
-              attempt: attempt + 1,
-              delayMs: delay,
-              err: err.message,
-            });
-            await sleep(delay);
-            attempt += 1;
-            continue;
-          }
-          throw err;
-        }
-      }
+      await setupAdapterWithRetry(adapter, setupFn(adapter), name);
       activeAdapters.set(adapterKey(adapter.channelType, adapter.botId), adapter);
       log.info('Channel adapter started', {
         channel: name,
@@ -128,6 +151,96 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
       });
     } catch (err) {
       log.error('Failed to start channel adapter', { channel: name, err });
+    }
+  }
+}
+
+/**
+ * Register an adapter for a specific bot at runtime — used by the
+ * `POST /api/channels/{channel}/register-bot` endpoint after the operator
+ * pastes a token via the wire-channel UI.
+ *
+ * Resolves the channel's `spawnFromSecret` hook to build the adapter, runs
+ * setup with the same callbacks the primary adapter uses, and slots it into
+ * `activeAdapters` keyed by `(channelType, botId)`. Idempotent: if an
+ * adapter is already active for this `(channelType, botId)` it returns the
+ * existing one instead of double-registering.
+ *
+ * Throws if the channel doesn't expose `spawnFromSecret` (single-bot
+ * channel) or if `initChannelAdapters` hasn't run yet (no cached setup
+ * callbacks). Returns null if the spawn hook itself returns null (token
+ * rejected at the platform).
+ */
+export async function registerBotAdapter(
+  channelType: string,
+  secretName: string,
+  secretValue: string,
+): Promise<ChannelAdapter | null> {
+  const registration = registry.get(channelType);
+  if (!registration) throw new Error(`unknown channel: ${channelType}`);
+  if (!registration.spawnFromSecret) {
+    throw new Error(`channel does not support multi-bot operation: ${channelType}`);
+  }
+  if (!cachedSetupFn) {
+    throw new Error('initChannelAdapters has not run yet — cannot register dynamic bot');
+  }
+  const adapter = await registration.spawnFromSecret(secretName, secretValue);
+  if (!adapter) return null;
+  const key = adapterKey(adapter.channelType, adapter.botId);
+  const existing = activeAdapters.get(key);
+  if (existing) {
+    log.info('Channel adapter already active for bot, skipping re-setup', {
+      channel: channelType,
+      botId: adapter.botId ?? null,
+    });
+    return existing;
+  }
+  await setupAdapterWithRetry(adapter, cachedSetupFn(adapter), channelType);
+  activeAdapters.set(key, adapter);
+  log.info('Channel adapter registered dynamically', {
+    channel: channelType,
+    botId: adapter.botId ?? null,
+  });
+  return adapter;
+}
+
+/**
+ * Boot-time scan that brings up adapters for every persisted
+ * `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret whose adapter isn't already
+ * active. Run AFTER `initChannelAdapters` (which seeds the primary `.env`
+ * adapter) and AFTER `runStartupBootstrap` (which copies `.env` tokens into
+ * the secrets table); the combination ensures the primary bot stays primary
+ * while every additional bot the operator has registered comes back online
+ * across restarts.
+ *
+ * Skips channels with no `spawnFromSecret` hook and skips secrets whose
+ * `(channelType, botId)` is already covered by an active adapter (the
+ * primary). Logs but doesn't throw on individual spawn failures — one bad
+ * token shouldn't keep the rest offline.
+ */
+export async function spawnSecretsBackedBots(): Promise<void> {
+  const tokens = listSecrets(null).filter((s) => s.kind === 'channel-token' && s.name.startsWith('CHANNEL_BOT_TOKEN:'));
+  for (const row of tokens) {
+    const parts = row.name.split(':');
+    if (parts.length < 3) continue;
+    const channelType = parts[1]!;
+    const botId = parts.slice(2).join(':');
+    if (!channelType || !botId) continue;
+    const registration = registry.get(channelType);
+    if (!registration?.spawnFromSecret) continue;
+    if (activeAdapters.has(adapterKey(channelType, botId))) continue;
+    const value = getSecret(row.name);
+    if (!value) {
+      log.warn('Channel bot secret has no value, skipping', { secret: row.name });
+      continue;
+    }
+    try {
+      const adapter = await registerBotAdapter(channelType, row.name, value);
+      if (!adapter) {
+        log.warn('Secrets-backed bot spawn returned null', { channel: channelType, botId });
+      }
+    } catch (err) {
+      log.error('Failed to spawn secrets-backed bot', { channel: channelType, botId, err });
     }
   }
 }

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -5,6 +5,7 @@
 import { createDiscordAdapter } from '@chat-adapter/discord';
 
 import { readEnvFile } from '../env.js';
+import type { ChannelAdapter } from './adapter.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
@@ -18,25 +19,52 @@ function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
   };
 }
 
+export interface DiscordSpawnInput {
+  botToken: string;
+  applicationId: string;
+  publicKey?: string;
+}
+
+/**
+ * Build (but don't `setup()`) a Discord channel adapter for the given bot
+ * credentials. Discord doesn't expose a getMe-equivalent for the bot user
+ * itself, so the bot's identity (`applicationId`) must be passed in by the
+ * caller — read from `.env`'s `DISCORD_APPLICATION_ID` for the primary
+ * adapter, or from the secret/operator input for dynamic per-bot adds.
+ *
+ * Used by:
+ *   - the channel-registry's startup factory below (single bot via `.env`)
+ *   - `registerBotAdapter('discord', { ... })` (dynamic per-bot adds)
+ *   - the secrets-backed startup scan
+ */
+export function spawnDiscordAdapter(input: DiscordSpawnInput): ChannelAdapter {
+  const { botToken, applicationId, publicKey } = input;
+  const botId = applicationId;
+  const discordAdapter = createDiscordAdapter({
+    botToken,
+    publicKey,
+    applicationId,
+  });
+  const bridge = createChatSdkBridge({
+    adapter: discordAdapter,
+    botId,
+    concurrency: 'concurrent',
+    botToken,
+    extractReplyContext,
+    supportsThreads: true,
+  });
+  return { ...bridge, botId };
+}
+
 registerChannelAdapter('discord', {
   factory: () => {
     const env = readEnvFile(['DISCORD_BOT_TOKEN', 'DISCORD_PUBLIC_KEY', 'DISCORD_APPLICATION_ID']);
     if (!env.DISCORD_BOT_TOKEN) return null;
     if (!env.DISCORD_APPLICATION_ID) return null;
-    const botId = env.DISCORD_APPLICATION_ID;
-    const discordAdapter = createDiscordAdapter({
+    return spawnDiscordAdapter({
       botToken: env.DISCORD_BOT_TOKEN,
-      publicKey: env.DISCORD_PUBLIC_KEY,
       applicationId: env.DISCORD_APPLICATION_ID,
+      publicKey: env.DISCORD_PUBLIC_KEY,
     });
-    const bridge = createChatSdkBridge({
-      adapter: discordAdapter,
-      botId,
-      concurrency: 'concurrent',
-      botToken: env.DISCORD_BOT_TOKEN,
-      extractReplyContext,
-      supportsThreads: true,
-    });
-    return { ...bridge, botId };
   },
 });

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -5,6 +5,7 @@
 import { createDiscordAdapter } from '@chat-adapter/discord';
 
 import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
 import type { ChannelAdapter } from './adapter.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
@@ -66,5 +67,24 @@ registerChannelAdapter('discord', {
       applicationId: env.DISCORD_APPLICATION_ID,
       publicKey: env.DISCORD_PUBLIC_KEY,
     });
+  },
+  /**
+   * Discord has no `getMe`-equivalent, so the applicationId must come from
+   * somewhere. Convention: `CHANNEL_BOT_TOKEN:discord:<applicationId>` —
+   * the trailing segment IS the applicationId. Public key is webhook-only
+   * (interaction mode); polling-mode bots leave it undefined.
+   */
+  spawnFromSecret: async (secretName, secretValue) => {
+    const applicationId = secretName.split(':').pop();
+    if (!applicationId) {
+      log.error('Discord spawnFromSecret got malformed secret name', { secretName });
+      return null;
+    }
+    try {
+      return spawnDiscordAdapter({ botToken: secretValue, applicationId });
+    } catch (err) {
+      log.error('Discord spawnFromSecret failed', { secretName, err });
+      return null;
+    }
   },
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -262,4 +262,18 @@ registerChannelAdapter('telegram', {
     if (!env.TELEGRAM_BOT_TOKEN) return null;
     return spawnTelegramAdapter(env.TELEGRAM_BOT_TOKEN);
   },
+  /**
+   * The token is the only thing Telegram needs — the bot's id and username
+   * are recovered via getMe inside spawnTelegramAdapter. The secretName's
+   * trailing segment IS the botId, but we don't need to parse it; the adapter
+   * resolves identity itself.
+   */
+  spawnFromSecret: async (_secretName, secretValue) => {
+    try {
+      return await spawnTelegramAdapter(secretValue);
+    } catch (err) {
+      log.error('Telegram spawnFromSecret failed', { err });
+      return null;
+    }
+  },
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -211,46 +211,55 @@ function createPairingInterceptor(
   };
 }
 
+/**
+ * Build (but don't `setup()`) a Telegram channel adapter for the given bot
+ * token. Resolves bot identity eagerly via `getMe` so the bridge can encode
+ * v2 platform_ids before any inbound traffic arrives.
+ *
+ * Used by:
+ *   - the channel-registry's startup factory below (single bot via `.env`)
+ *   - `registerBotAdapter('telegram', { token })` (dynamic per-bot adds via
+ *     `POST /api/channels/telegram/register-bot`, see channel-registry.ts)
+ *   - the secrets-backed startup scan (one adapter per
+ *     `CHANNEL_BOT_TOKEN:telegram:*` row across restarts)
+ *
+ * Throws on getMe failure; callers decide whether the bot is essential
+ * (factory: log + skip) or operator-driven (register-bot: surface as 4xx).
+ */
+export async function spawnTelegramAdapter(token: string): Promise<ChannelAdapter> {
+  const identity = await withRetry(() => fetchBotIdentity(token), 'getMe');
+  const { botId, username } = identity;
+
+  const telegramAdapter = createTelegramAdapter({
+    botToken: token,
+    mode: 'polling',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: telegramAdapter,
+    botId,
+    concurrency: 'concurrent',
+    extractReplyContext,
+    supportsThreads: false,
+    transformOutboundText: sanitizeTelegramLegacyMarkdown,
+  });
+
+  return {
+    ...bridge,
+    botId,
+    async setup(hostConfig: ChannelSetup) {
+      const intercepted: ChannelSetup = {
+        ...hostConfig,
+        onInbound: createPairingInterceptor(username, hostConfig.onInbound, token),
+      };
+      return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+    },
+  };
+}
+
 registerChannelAdapter('telegram', {
   factory: async () => {
     const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
     if (!env.TELEGRAM_BOT_TOKEN) return null;
-    const token = env.TELEGRAM_BOT_TOKEN;
-
-    // Resolve the bot identity (id + username) eagerly. The id keys the v2
-    // platform_id encoding and the registry slot, so we cannot defer it the
-    // way the old code lazily fetched the username for pairing — paraclaw
-    // would otherwise route all inbound traffic before knowing how to encode
-    // it. If getMe fails we surface the error so initChannelAdapters logs
-    // a clear "Failed to start channel adapter" instead of silently routing
-    // to the wrong key.
-    const identity = await withRetry(() => fetchBotIdentity(token), 'getMe');
-    const { botId, username } = identity;
-
-    const telegramAdapter = createTelegramAdapter({
-      botToken: token,
-      mode: 'polling',
-    });
-    const bridge = createChatSdkBridge({
-      adapter: telegramAdapter,
-      botId,
-      concurrency: 'concurrent',
-      extractReplyContext,
-      supportsThreads: false,
-      transformOutboundText: sanitizeTelegramLegacyMarkdown,
-    });
-
-    const wrapped: ChannelAdapter = {
-      ...bridge,
-      botId,
-      async setup(hostConfig: ChannelSetup) {
-        const intercepted: ChannelSetup = {
-          ...hostConfig,
-          onInbound: createPairingInterceptor(username, hostConfig.onInbound, token),
-        };
-        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
-      },
-    };
-    return wrapped;
+    return spawnTelegramAdapter(env.TELEGRAM_BOT_TOKEN);
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
   initChannelAdapters,
   teardownChannelAdapters,
   getChannelAdapterForPlatformId,
+  spawnSecretsBackedBots,
 } from './channels/channel-registry.js';
 
 async function main(): Promise<void> {
@@ -142,6 +143,13 @@ async function main(): Promise<void> {
   // tokens into the secrets table and rewrite legacy v1 messaging_groups
   // platform_ids to the v2 form. Idempotent; safe across restarts.
   runStartupBootstrap();
+
+  // 3c. Bring up adapters for every additional bot the operator has
+  // registered via the dynamic register-bot endpoint. Runs after the `.env`
+  // primary is up + bootstrap has populated the secrets table, so we know
+  // the primary's `(channelType, botId)` is already covered and won't be
+  // re-registered.
+  await spawnSecretsBackedBots();
 
   // 4. Delivery adapter bridge — dispatches to channel adapters
   const deliveryAdapter = {

--- a/src/startup-bootstrap.ts
+++ b/src/startup-bootstrap.ts
@@ -63,12 +63,24 @@ export function bootstrapChannelTokensToSecrets(): void {
     const value = env[envVar];
     if (!value) continue;
     const name = channelTokenSecretName(adapter.channelType, adapter.botId);
-    if (getSecret(name) === value) continue;
+    const existing = getSecret(name);
+    if (existing === value) continue;
     putSecret(name, value, { kind: 'channel-token', agent_group_id: null });
-    log.info('Bootstrapped channel bot token to secrets', {
-      channelType: adapter.channelType,
-      botId: adapter.botId,
-    });
+    if (existing === undefined) {
+      log.info('Bootstrapped channel bot token to secrets', {
+        channelType: adapter.channelType,
+        botId: adapter.botId,
+      });
+    } else {
+      // `.env` value diverged from what we previously stored — operator
+      // rotated the token. Single line so token-rotation events show up
+      // in `logs/paraclaw.log` without needing a separate observability
+      // surface.
+      log.info('Channel bot token rotated', {
+        channelType: adapter.channelType,
+        botId: adapter.botId,
+      });
+    }
   }
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -68,7 +68,7 @@ import { wireDmToAgent } from './wire-channel.js';
 import { getChannelAdapter, registerBotAdapter } from '../channels/channel-registry.js';
 import { validateDiscordBotToken } from './discord-validate.js';
 import { validateTelegramBotToken } from './telegram-validate.js';
-import { putSecret } from '../secrets/index.js';
+import { getSecret, putSecret } from '../secrets/index.js';
 import { channelTokenSecretName } from '../startup-bootstrap.js';
 
 const PROJECT_ROOT = process.cwd();
@@ -292,13 +292,15 @@ async function handleApi(
       // Persist before bringing up the adapter so a crash mid-setup still
       // leaves the token recoverable on next boot's spawnSecretsBackedBots.
       const secretName = channelTokenSecretName(adapter, botId);
+      const existing = getSecret(secretName);
+      const isRotation = existing !== undefined && existing !== token;
       putSecret(secretName, token, { kind: 'channel-token', agent_group_id: null });
       const live = await registerBotAdapter(adapter, secretName, token);
       if (!live) {
         error(res, 502, `${adapter} register-bot: spawnFromSecret returned null after a successful validate`);
         return;
       }
-      log.info('Channel bot registered', { adapter, botId });
+      log.info(isRotation ? 'Channel bot token rotated' : 'Channel bot registered', { adapter, botId });
       json(res, 200, { ok: true, botId, username });
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -279,12 +279,16 @@ async function handleApi(
         return;
       }
       // Validate first so we have a botId for the secret name and can fail
-      // fast on bad tokens without writing anything to the DB.
+      // fast on bad tokens without writing anything to the DB. We emit the
+      // error via the standard `{ error }` shape so the client's request<>
+      // wrapper extracts it cleanly — this endpoint is the SPA's only
+      // upstream-validation hop now that WireChannelPage skips the separate
+      // /test call.
       const validation =
         adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       if (!validation.ok) {
         const httpStatus = validation.status === 401 ? 400 : validation.status;
-        json(res, httpStatus, validation);
+        error(res, httpStatus, validation.error);
         return;
       }
       const botId = String(validation.identity.id);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,9 +65,11 @@ import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
 import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 import { wireDmToAgent } from './wire-channel.js';
-import { getChannelAdapter } from '../channels/channel-registry.js';
+import { getChannelAdapter, registerBotAdapter } from '../channels/channel-registry.js';
 import { validateDiscordBotToken } from './discord-validate.js';
 import { validateTelegramBotToken } from './telegram-validate.js';
+import { putSecret } from '../secrets/index.js';
+import { channelTokenSecretName } from '../startup-bootstrap.js';
 
 const PROJECT_ROOT = process.cwd();
 const UI_DIST = path.resolve(PROJECT_ROOT, 'web/ui/dist');
@@ -251,6 +253,53 @@ async function handleApi(
         adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       const httpStatus = result.ok ? 200 : result.status === 401 ? 400 : result.status;
       json(res, httpStatus, result);
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
+  // Persist + bring up an additional bot adapter at runtime. The wire-
+  // channel UI hits this after a successful /test so the operator can wire
+  // a NEW bot's token without restarting the host. Idempotent on
+  // (channelType, botId): re-posting the same token just refreshes the
+  // ciphertext and returns the already-active adapter's identity.
+  if (method === 'POST' && /^\/api\/channels\/[^/]+\/register-bot$/.test(pathname)) {
+    if (!(await gate(req, res, SCOPE_CLAW_ADMIN))) return;
+    const adapter = pathname.split('/')[3];
+    if (adapter !== 'discord' && adapter !== 'telegram') {
+      error(res, 404, `unknown adapter: ${adapter}`);
+      return;
+    }
+    try {
+      const body = await readJsonBody<{ token?: string }>(req);
+      const token = (body.token ?? '').trim();
+      if (!token) {
+        error(res, 400, 'token is required');
+        return;
+      }
+      // Validate first so we have a botId for the secret name and can fail
+      // fast on bad tokens without writing anything to the DB.
+      const validation =
+        adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
+      if (!validation.ok) {
+        const httpStatus = validation.status === 401 ? 400 : validation.status;
+        json(res, httpStatus, validation);
+        return;
+      }
+      const botId = String(validation.identity.id);
+      const username = validation.identity.username;
+      // Persist before bringing up the adapter so a crash mid-setup still
+      // leaves the token recoverable on next boot's spawnSecretsBackedBots.
+      const secretName = channelTokenSecretName(adapter, botId);
+      putSecret(secretName, token, { kind: 'channel-token', agent_group_id: null });
+      const live = await registerBotAdapter(adapter, secretName, token);
+      if (!live) {
+        error(res, 502, `${adapter} register-bot: spawnFromSecret returned null after a successful validate`);
+        return;
+      }
+      log.info('Channel bot registered', { adapter, botId });
+      json(res, 200, { ok: true, botId, username });
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));
     }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -931,6 +931,35 @@ export async function testTelegramToken(token: string): Promise<{ identity: Tele
   });
 }
 
+// --- Dynamic bot registration (used after token validate, before wire) ---
+
+export interface RegisterChannelBotResult {
+  ok: true;
+  botId: string;
+  username: string;
+}
+
+/**
+ * Persist the validated bot token to /secrets and bring up its adapter at
+ * runtime. Idempotent on `(channel, botId)` — re-posting the same token
+ * refreshes the ciphertext and returns the already-active adapter.
+ *
+ * Run this AFTER `testDiscordToken` / `testTelegramToken` succeeds so the
+ * server can fail fast on bad tokens before any DB write. The returned
+ * `botId` is what the next `wireChannelToGroup` call should pass as
+ * `botUserId` for Discord (where botId == bot's snowflake), and as the
+ * basis of the operator-id for Telegram.
+ */
+export async function registerChannelBot(
+  channel: ChannelKind,
+  token: string,
+): Promise<RegisterChannelBotResult> {
+  return request<RegisterChannelBotResult>(`/channels/${encodeURIComponent(channel)}/register-bot`, {
+    method: 'POST',
+    json: { token },
+  });
+}
+
 // --- Channel wiring (per-group, used by wizard step 7) ---
 
 export interface WireChannelResult {

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -30,7 +30,7 @@ import {
   type ChannelAdapter,
   type ResolvedIdentity,
 } from '../lib/channel-adapters.ts';
-import { wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
+import { registerChannelBot, wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
 
 export function WireChannelPage() {
   const [adapterKey, setAdapterKey] = useState<ChannelAdapter | null>(null);
@@ -66,8 +66,19 @@ export function WireChannelPage() {
     setValidating(true);
     setValidateError(null);
     try {
-      const r = await adapter.validate(token.trim());
-      setIdentity(r);
+      const trimmed = token.trim();
+      // Hit the per-adapter validator first so the user-facing error from a
+      // bad token names the platform's rejection ("telegram rejected token:
+      // …") rather than a 502 from the register-bot path. Then immediately
+      // register-bot, which persists the token to /secrets and brings up the
+      // adapter at runtime — a single user gesture covers both.
+      const validated = await adapter.validate(trimmed);
+      const registered = await registerChannelBot(adapter.key, trimmed);
+      // Server's register-bot is authoritative on botId — for Discord the
+      // validator returns the user.id which matches application.id for bot
+      // accounts, but in case they ever drift we trust whatever the live
+      // adapter resolved.
+      setIdentity({ id: registered.botId, username: registered.username || validated.username });
       setToken('');
     } catch (err) {
       setValidateError(err instanceof Error ? err.message : String(err));
@@ -191,7 +202,8 @@ export function WireChannelPage() {
         <Section step={2} title={`Bot identity — ${adapter.label}`}>
           <p className="dim" style={{ marginTop: 0 }}>
             We hit <code>{adapter.upstreamProbePath}</code> to confirm the token authenticates and the account
-            is a bot. Get a token from{' '}
+            is a bot, then encrypt-and-store it under <code>secrets</code> and bring up the adapter so
+            the bot is live across host restarts. Get a token from{' '}
             <a href={adapter.tokenHelp.href} target="_blank" rel="noreferrer">
               {adapter.tokenHelp.title}
             </a>
@@ -201,7 +213,7 @@ export function WireChannelPage() {
           {identity ? (
             <div className="empty empty-rich" style={{ marginTop: '0.5rem' }}>
               <p className="empty-headline" style={{ margin: 0 }}>
-                Bot identified: <code>@{identity.username}</code>{' '}
+                Bot registered: <code>@{identity.username}</code>{' '}
                 <span className="dim">
                   (id <code>{identity.id}</code>)
                 </span>
@@ -214,7 +226,7 @@ export function WireChannelPage() {
                   setToken('');
                 }}
               >
-                Re-validate with a different token
+                Use a different token
               </button>
             </div>
           ) : (
@@ -233,7 +245,7 @@ export function WireChannelPage() {
               {validateError && <div className="error-banner">{validateError}</div>}
               <div className="actions" style={{ marginTop: '0.5rem' }}>
                 <button onClick={onValidate} disabled={!token.trim() || validating}>
-                  {validating ? 'Validating…' : 'Validate token'}
+                  {validating ? 'Validating + registering…' : 'Validate & register bot'}
                 </button>
               </div>
             </>

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -67,18 +67,18 @@ export function WireChannelPage() {
     setValidateError(null);
     try {
       const trimmed = token.trim();
-      // Hit the per-adapter validator first so the user-facing error from a
-      // bad token names the platform's rejection ("telegram rejected token:
-      // …") rather than a 502 from the register-bot path. Then immediately
-      // register-bot, which persists the token to /secrets and brings up the
-      // adapter at runtime — a single user gesture covers both.
-      const validated = await adapter.validate(trimmed);
+      // Single hop: register-bot validates upstream, persists to /secrets,
+      // and brings the adapter live in one server round-trip. The server
+      // surfaces the upstream platform's rejection message via the standard
+      // `{ error }` shape on bad tokens, so we don't need a separate /test
+      // pre-call.
+      //
+      // Re-posting the same bot's secret with a new token persists the
+      // rotation immediately but the live polling loop keeps the old token
+      // until the next host restart — same as a `.env` rotation. Operators
+      // doing a forced rotation should restart paraclaw.
       const registered = await registerChannelBot(adapter.key, trimmed);
-      // Server's register-bot is authoritative on botId — for Discord the
-      // validator returns the user.id which matches application.id for bot
-      // accounts, but in case they ever drift we trust whatever the live
-      // adapter resolved.
-      setIdentity({ id: registered.botId, username: registered.username || validated.username });
+      setIdentity({ id: registered.botId, username: registered.username });
       setToken('');
     } catch (err) {
       setValidateError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

B2 of the paraclaw#67 split — stacked on #69. Lands the multi-bot infrastructure that lets paraclaw run **more than one bot per channel-type** (e.g. two Telegram bots → two agent groups) without restarting the host.

**Base: `feat/channel-wiring-impl` (PR #69 / B1)**, not `night/paraclaw-rebirth`. Per the stacked-PR convention, B2 includes B1's commits so end-to-end testing on Aaron's bun-link checkout works against a complete branch. After B1 merges I'll rebase B2 onto fresh main and re-push.

## What this lands

### Dynamic register-bot hook (`src/channels/`)

- `ChannelSpawnFromSecret` (adapter.ts) — channels expose a hook that builds an adapter from a stored `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret. Telegram resolves identity via `getMe`, Discord parses `applicationId` from the secret name's trailing segment (no getMe equivalent on Discord).
- `setupAdapterWithRetry` extracted (channel-registry.ts) so boot-time and runtime adds get identical resilience semantics.
- `cachedSetupFn` on the registry — captured during `initChannelAdapters`, reused by `registerBotAdapter` and the boot-time `spawnSecretsBackedBots()` scan so dynamic adds use the same host callbacks as the primary adapter.
- `registerBotAdapter(channelType, secretName, secretValue)` — runtime entry point; idempotent on `(channelType, botId)` (no-op on a repeat call with the same bot).
- `spawnSecretsBackedBots()` — boot-time scan of `secrets` for rows with `kind: 'channel-token'` named `CHANNEL_BOT_TOKEN:<channel>:<botId>`; brings each one live without restart. Wired into `src/index.ts` step 3c, after `initChannelAdapters` + `runStartupBootstrap`.
- Refactor: `spawnTelegramAdapter` / `spawnDiscordAdapter` helpers extracted so the static `factory` and dynamic `spawnFromSecret` paths share construction.

### HTTP endpoint (`POST /api/channels/{adapter}/register-bot`)

- `claw:admin` gated (matches `/api/secrets` POST — anyone with the scope to write secrets can register a bot).
- Flow: validate token via existing per-adapter validator → persist token to secrets *first* (so a crash mid-setup leaves the token recoverable on next boot's `spawnSecretsBackedBots`) → call `registerBotAdapter`. Idempotent on `(channelType, botId)`.
- Returns `{ ok: true, botId, username }` on success; emits validation failures via the standard `{ error }` shape so SPA `request<>` extracts the message cleanly.

### UI (`WireChannelPage`)

- One server round-trip per registration: the page's `Validate & register bot` button now hits only `/register-bot`, which validates upstream internally and returns the resolved identity. (Previously called `/test` then `/register-bot` — same upstream, same token, doubled API quota.)
- Server-returned identity is authoritative on `botId`.

### Token rotation behavior — read this carefully

When the same bot is re-registered with a new token (operator rotated upstream), the new token is persisted to secrets immediately, **but the live polling loop continues to use the old token until the next host restart.** This is intentional and matches `.env` rotation behavior — `bootstrapChannelTokensToSecrets` and `register-bot` both write-through and let the next boot pick up the new value. Operators doing a forced rotation should restart paraclaw.

The rotation is observable in logs: both paths emit `"Channel bot token rotated"` (vs `"Bootstrapped"` / `"Channel bot registered"` for first-write).

A respawn-on-rotation path is feasible (tear down old polling loop, spawn fresh) but operationally rare; deferred until there's a real need.

### Tests (`channel-registry.test.ts`)

New "multi-bot routing via dynamic register-bot" suite — 4 tests:
- two-bot routing via `encodePlatformId` + `getChannelAdapterForPlatformId`
- `registerBotAdapter` idempotency on `(channelType, botId)`
- throws on a channel without `spawnFromSecret`
- `spawnSecretsBackedBots()` restores bots after simulated restart

### Versioning

`0.0.14-rc.24 → 0.0.14-rc.25`.

## Test plan

- [x] Host typecheck: `pnpm typecheck` — clean
- [x] Host tests: `pnpm test` — 403/403 pass (45 files; +4 over B1's 399)
- [x] UI typecheck: `cd web/ui && pnpm typecheck` — clean
- [x] Prettier: `pnpm format:check` — clean
- [ ] Browser exercise (reviewer + Aaron): on a fresh install with a primary discord bot already wired, hit `/claw/channels/new`, validate-and-register a *second* discord token, complete the wire flow; confirm both bots route correctly without restart. Then simulate restart (kickstart the launchd job) and confirm both bots come back live via `spawnSecretsBackedBots()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)