### PR TITLE
feat: multi-bot wiring + deferred spawn + operator trust hint (paraclaw#67 PR B)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ The frontend bundle in `web/ui/` is intentionally outside the pnpm workspace (th
 cd web/ui && pnpm install --ignore-workspace && pnpm test
 ```
 
-Otherwise the runner exits with `ERR_MODULE_NOT_FOUND: @vitejs/plugin-react`.
+Otherwise the test runner exits with a missing-dependency error (the exact symptom — module-not-found on `@vitejs/plugin-react`, missing test framework, etc. — depends on which entry point your package manager hits first).
 
 ## Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.24",
+  "version": "0.0.14-rc.25",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.26",
+  "version": "0.0.14-rc.27",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.25",
+  "version": "0.0.14-rc.26",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/channels/adapter.ts
+++ b/src/channels/adapter.ts
@@ -178,9 +178,35 @@ export interface ChannelAdapter {
 /** Factory function that creates a channel adapter (returns null if credentials missing). */
 export type ChannelAdapterFactory = () => ChannelAdapter | null | Promise<ChannelAdapter | null>;
 
+/**
+ * Build an adapter from a stored secret. Channel modules implement this so
+ * the registry's secrets-backed startup scan and the dynamic register-bot
+ * endpoint can spawn additional bot adapters beyond the `.env`-defined
+ * primary, without channel-registry needing to know per-channel internals.
+ *
+ * Receives the full secret name (e.g. `CHANNEL_BOT_TOKEN:discord:9128…`)
+ * and its plaintext value (the bot token). Adapters that need more than
+ * just a token (Discord needs `applicationId`) parse it out of the name's
+ * trailing segment, which by convention is the bot's identity.
+ *
+ * Returns the adapter ready for `setup()`; the caller wires up host
+ * callbacks. Returns null if the secret can't produce a viable adapter
+ * (e.g. token rejected by the platform); callers log + skip.
+ */
+export type ChannelSpawnFromSecret = (secretName: string, secretValue: string) => Promise<ChannelAdapter | null>;
+
 /** Registration entry for a channel adapter. */
 export interface ChannelRegistration {
   factory: ChannelAdapterFactory;
+  /**
+   * Optional. Channels that support multi-bot operation expose this so the
+   * registry can spawn additional bots from `CHANNEL_BOT_TOKEN:<channel>:*`
+   * secrets at boot time and on-demand via the register-bot HTTP endpoint.
+   *
+   * Channels without it support exactly one bot per install (the
+   * `.env`-defined primary).
+   */
+  spawnFromSecret?: ChannelSpawnFromSecret;
   containerConfig?: {
     mounts?: Array<{ hostPath: string; containerPath: string; readonly: boolean }>;
     env?: Record<string, string>;

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -233,3 +233,157 @@ describe('channel + router integration', () => {
     expect((mockAdapter.delivered[0].content as { text: string }).text).toBe('Agent response');
   });
 });
+
+describe('multi-bot routing via dynamic register-bot', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    const { initTestDb, runMigrations } = await import('../db/index.js');
+    const db = initTestDb();
+    runMigrations(db);
+    const { _resetActiveAdaptersForTest } = await import('./channel-registry.js');
+    _resetActiveAdaptersForTest();
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../db/index.js');
+    const { _resetActiveAdaptersForTest } = await import('./channel-registry.js');
+    _resetActiveAdaptersForTest();
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('registers two bots on the same channel-type and routes by botId', async () => {
+    const {
+      registerChannelAdapter,
+      registerBotAdapter,
+      initChannelAdapters,
+      getActiveAdapters,
+      getChannelAdapter,
+      getChannelAdapterForPlatformId,
+    } = await import('./channel-registry.js');
+    const { encodePlatformId } = await import('../platform-id.js');
+
+    // Channel that supports multi-bot — spawnFromSecret returns a fresh
+    // adapter whose botId is parsed from the secret name's trailing segment.
+    // Mirrors discord.ts's spawnFromSecret shape; telegram would call getMe
+    // but we keep the test in-memory.
+    registerChannelAdapter('multi-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('multi-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    // Init with no .env-backed primary, then dynamically register two bots.
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    const a = await registerBotAdapter('multi-mock', 'CHANNEL_BOT_TOKEN:multi-mock:bot-A', 'token-A');
+    const b = await registerBotAdapter('multi-mock', 'CHANNEL_BOT_TOKEN:multi-mock:bot-B', 'token-B');
+    expect(a?.botId).toBe('bot-A');
+    expect(b?.botId).toBe('bot-B');
+
+    // Both adapters live, keyed independently.
+    const active = getActiveAdapters().filter((x) => x.channelType === 'multi-mock');
+    expect(active).toHaveLength(2);
+    expect(active.map((x) => x.botId).sort()).toEqual(['bot-A', 'bot-B']);
+
+    // v2 platform_id's bot segment selects the right adapter.
+    const pidA = encodePlatformId('multi-mock', 'bot-A', 'chat-1');
+    const pidB = encodePlatformId('multi-mock', 'bot-B', 'chat-1');
+    expect(getChannelAdapterForPlatformId('multi-mock', pidA)).toBe(a);
+    expect(getChannelAdapterForPlatformId('multi-mock', pidB)).toBe(b);
+
+    // Channel-type-only lookup picks one (not deterministic which) — that
+    // path is for legacy v1 ids only; prove it doesn't throw.
+    expect(getChannelAdapter('multi-mock')).toBeDefined();
+  });
+
+  it('register-bot is idempotent on (channelType, botId)', async () => {
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } = await import(
+      './channel-registry.js'
+    );
+
+    registerChannelAdapter('idem-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('idem-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    const first = await registerBotAdapter('idem-mock', 'CHANNEL_BOT_TOKEN:idem-mock:bot-X', 'token-X');
+    const second = await registerBotAdapter('idem-mock', 'CHANNEL_BOT_TOKEN:idem-mock:bot-X', 'token-X-rotated');
+    expect(first?.botId).toBe('bot-X');
+    expect(second).toBe(first);
+    const active = getActiveAdapters().filter((x) => x.channelType === 'idem-mock');
+    expect(active).toHaveLength(1);
+  });
+
+  it('register-bot throws on a channel without spawnFromSecret', async () => {
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters } = await import('./channel-registry.js');
+
+    registerChannelAdapter('single-only', { factory: () => null });
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+    await expect(registerBotAdapter('single-only', 'CHANNEL_BOT_TOKEN:single-only:x', 'tok')).rejects.toThrow(
+      /multi-bot/,
+    );
+  });
+
+  it('spawnSecretsBackedBots brings up persisted bots after restart', async () => {
+    const {
+      registerChannelAdapter,
+      initChannelAdapters,
+      spawnSecretsBackedBots,
+      getActiveAdapters,
+      _resetActiveAdaptersForTest,
+    } = await import('./channel-registry.js');
+    const { putSecret } = await import('../secrets/index.js');
+
+    registerChannelAdapter('boot-mock', {
+      factory: () => null,
+      spawnFromSecret: async (secretName) => {
+        const botId = secretName.split(':').pop()!;
+        const adapter = createMockAdapter('boot-mock');
+        return { ...adapter, botId };
+      },
+    });
+
+    // Persist two tokens as if a previous boot had registered them.
+    putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-1', 'tok-1', { kind: 'channel-token', agent_group_id: null });
+    putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-2', 'tok-2', { kind: 'channel-token', agent_group_id: null });
+
+    await initChannelAdapters(() => ({
+      onInbound: () => {},
+      onInboundEvent: () => {},
+      onMetadata: () => {},
+      onAction: () => {},
+    }));
+
+    // Simulate restart: clear actives, then run the boot scan.
+    _resetActiveAdaptersForTest();
+    await spawnSecretsBackedBots();
+    const active = getActiveAdapters().filter((x) => x.channelType === 'boot-mock');
+    expect(active.map((x) => x.botId).sort()).toEqual(['bot-1', 'bot-2']);
+  });
+});

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -307,9 +307,8 @@ describe('multi-bot routing via dynamic register-bot', () => {
   });
 
   it('register-bot is idempotent on (channelType, botId)', async () => {
-    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } = await import(
-      './channel-registry.js'
-    );
+    const { registerChannelAdapter, registerBotAdapter, initChannelAdapters, getActiveAdapters } =
+      await import('./channel-registry.js');
 
     registerChannelAdapter('idem-mock', {
       factory: () => null,

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -103,7 +103,6 @@ describe('channel registry', () => {
     });
 
     await initChannelAdapters(() => ({
-      conversations: [],
       onInbound: () => {},
       onInboundEvent: () => {},
       onMetadata: () => {},
@@ -207,7 +206,6 @@ describe('channel + router integration', () => {
     });
 
     await initChannelAdapters(() => ({
-      conversations: [],
       onInbound: () => {},
       onInboundEvent: () => {},
       onMetadata: () => {},

--- a/src/channels/channel-registry.test.ts
+++ b/src/channels/channel-registry.test.ts
@@ -347,7 +347,7 @@ describe('multi-bot routing via dynamic register-bot', () => {
     );
   });
 
-  it('spawnSecretsBackedBots brings up persisted bots after restart', async () => {
+  it('spawnSecretsBackedBots brings up only bots that have at least one MGA wiring', async () => {
     const {
       registerChannelAdapter,
       initChannelAdapters,
@@ -356,6 +356,8 @@ describe('multi-bot routing via dynamic register-bot', () => {
       _resetActiveAdaptersForTest,
     } = await import('./channel-registry.js');
     const { putSecret } = await import('../secrets/index.js');
+    const { createMessagingGroup, createMessagingGroupAgent } = await import('../db/messaging-groups.js');
+    const { createAgentGroup } = await import('../db/agent-groups.js');
 
     registerChannelAdapter('boot-mock', {
       factory: () => null,
@@ -366,9 +368,42 @@ describe('multi-bot routing via dynamic register-bot', () => {
       },
     });
 
-    // Persist two tokens as if a previous boot had registered them.
+    // Persist two tokens — only one is wired to a group. The other is an
+    // orphan that the scan must skip (paraclaw#67 Proposal A: registered
+    // but inert bots don't auto-spawn at boot, because doing so re-opens
+    // the validate-then-poll race the deferred-spawn rework was meant to
+    // remove).
     putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-1', 'tok-1', { kind: 'channel-token', agent_group_id: null });
     putSecret('CHANNEL_BOT_TOKEN:boot-mock:bot-2', 'tok-2', { kind: 'channel-token', agent_group_id: null });
+
+    createAgentGroup({
+      id: 'ag-test',
+      folder: 'test-group',
+      name: 'Test',
+      agent_provider: null,
+      created_at: now(),
+    });
+    createMessagingGroup({
+      id: 'mg-bot1',
+      channel_type: 'boot-mock',
+      platform_id: 'boot-mock:bot-1:dm',
+      name: null,
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: now(),
+    });
+    createMessagingGroupAgent({
+      id: 'mga-bot1',
+      messaging_group_id: 'mg-bot1',
+      agent_group_id: 'ag-test',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'all',
+      ignored_message_policy: 'drop',
+      session_mode: 'shared',
+      priority: 0,
+      created_at: now(),
+    });
 
     await initChannelAdapters(() => ({
       onInbound: () => {},
@@ -381,6 +416,6 @@ describe('multi-bot routing via dynamic register-bot', () => {
     _resetActiveAdaptersForTest();
     await spawnSecretsBackedBots();
     const active = getActiveAdapters().filter((x) => x.channelType === 'boot-mock');
-    expect(active.map((x) => x.botId).sort()).toEqual(['bot-1', 'bot-2']);
+    expect(active.map((x) => x.botId).sort()).toEqual(['bot-1']);
   });
 });

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -96,11 +96,7 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
  * {@link initChannelAdapters} and the dynamic register helpers share so
  * boot-time and runtime adds get identical resilience semantics.
  */
-async function setupAdapterWithRetry(
-  adapter: ChannelAdapter,
-  setup: ChannelSetup,
-  label: string,
-): Promise<void> {
+async function setupAdapterWithRetry(adapter: ChannelAdapter, setup: ChannelSetup, label: string): Promise<void> {
   let attempt = 0;
   while (true) {
     try {

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -5,6 +5,7 @@
  * to instantiate and set up all registered adapters.
  */
 import type { ChannelAdapter, ChannelRegistration, ChannelSetup } from './adapter.js';
+import { getDb } from '../db/connection.js';
 import { log } from '../log.js';
 import { decodePlatformIdAs } from '../platform-id.js';
 import { listSecrets, getSecret } from '../secrets/index.js';
@@ -59,6 +60,11 @@ export function getChannelAdapter(channelType: string): ChannelAdapter | undefin
     if (key.startsWith(`${channelType}\0`)) return adapter;
   }
   return undefined;
+}
+
+/** Resolve a live adapter by exact `(channelType, botId)`. Returns undefined if no adapter for that bot is active. */
+export function getChannelAdapterByBotId(channelType: string, botId: string): ChannelAdapter | undefined {
+  return activeAdapters.get(adapterKey(channelType, botId));
 }
 
 /**
@@ -202,17 +208,23 @@ export async function registerBotAdapter(
 
 /**
  * Boot-time scan that brings up adapters for every persisted
- * `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret whose adapter isn't already
- * active. Run AFTER `initChannelAdapters` (which seeds the primary `.env`
- * adapter) and AFTER `runStartupBootstrap` (which copies `.env` tokens into
- * the secrets table); the combination ensures the primary bot stays primary
- * while every additional bot the operator has registered comes back online
- * across restarts.
+ * `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret that (a) has at least one
+ * wired messaging_group_agents row and (b) isn't already covered by the
+ * `.env`-seeded primary adapter. Run AFTER `initChannelAdapters` and
+ * AFTER `runStartupBootstrap`.
  *
- * Skips channels with no `spawnFromSecret` hook and skips secrets whose
- * `(channelType, botId)` is already covered by an active adapter (the
- * primary). Logs but doesn't throw on individual spawn failures — one bad
- * token shouldn't keep the rest offline.
+ * Orphan rule (paraclaw#67 Proposal A): a secret with no MGA wiring is
+ * "registered but inert" — the operator validated a token but never
+ * committed it to a group. We deliberately don't spawn its adapter at
+ * boot, because doing so would re-introduce the validate-then-poll race
+ * that pre-A behavior had: an adapter polling without a wire feeds
+ * inbounds straight into the unwired-channel approval cascade. Operators
+ * recover by completing the wire from `/claw/channels/new` (the wire
+ * endpoint spawns the adapter atomically with the MGA insert).
+ *
+ * Skips channels with no `spawnFromSecret` hook. Logs but doesn't throw
+ * on individual spawn failures — one bad token shouldn't keep the rest
+ * offline.
  */
 export async function spawnSecretsBackedBots(): Promise<void> {
   const tokens = listSecrets(null).filter((s) => s.kind === 'channel-token' && s.name.startsWith('CHANNEL_BOT_TOKEN:'));
@@ -225,6 +237,10 @@ export async function spawnSecretsBackedBots(): Promise<void> {
     const registration = registry.get(channelType);
     if (!registration?.spawnFromSecret) continue;
     if (activeAdapters.has(adapterKey(channelType, botId))) continue;
+    if (!hasWiringForBot(channelType, botId)) {
+      log.info('Skipping orphan channel bot secret (no wiring)', { channel: channelType, botId });
+      continue;
+    }
     const value = getSecret(row.name);
     if (!value) {
       log.warn('Channel bot secret has no value, skipping', { secret: row.name });
@@ -239,6 +255,35 @@ export async function spawnSecretsBackedBots(): Promise<void> {
       log.error('Failed to spawn secrets-backed bot', { channel: channelType, botId, err });
     }
   }
+}
+
+/**
+ * Returns true iff at least one messaging_group_agents row exists wired
+ * through a messaging_groups row whose platform_id encodes the given
+ * `(channelType, botId)` pair (v2 format `<channel>:<botId>:<native>`).
+ *
+ * v1 rows (no bot dimension) for the same channel match nothing here —
+ * the secrets-backed scan only runs for bots that have a botId in their
+ * secret name, and v1 wires don't carry one. That's the correct
+ * conservative answer: a v1 wire could belong to *any* bot on that
+ * channel, so we can't safely auto-attribute it to this secret.
+ */
+function hasWiringForBot(channelType: string, botId: string): boolean {
+  const row = getDb()
+    .prepare(
+      `SELECT 1
+         FROM messaging_groups mg
+         JOIN messaging_group_agents mga ON mga.messaging_group_id = mg.id
+        WHERE mg.channel_type = ?
+          AND mg.platform_id LIKE ? ESCAPE '\\'
+        LIMIT 1`,
+    )
+    .get(channelType, `${channelType}:${escapeLike(botId)}:%`);
+  return row !== undefined;
+}
+
+function escapeLike(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 /**

--- a/src/channels/channel-registry.ts
+++ b/src/channels/channel-registry.ts
@@ -7,6 +7,7 @@
 import type { ChannelAdapter, ChannelRegistration, ChannelSetup } from './adapter.js';
 import { log } from '../log.js';
 import { decodePlatformIdAs } from '../platform-id.js';
+import { listSecrets, getSecret } from '../secrets/index.js';
 
 const SETUP_RETRY_DELAYS_MS = [2000, 5000, 10000];
 
@@ -27,6 +28,15 @@ const registry = new Map<string, ChannelRegistration>();
  * botId.
  */
 const activeAdapters = new Map<string, ChannelAdapter>();
+
+/**
+ * Cached host-callbacks builder, set by {@link initChannelAdapters} the
+ * first time it runs. Reused by {@link spawnSecretsBackedBots} (boot scan)
+ * and {@link registerBotAdapter} (dynamic per-bot adds via the HTTP
+ * register-bot endpoint) so every adapter — primary or dynamic — wires
+ * inbound through the same router callbacks.
+ */
+let cachedSetupFn: ((adapter: ChannelAdapter) => ChannelSetup) | null = null;
 
 function adapterKey(channelType: string, botId: string | null | undefined): string {
   return `${channelType}\0${botId ?? ''}`;
@@ -82,10 +92,44 @@ export function getChannelContainerConfig(name: string): ChannelRegistration['co
 }
 
 /**
+ * Run an adapter's setup with NetworkError retry — the same retry loop both
+ * {@link initChannelAdapters} and the dynamic register helpers share so
+ * boot-time and runtime adds get identical resilience semantics.
+ */
+async function setupAdapterWithRetry(
+  adapter: ChannelAdapter,
+  setup: ChannelSetup,
+  label: string,
+): Promise<void> {
+  let attempt = 0;
+  while (true) {
+    try {
+      await adapter.setup(setup);
+      return;
+    } catch (err) {
+      if (isNetworkError(err) && attempt < SETUP_RETRY_DELAYS_MS.length) {
+        const delay = SETUP_RETRY_DELAYS_MS[attempt]!;
+        log.warn('Channel adapter setup failed with network error, retrying', {
+          channel: label,
+          attempt: attempt + 1,
+          delayMs: delay,
+          err: err.message,
+        });
+        await sleep(delay);
+        attempt += 1;
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
  * Instantiate and set up all registered channel adapters.
  * Skips adapters that return null (missing credentials).
  */
 export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => ChannelSetup): Promise<void> {
+  cachedSetupFn = setupFn;
   for (const [name, registration] of registry) {
     try {
       const adapter = await registration.factory();
@@ -94,32 +138,11 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
         continue;
       }
 
-      const setup = setupFn(adapter);
       // Transient network failures during adapter init (e.g. Telegram deleteWebhook
       // hitting a DNS hiccup at boot) would otherwise leave the channel permanently
       // dead until manual restart. Retry only on NetworkError so misconfigs (bad
       // tokens, etc.) still fail fast.
-      let attempt = 0;
-      while (true) {
-        try {
-          await adapter.setup(setup);
-          break;
-        } catch (err) {
-          if (isNetworkError(err) && attempt < SETUP_RETRY_DELAYS_MS.length) {
-            const delay = SETUP_RETRY_DELAYS_MS[attempt]!;
-            log.warn('Channel adapter setup failed with network error, retrying', {
-              channel: name,
-              attempt: attempt + 1,
-              delayMs: delay,
-              err: err.message,
-            });
-            await sleep(delay);
-            attempt += 1;
-            continue;
-          }
-          throw err;
-        }
-      }
+      await setupAdapterWithRetry(adapter, setupFn(adapter), name);
       activeAdapters.set(adapterKey(adapter.channelType, adapter.botId), adapter);
       log.info('Channel adapter started', {
         channel: name,
@@ -128,6 +151,96 @@ export async function initChannelAdapters(setupFn: (adapter: ChannelAdapter) => 
       });
     } catch (err) {
       log.error('Failed to start channel adapter', { channel: name, err });
+    }
+  }
+}
+
+/**
+ * Register an adapter for a specific bot at runtime — used by the
+ * `POST /api/channels/{channel}/register-bot` endpoint after the operator
+ * pastes a token via the wire-channel UI.
+ *
+ * Resolves the channel's `spawnFromSecret` hook to build the adapter, runs
+ * setup with the same callbacks the primary adapter uses, and slots it into
+ * `activeAdapters` keyed by `(channelType, botId)`. Idempotent: if an
+ * adapter is already active for this `(channelType, botId)` it returns the
+ * existing one instead of double-registering.
+ *
+ * Throws if the channel doesn't expose `spawnFromSecret` (single-bot
+ * channel) or if `initChannelAdapters` hasn't run yet (no cached setup
+ * callbacks). Returns null if the spawn hook itself returns null (token
+ * rejected at the platform).
+ */
+export async function registerBotAdapter(
+  channelType: string,
+  secretName: string,
+  secretValue: string,
+): Promise<ChannelAdapter | null> {
+  const registration = registry.get(channelType);
+  if (!registration) throw new Error(`unknown channel: ${channelType}`);
+  if (!registration.spawnFromSecret) {
+    throw new Error(`channel does not support multi-bot operation: ${channelType}`);
+  }
+  if (!cachedSetupFn) {
+    throw new Error('initChannelAdapters has not run yet — cannot register dynamic bot');
+  }
+  const adapter = await registration.spawnFromSecret(secretName, secretValue);
+  if (!adapter) return null;
+  const key = adapterKey(adapter.channelType, adapter.botId);
+  const existing = activeAdapters.get(key);
+  if (existing) {
+    log.info('Channel adapter already active for bot, skipping re-setup', {
+      channel: channelType,
+      botId: adapter.botId ?? null,
+    });
+    return existing;
+  }
+  await setupAdapterWithRetry(adapter, cachedSetupFn(adapter), channelType);
+  activeAdapters.set(key, adapter);
+  log.info('Channel adapter registered dynamically', {
+    channel: channelType,
+    botId: adapter.botId ?? null,
+  });
+  return adapter;
+}
+
+/**
+ * Boot-time scan that brings up adapters for every persisted
+ * `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret whose adapter isn't already
+ * active. Run AFTER `initChannelAdapters` (which seeds the primary `.env`
+ * adapter) and AFTER `runStartupBootstrap` (which copies `.env` tokens into
+ * the secrets table); the combination ensures the primary bot stays primary
+ * while every additional bot the operator has registered comes back online
+ * across restarts.
+ *
+ * Skips channels with no `spawnFromSecret` hook and skips secrets whose
+ * `(channelType, botId)` is already covered by an active adapter (the
+ * primary). Logs but doesn't throw on individual spawn failures — one bad
+ * token shouldn't keep the rest offline.
+ */
+export async function spawnSecretsBackedBots(): Promise<void> {
+  const tokens = listSecrets(null).filter((s) => s.kind === 'channel-token' && s.name.startsWith('CHANNEL_BOT_TOKEN:'));
+  for (const row of tokens) {
+    const parts = row.name.split(':');
+    if (parts.length < 3) continue;
+    const channelType = parts[1]!;
+    const botId = parts.slice(2).join(':');
+    if (!channelType || !botId) continue;
+    const registration = registry.get(channelType);
+    if (!registration?.spawnFromSecret) continue;
+    if (activeAdapters.has(adapterKey(channelType, botId))) continue;
+    const value = getSecret(row.name);
+    if (!value) {
+      log.warn('Channel bot secret has no value, skipping', { secret: row.name });
+      continue;
+    }
+    try {
+      const adapter = await registerBotAdapter(channelType, row.name, value);
+      if (!adapter) {
+        log.warn('Secrets-backed bot spawn returned null', { channel: channelType, botId });
+      }
+    } catch (err) {
+      log.error('Failed to spawn secrets-backed bot', { channel: channelType, botId, err });
     }
   }
 }

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -5,6 +5,7 @@
 import { createDiscordAdapter } from '@chat-adapter/discord';
 
 import { readEnvFile } from '../env.js';
+import type { ChannelAdapter } from './adapter.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
 
@@ -18,25 +19,52 @@ function extractReplyContext(raw: Record<string, any>): ReplyContext | null {
   };
 }
 
+export interface DiscordSpawnInput {
+  botToken: string;
+  applicationId: string;
+  publicKey?: string;
+}
+
+/**
+ * Build (but don't `setup()`) a Discord channel adapter for the given bot
+ * credentials. Discord doesn't expose a getMe-equivalent for the bot user
+ * itself, so the bot's identity (`applicationId`) must be passed in by the
+ * caller — read from `.env`'s `DISCORD_APPLICATION_ID` for the primary
+ * adapter, or from the secret/operator input for dynamic per-bot adds.
+ *
+ * Used by:
+ *   - the channel-registry's startup factory below (single bot via `.env`)
+ *   - `registerBotAdapter('discord', { ... })` (dynamic per-bot adds)
+ *   - the secrets-backed startup scan
+ */
+export function spawnDiscordAdapter(input: DiscordSpawnInput): ChannelAdapter {
+  const { botToken, applicationId, publicKey } = input;
+  const botId = applicationId;
+  const discordAdapter = createDiscordAdapter({
+    botToken,
+    publicKey,
+    applicationId,
+  });
+  const bridge = createChatSdkBridge({
+    adapter: discordAdapter,
+    botId,
+    concurrency: 'concurrent',
+    botToken,
+    extractReplyContext,
+    supportsThreads: true,
+  });
+  return { ...bridge, botId };
+}
+
 registerChannelAdapter('discord', {
   factory: () => {
     const env = readEnvFile(['DISCORD_BOT_TOKEN', 'DISCORD_PUBLIC_KEY', 'DISCORD_APPLICATION_ID']);
     if (!env.DISCORD_BOT_TOKEN) return null;
     if (!env.DISCORD_APPLICATION_ID) return null;
-    const botId = env.DISCORD_APPLICATION_ID;
-    const discordAdapter = createDiscordAdapter({
+    return spawnDiscordAdapter({
       botToken: env.DISCORD_BOT_TOKEN,
-      publicKey: env.DISCORD_PUBLIC_KEY,
       applicationId: env.DISCORD_APPLICATION_ID,
+      publicKey: env.DISCORD_PUBLIC_KEY,
     });
-    const bridge = createChatSdkBridge({
-      adapter: discordAdapter,
-      botId,
-      concurrency: 'concurrent',
-      botToken: env.DISCORD_BOT_TOKEN,
-      extractReplyContext,
-      supportsThreads: true,
-    });
-    return { ...bridge, botId };
   },
 });

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -5,6 +5,7 @@
 import { createDiscordAdapter } from '@chat-adapter/discord';
 
 import { readEnvFile } from '../env.js';
+import { log } from '../log.js';
 import type { ChannelAdapter } from './adapter.js';
 import { createChatSdkBridge, type ReplyContext } from './chat-sdk-bridge.js';
 import { registerChannelAdapter } from './channel-registry.js';
@@ -66,5 +67,24 @@ registerChannelAdapter('discord', {
       applicationId: env.DISCORD_APPLICATION_ID,
       publicKey: env.DISCORD_PUBLIC_KEY,
     });
+  },
+  /**
+   * Discord has no `getMe`-equivalent, so the applicationId must come from
+   * somewhere. Convention: `CHANNEL_BOT_TOKEN:discord:<applicationId>` —
+   * the trailing segment IS the applicationId. Public key is webhook-only
+   * (interaction mode); polling-mode bots leave it undefined.
+   */
+  spawnFromSecret: async (secretName, secretValue) => {
+    const applicationId = secretName.split(':').pop();
+    if (!applicationId) {
+      log.error('Discord spawnFromSecret got malformed secret name', { secretName });
+      return null;
+    }
+    try {
+      return spawnDiscordAdapter({ botToken: secretValue, applicationId });
+    } catch (err) {
+      log.error('Discord spawnFromSecret failed', { secretName, err });
+      return null;
+    }
   },
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -262,4 +262,18 @@ registerChannelAdapter('telegram', {
     if (!env.TELEGRAM_BOT_TOKEN) return null;
     return spawnTelegramAdapter(env.TELEGRAM_BOT_TOKEN);
   },
+  /**
+   * The token is the only thing Telegram needs — the bot's id and username
+   * are recovered via getMe inside spawnTelegramAdapter. The secretName's
+   * trailing segment IS the botId, but we don't need to parse it; the adapter
+   * resolves identity itself.
+   */
+  spawnFromSecret: async (_secretName, secretValue) => {
+    try {
+      return await spawnTelegramAdapter(secretValue);
+    } catch (err) {
+      log.error('Telegram spawnFromSecret failed', { err });
+      return null;
+    }
+  },
 });

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -211,46 +211,55 @@ function createPairingInterceptor(
   };
 }
 
+/**
+ * Build (but don't `setup()`) a Telegram channel adapter for the given bot
+ * token. Resolves bot identity eagerly via `getMe` so the bridge can encode
+ * v2 platform_ids before any inbound traffic arrives.
+ *
+ * Used by:
+ *   - the channel-registry's startup factory below (single bot via `.env`)
+ *   - `registerBotAdapter('telegram', { token })` (dynamic per-bot adds via
+ *     `POST /api/channels/telegram/register-bot`, see channel-registry.ts)
+ *   - the secrets-backed startup scan (one adapter per
+ *     `CHANNEL_BOT_TOKEN:telegram:*` row across restarts)
+ *
+ * Throws on getMe failure; callers decide whether the bot is essential
+ * (factory: log + skip) or operator-driven (register-bot: surface as 4xx).
+ */
+export async function spawnTelegramAdapter(token: string): Promise<ChannelAdapter> {
+  const identity = await withRetry(() => fetchBotIdentity(token), 'getMe');
+  const { botId, username } = identity;
+
+  const telegramAdapter = createTelegramAdapter({
+    botToken: token,
+    mode: 'polling',
+  });
+  const bridge = createChatSdkBridge({
+    adapter: telegramAdapter,
+    botId,
+    concurrency: 'concurrent',
+    extractReplyContext,
+    supportsThreads: false,
+    transformOutboundText: sanitizeTelegramLegacyMarkdown,
+  });
+
+  return {
+    ...bridge,
+    botId,
+    async setup(hostConfig: ChannelSetup) {
+      const intercepted: ChannelSetup = {
+        ...hostConfig,
+        onInbound: createPairingInterceptor(username, hostConfig.onInbound, token),
+      };
+      return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
+    },
+  };
+}
+
 registerChannelAdapter('telegram', {
   factory: async () => {
     const env = readEnvFile(['TELEGRAM_BOT_TOKEN']);
     if (!env.TELEGRAM_BOT_TOKEN) return null;
-    const token = env.TELEGRAM_BOT_TOKEN;
-
-    // Resolve the bot identity (id + username) eagerly. The id keys the v2
-    // platform_id encoding and the registry slot, so we cannot defer it the
-    // way the old code lazily fetched the username for pairing — paraclaw
-    // would otherwise route all inbound traffic before knowing how to encode
-    // it. If getMe fails we surface the error so initChannelAdapters logs
-    // a clear "Failed to start channel adapter" instead of silently routing
-    // to the wrong key.
-    const identity = await withRetry(() => fetchBotIdentity(token), 'getMe');
-    const { botId, username } = identity;
-
-    const telegramAdapter = createTelegramAdapter({
-      botToken: token,
-      mode: 'polling',
-    });
-    const bridge = createChatSdkBridge({
-      adapter: telegramAdapter,
-      botId,
-      concurrency: 'concurrent',
-      extractReplyContext,
-      supportsThreads: false,
-      transformOutboundText: sanitizeTelegramLegacyMarkdown,
-    });
-
-    const wrapped: ChannelAdapter = {
-      ...bridge,
-      botId,
-      async setup(hostConfig: ChannelSetup) {
-        const intercepted: ChannelSetup = {
-          ...hostConfig,
-          onInbound: createPairingInterceptor(username, hostConfig.onInbound, token),
-        };
-        return withRetry(() => bridge.setup(intercepted), 'bridge.setup');
-      },
-    };
-    return wrapped;
+    return spawnTelegramAdapter(env.TELEGRAM_BOT_TOKEN);
   },
 });

--- a/src/channels/trust-hint.test.ts
+++ b/src/channels/trust-hint.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { recordTrustHint, consumeTrustHint, _resetTrustHintsForTest } from './trust-hint.js';
+
+describe('channel trust hint', () => {
+  beforeEach(() => {
+    _resetTrustHintsForTest();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    _resetTrustHintsForTest();
+  });
+
+  it('returns true once for a recorded triple, then false on second consume', () => {
+    recordTrustHint('telegram', 'bot-1', 'op-42');
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(true);
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(false);
+  });
+
+  it('returns false for a triple that was never recorded', () => {
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(false);
+  });
+
+  it('discriminates by all three key parts', () => {
+    recordTrustHint('telegram', 'bot-1', 'op-42');
+    expect(consumeTrustHint('discord', 'bot-1', 'op-42')).toBe(false);
+    expect(consumeTrustHint('telegram', 'bot-2', 'op-42')).toBe(false);
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-43')).toBe(false);
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(true);
+  });
+
+  it('expires hints after the TTL', () => {
+    recordTrustHint('telegram', 'bot-1', 'op-42');
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(false);
+  });
+
+  it('keeps hints valid up to the TTL boundary', () => {
+    recordTrustHint('telegram', 'bot-1', 'op-42');
+    vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+    expect(consumeTrustHint('telegram', 'bot-1', 'op-42')).toBe(true);
+  });
+
+  it('treats empty operatorUserId as a no-op (Discord wires)', () => {
+    recordTrustHint('discord', 'bot-app-id', '');
+    expect(consumeTrustHint('discord', 'bot-app-id', '')).toBe(false);
+  });
+});

--- a/src/channels/trust-hint.ts
+++ b/src/channels/trust-hint.ts
@@ -1,0 +1,74 @@
+/**
+ * Operator-self-wire trust hint (paraclaw#67 — Proposal B).
+ *
+ * When the operator submits `/claw/channels/new`, we record an in-memory
+ * hint keyed `(channelType, botId, operatorUserId)` saying "the operator
+ * just wired this bot themselves; the next inbound from them on this bot
+ * should bypass the unwired-channel approval gate and route as trusted."
+ *
+ * Why in-memory (no table): hints are 5-minute things. If paraclaw
+ * restarts in that window, the operator who hasn't DM'd the bot yet
+ * starts from a wired MGA anyway (Proposal A makes wire the spawn point);
+ * no hint needed on the cold path. A persistent table would only matter
+ * if we wanted hints to survive crashes mid-window — that's not worth
+ * the migration cost or sweep complexity.
+ *
+ * Why bound to operatorUserId, not just (channel, bot): the form captures
+ * the operator's user id explicitly (Telegram operatorUserId field).
+ * Trusting only that user means a third-party who DMs the bot in the
+ * trust window still goes through the approval flow — exactly the
+ * cautious behavior we want.
+ *
+ * Discord: the form doesn't capture an operator user id (sender_scope
+ * 'all' on the wire MGA already covers that case at the routing layer),
+ * so Discord wires record no hint and the router check is a no-op for
+ * Discord inbounds.
+ */
+const TTL_MS = 5 * 60 * 1000;
+
+type HintKey = string;
+
+function key(channelType: string, botId: string, operatorUserId: string): HintKey {
+  return `${channelType}\0${botId}\0${operatorUserId}`;
+}
+
+const hints = new Map<HintKey, number>();
+
+function sweep(now: number): void {
+  for (const [k, expiresAt] of hints) {
+    if (expiresAt <= now) hints.delete(k);
+  }
+}
+
+/**
+ * Record that the operator just wired `botId` on `channelType` and
+ * identifies as `operatorUserId`. The next inbound matching this triple
+ * within {@link TTL_MS} bypasses the unwired-channel approval gate.
+ *
+ * No-op if `operatorUserId` is empty (Discord wires don't capture one).
+ */
+export function recordTrustHint(channelType: string, botId: string, operatorUserId: string): void {
+  if (!operatorUserId) return;
+  const now = Date.now();
+  sweep(now);
+  hints.set(key(channelType, botId, operatorUserId), now + TTL_MS);
+}
+
+/**
+ * Single-use check: if a hint matches, returns true and removes the hint.
+ * Returns false on miss or expired hint.
+ */
+export function consumeTrustHint(channelType: string, botId: string, operatorUserId: string): boolean {
+  if (!operatorUserId) return false;
+  const now = Date.now();
+  sweep(now);
+  const k = key(channelType, botId, operatorUserId);
+  const expiresAt = hints.get(k);
+  if (expiresAt === undefined) return false;
+  hints.delete(k);
+  return true;
+}
+
+export function _resetTrustHintsForTest(): void {
+  hints.clear();
+}

--- a/src/channels/trust-hint.ts
+++ b/src/channels/trust-hint.ts
@@ -35,6 +35,7 @@ function key(channelType: string, botId: string, operatorUserId: string): HintKe
 const hints = new Map<HintKey, number>();
 
 function sweep(now: number): void {
+  // O(n) sweep over active hints; n stays tiny in practice (operator-window bounded).
   for (const [k, expiresAt] of hints) {
     if (expiresAt <= now) hints.delete(k);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
   initChannelAdapters,
   teardownChannelAdapters,
   getChannelAdapterForPlatformId,
+  spawnSecretsBackedBots,
 } from './channels/channel-registry.js';
 
 async function main(): Promise<void> {
@@ -142,6 +143,13 @@ async function main(): Promise<void> {
   // tokens into the secrets table and rewrite legacy v1 messaging_groups
   // platform_ids to the v2 form. Idempotent; safe across restarts.
   runStartupBootstrap();
+
+  // 3c. Bring up adapters for every additional bot the operator has
+  // registered via the dynamic register-bot endpoint. Runs after the `.env`
+  // primary is up + bootstrap has populated the secrets table, so we know
+  // the primary's `(channelType, botId)` is already covered and won't be
+  // re-registered.
+  await spawnSecretsBackedBots();
 
   // 4. Delivery adapter bridge — dispatches to channel adapters
   const deliveryAdapter = {

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -122,7 +122,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
       : `Someone DM'd your agent on ${originChannelType}. Wire it to ${target.name} and let it respond?`;
   const options = normalizeOptions(APPROVAL_OPTIONS);
 
-  createPendingChannelApproval({
+  const inserted = createPendingChannelApproval({
     messaging_group_id: messagingGroupId,
     agent_group_id: target.id,
     original_message: JSON.stringify(event),
@@ -131,6 +131,18 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
     title,
     options_json: JSON.stringify(options),
   });
+  if (!inserted) {
+    // Lost a concurrent race against another inbound for this same
+    // messaging group. The winner already produced a card; we silently
+    // skip delivery rather than spamming a duplicate. The earlier
+    // `hasInFlightChannelApproval` check catches the common case but
+    // doesn't cover concurrent inbounds that both pass it before either
+    // INSERTs.
+    log.debug('Channel registration card already inserted by concurrent inbound', {
+      messagingGroupId,
+    });
+    return;
+  }
 
   const adapter = getDeliveryAdapter();
   if (!adapter) {

--- a/src/modules/permissions/db/pending-channel-approvals.test.ts
+++ b/src/modules/permissions/db/pending-channel-approvals.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../config.js', async () => {
+  const actual = await vi.importActual('../../../config.js');
+  return { ...actual, DATA_DIR: '/tmp/paraclaw-test-pending-channel-approvals' };
+});
+
+const TEST_DIR = '/tmp/paraclaw-test-pending-channel-approvals';
+
+const sampleRow = (messagingGroupId: string) => ({
+  messaging_group_id: messagingGroupId,
+  agent_group_id: 'ag-1',
+  original_message: '{"text":"hi"}',
+  approver_user_id: 'user-1',
+  created_at: new Date().toISOString(),
+  title: 'Card',
+  options_json: '[]',
+});
+
+describe('pending_channel_approvals atomic create', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    vi.resetModules();
+    const { initTestDb, runMigrations } = await import('../../../db/index.js');
+    const db = initTestDb();
+    runMigrations(db);
+    const { createAgentGroup } = await import('../../../db/agent-groups.js');
+    const { createMessagingGroup } = await import('../../../db/messaging-groups.js');
+    createAgentGroup({
+      id: 'ag-1',
+      folder: 'group-1',
+      name: 'G',
+      agent_provider: null,
+      created_at: new Date().toISOString(),
+    });
+    for (const id of ['mg-1', 'mg-2']) {
+      createMessagingGroup({
+        id,
+        channel_type: 'telegram',
+        platform_id: `telegram:bot:${id}`,
+        name: null,
+        is_group: 0,
+        unknown_sender_policy: 'request_approval',
+        created_at: new Date().toISOString(),
+      });
+    }
+    const { upsertUser } = await import('./users.js');
+    upsertUser({
+      id: 'user-1',
+      kind: 'human',
+      display_name: 'User',
+      created_at: new Date().toISOString(),
+    });
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import('../../../db/index.js');
+    closeDb();
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('returns true on first insert, false on duplicate, and never throws', async () => {
+    const { createPendingChannelApproval, getPendingChannelApproval } = await import('./pending-channel-approvals.js');
+
+    const first = createPendingChannelApproval(sampleRow('mg-1'));
+    expect(first).toBe(true);
+
+    // Concurrent inbounds racing past the dedup check used to throw
+    // `UNIQUE constraint failed`. With ON CONFLICT DO NOTHING they
+    // return false silently and the caller skips delivery without an
+    // ERROR-level log line.
+    const second = createPendingChannelApproval(sampleRow('mg-1'));
+    expect(second).toBe(false);
+
+    const stored = getPendingChannelApproval('mg-1');
+    expect(stored?.title).toBe('Card');
+  });
+
+  it('lets a different messaging_group_id through without conflict', async () => {
+    const { createPendingChannelApproval } = await import('./pending-channel-approvals.js');
+    expect(createPendingChannelApproval(sampleRow('mg-1'))).toBe(true);
+    expect(createPendingChannelApproval(sampleRow('mg-2'))).toBe(true);
+  });
+});

--- a/src/modules/permissions/db/pending-channel-approvals.ts
+++ b/src/modules/permissions/db/pending-channel-approvals.ts
@@ -23,8 +23,16 @@ export interface PendingChannelApproval {
   options_json: string;
 }
 
-export function createPendingChannelApproval(row: PendingChannelApproval): void {
-  getDb()
+/**
+ * Insert atomically; returns true iff this call won the race and inserted
+ * the row. Returns false (without throwing) if a row was already present
+ * for this messaging_group_id — the previous non-atomic check+insert pair
+ * threw `UNIQUE constraint failed` when concurrent inbounds raced past
+ * the dedup check, surfacing as ERROR-level noise on every multi-mention
+ * burst even though user-visible behavior was correct.
+ */
+export function createPendingChannelApproval(row: PendingChannelApproval): boolean {
+  const result = getDb()
     .prepare(
       `INSERT INTO pending_channel_approvals (
          messaging_group_id, agent_group_id, original_message,
@@ -33,9 +41,11 @@ export function createPendingChannelApproval(row: PendingChannelApproval): void 
        VALUES (
          @messaging_group_id, @agent_group_id, @original_message,
          @approver_user_id, @created_at, @title, @options_json
-       )`,
+       )
+       ON CONFLICT(messaging_group_id) DO NOTHING`,
     )
     .run(row);
+  return result.changes > 0;
 }
 
 export function getPendingChannelApproval(messagingGroupId: string): PendingChannelApproval | undefined {

--- a/src/router.ts
+++ b/src/router.ts
@@ -220,7 +220,23 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
     const senderId = parsedUnwired.senderId;
     if (decoded.botId && senderId && consumeTrustHint(event.channelType, decoded.botId, senderId)) {
       const targetGroups = getAllAgentGroups();
+      if (targetGroups.length === 0) {
+        // Hint already consumed (single-use) but there's no agent group to
+        // wire to. Falls through to the approval cascade below; surface a
+        // warn so an operator who hits this can correlate it with their
+        // missing agent-group setup.
+        log.warn('Trust hint consumed but no agent groups — operator message dropped', {
+          messagingGroupId: mg.id,
+          channelType: event.channelType,
+          botId: decoded.botId,
+        });
+      }
       if (targetGroups.length > 0) {
+        // Multi-agent-group installs: this picks the first group by DB
+        // insert order. Good enough for the trust-hint use case (operator
+        // just wired a bot and is DM'ing it now — usually the install only
+        // has one group anyway), but a richer "wire to the most recently
+        // wired group" or operator-prompted pick is a follow-up if needed.
         const target = targetGroups[0]!;
         log.info('Channel inbound auto-wired via operator trust hint', {
           messagingGroupId: mg.id,

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,14 +18,18 @@
  * for policy refusals.
  */
 import { getChannelAdapter } from './channels/channel-registry.js';
+import { consumeTrustHint } from './channels/trust-hint.js';
 import { gateCommand } from './command-gate.js';
-import { getAgentGroup } from './db/agent-groups.js';
+import { getAgentGroup, getAllAgentGroups } from './db/agent-groups.js';
 import { recordDroppedMessage } from './db/dropped-messages.js';
 import {
   createMessagingGroup,
   getMessagingGroupAgents,
   getMessagingGroupWithAgentCount,
+  updateMessagingGroup,
 } from './db/messaging-groups.js';
+import { decodePlatformIdAs } from './platform-id.js';
+import { wireDmToAgent } from './web/wire-channel.js';
 import { findSessionForAgent } from './db/sessions.js';
 import { startTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
@@ -204,12 +208,50 @@ export async function routeInbound(event: InboundEvent): Promise<void> {
       return;
     }
 
-    const parsed = safeParseContent(event.message.content);
+    const parsedUnwired = safeParseContent(event.message.content);
+
+    // Trust hint: if the operator just wired this bot at /channels/new and
+    // is now DM'ing it, treat the message as trusted self-traffic instead
+    // of escalating through the channel-registration approval flow. The
+    // hint is single-use and bound to (channelType, botId, operatorUserId)
+    // — Discord wires record no hint (no operator user id captured), so
+    // this branch only fires for Telegram self-DMs in the trust window.
+    const decoded = decodePlatformIdAs(event.platformId, 'v2');
+    const senderId = parsedUnwired.senderId;
+    if (decoded.botId && senderId && consumeTrustHint(event.channelType, decoded.botId, senderId)) {
+      const targetGroups = getAllAgentGroups();
+      if (targetGroups.length > 0) {
+        const target = targetGroups[0]!;
+        log.info('Channel inbound auto-wired via operator trust hint', {
+          messagingGroupId: mg.id,
+          channelType: event.channelType,
+          botId: decoded.botId,
+          targetAgentGroupId: target.id,
+        });
+        // Drop the auto-created request_approval row in favor of a fresh
+        // wire built with the trusted defaults (strict policy, all-senders
+        // MGA). wireDmToAgent is idempotent — if we beat it to a wire that
+        // already exists, it returns the existing rows.
+        updateMessagingGroup(mg.id, { unknown_sender_policy: 'strict' });
+        wireDmToAgent({
+          channelType: event.channelType as 'discord' | 'telegram',
+          agentGroup: target,
+          botId: decoded.botId,
+          botUserId: decoded.native,
+        });
+        // Re-run the standard route from the now-wired path so engage
+        // checks, sender resolution, and session creation behave exactly
+        // as if this were a normal message on a pre-wired channel.
+        await routeInbound(event);
+        return;
+      }
+    }
+
     recordDroppedMessage({
       channel_type: event.channelType,
       platform_id: event.platformId,
       user_id: null,
-      sender_name: parsed.sender ?? null,
+      sender_name: parsedUnwired.sender ?? null,
       reason: 'no_agent_wired',
       messaging_group_id: mg.id,
       agent_group_id: null,

--- a/src/startup-bootstrap.test.ts
+++ b/src/startup-bootstrap.test.ts
@@ -15,7 +15,7 @@ import type { ChannelAdapter } from './channels/adapter.js';
 import { createMessagingGroup, getMessagingGroup } from './db/messaging-groups.js';
 import { closeDb, initTestDb } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
-import { getSecret } from './secrets/index.js';
+import { getSecret, putSecret } from './secrets/index.js';
 import {
   backfillMessagingGroupsToV2,
   bootstrapChannelTokensToSecrets,
@@ -131,6 +131,48 @@ describe('backfillMessagingGroupsToV2', () => {
     // Second run must also be a no-op.
     expect(backfillMessagingGroupsToV2()).toBe(0);
     expect(getMessagingGroup('mg-4')!.platform_id).toBe('telegram:bot1:1190596288');
+  });
+
+  it('does not re-prefix already-v2 rows that belong to a registered-but-not-yet-active secondary bot', () => {
+    // Reproduces the live regression that corrupted TechneRobot's rows on
+    // reboot: only the .env primary adapter is active at boot, but the
+    // secondary bot's CHANNEL_BOT_TOKEN secret is already in the table
+    // (Proposal A: register-bot persists the token before adapter spawn).
+    // The backfill iterates over the primary; if it forgets the secondary's
+    // botId, it sees the secondary's already-v2 row, treats it as v1, and
+    // re-prefixes it under the primary → 4-segment garbage id.
+    _setActiveAdapterForTest(fakeAdapter('telegram', 'primary-bot'));
+    putSecret(channelTokenSecretName('telegram', 'secondary-bot'), 'tg-token-2', {
+      kind: 'channel-token',
+      agent_group_id: null,
+    });
+    createMessagingGroup({
+      id: 'mg-primary',
+      channel_type: 'telegram',
+      platform_id: 'telegram:primary-bot:1190596288',
+      name: null,
+      is_group: 0,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+    createMessagingGroup({
+      id: 'mg-secondary',
+      channel_type: 'telegram',
+      platform_id: 'telegram:secondary-bot:-1002245300962',
+      name: null,
+      is_group: 1,
+      unknown_sender_policy: 'strict',
+      created_at: new Date().toISOString(),
+    });
+
+    expect(backfillMessagingGroupsToV2()).toBe(0);
+    expect(getMessagingGroup('mg-primary')!.platform_id).toBe('telegram:primary-bot:1190596288');
+    expect(getMessagingGroup('mg-secondary')!.platform_id).toBe('telegram:secondary-bot:-1002245300962');
+
+    // Second pass must remain a no-op even with mixed-bot rows present.
+    expect(backfillMessagingGroupsToV2()).toBe(0);
+    expect(getMessagingGroup('mg-primary')!.platform_id).toBe('telegram:primary-bot:1190596288');
+    expect(getMessagingGroup('mg-secondary')!.platform_id).toBe('telegram:secondary-bot:-1002245300962');
   });
 
   it('skips channels with no active adapter (e.g. install with only Telegram running)', () => {

--- a/src/startup-bootstrap.ts
+++ b/src/startup-bootstrap.ts
@@ -63,12 +63,24 @@ export function bootstrapChannelTokensToSecrets(): void {
     const value = env[envVar];
     if (!value) continue;
     const name = channelTokenSecretName(adapter.channelType, adapter.botId);
-    if (getSecret(name) === value) continue;
+    const existing = getSecret(name);
+    if (existing === value) continue;
     putSecret(name, value, { kind: 'channel-token', agent_group_id: null });
-    log.info('Bootstrapped channel bot token to secrets', {
-      channelType: adapter.channelType,
-      botId: adapter.botId,
-    });
+    if (existing === undefined) {
+      log.info('Bootstrapped channel bot token to secrets', {
+        channelType: adapter.channelType,
+        botId: adapter.botId,
+      });
+    } else {
+      // `.env` value diverged from what we previously stored — operator
+      // rotated the token. Single line so token-rotation events show up
+      // in `logs/paraclaw.log` without needing a separate observability
+      // surface.
+      log.info('Channel bot token rotated', {
+        channelType: adapter.channelType,
+        botId: adapter.botId,
+      });
+    }
   }
 }
 

--- a/src/startup-bootstrap.ts
+++ b/src/startup-bootstrap.ts
@@ -24,18 +24,20 @@
  *      starts emitting v2 ids.
  *
  * Idempotency strategy: detect already-v2 rows by checking whether their
- * second segment equals the active adapter's botId. v1 rows have either
- * no second segment (Telegram `telegram:<chatId>`) or a different second
- * segment (Discord `discord:<guildId>:<channelId>`). The collision case
- * (a chat_id that happens to match the bot's own user id) is vanishingly
- * unlikely given Telegram's id-allocation pattern.
+ * second segment matches *any* known bot id for the channel — the union of
+ * active adapters + every botId persisted under `CHANNEL_BOT_TOKEN:<channel>:`
+ * in the secrets table. Comparing against only the iteration's adapter
+ * misclassifies rows already-v2 for a *secondary* bot as v1 and re-prefixes
+ * them, producing a 4-segment garbage id; consulting secrets too means even
+ * pre-spawn secondary bots (Proposal A defers adapter spawn until wire) are
+ * recognized.
  */
 import { getDb } from './db/connection.js';
 import { readEnvFile } from './env.js';
 import { log } from './log.js';
 import { encodePlatformId } from './platform-id.js';
 import { getActiveAdapters } from './channels/channel-registry.js';
-import { getSecret, putSecret } from './secrets/index.js';
+import { getSecret, listSecrets, putSecret } from './secrets/index.js';
 
 /** `.env` var name carrying each channel's bot token. Empty for channels
  *  paraclaw doesn't manage credentials for in `.env` (CLI, native channels). */
@@ -91,22 +93,60 @@ interface MessagingGroupRow {
 }
 
 /**
- * True if the platform_id's bot segment is already the given bot's id.
+ * True if the platform_id's bot segment matches *any* known bot id for this
+ * channel — not just the active adapter's. The set must be the union of
+ * every botId the install has ever registered (active adapters + persisted
+ * `CHANNEL_BOT_TOKEN:<channel>:<botId>` secrets), or rows already-v2 for a
+ * secondary bot get re-prefixed under the iteration's primary botId and end
+ * up with a 4-segment platform_id like `telegram:primary:secondary:chat`.
  *
- * Collision case: if a v1 row's first native segment happens to equal this
- * bot's botId (a Telegram chat_id matching the bot's own user_id, or a
- * Discord guild id matching its application id), it would be misclassified
+ * Collision case: if a v1 row's first native segment happens to equal one
+ * of the known bot ids (a Telegram chat_id matching a bot's own user_id, or
+ * a Discord guild id matching an application id), it would be misclassified
  * as already-v2 and skipped. Vanishingly unlikely given how those id spaces
  * are allocated — flagged here so a future operator hitting the case knows
  * where to look.
  */
-function isAlreadyV2(channelType: string, platformId: string, botId: string): boolean {
+function isAlreadyV2(channelType: string, platformId: string, knownBotIds: ReadonlySet<string>): boolean {
   const prefix = `${channelType}:`;
   if (!platformId.startsWith(prefix)) return false;
   const after = platformId.slice(prefix.length);
   const colon = after.indexOf(':');
   const slot1 = colon === -1 ? after : after.slice(0, colon);
-  return slot1 === botId;
+  return knownBotIds.has(slot1);
+}
+
+/**
+ * Union of every known bot id per channel: the live adapters + every botId
+ * that appears in a `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret name. We
+ * consult secrets because at boot only the `.env` primary is yet active;
+ * secondary bots persisted via `/register-bot` haven't been adapter-spawned
+ * yet (Proposal A defers spawn until `/wire-channel`), but their tokens are
+ * already in the secrets table — and rows pointing at them are already v2.
+ */
+function knownBotIdsPerChannel(): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  const add = (channel: string, botId: string) => {
+    let set = out.get(channel);
+    if (!set) {
+      set = new Set();
+      out.set(channel, set);
+    }
+    set.add(botId);
+  };
+  for (const a of getActiveAdapters()) {
+    if (a.botId) add(a.channelType, a.botId);
+  }
+  for (const s of listSecrets(null)) {
+    if (s.kind !== 'channel-token') continue;
+    const parts = s.name.split(':');
+    if (parts.length < 3 || parts[0] !== 'CHANNEL_BOT_TOKEN') continue;
+    const channel = parts[1];
+    const botId = parts.slice(2).join(':');
+    if (!channel || !botId) continue;
+    add(channel, botId);
+  }
+  return out;
 }
 
 /**
@@ -117,6 +157,7 @@ function isAlreadyV2(channelType: string, platformId: string, botId: string): bo
 export function backfillMessagingGroupsToV2(): number {
   const adapters = getActiveAdapters().filter((a) => a.botId);
   if (adapters.length === 0) return 0;
+  const knownByChannel = knownBotIdsPerChannel();
   const select = getDb().prepare<MessagingGroupRow>(
     `SELECT id, channel_type, platform_id
        FROM messaging_groups
@@ -127,10 +168,11 @@ export function backfillMessagingGroupsToV2(): number {
   for (const adapter of adapters) {
     const channel = adapter.channelType;
     const botId = adapter.botId!;
+    const known = knownByChannel.get(channel) ?? new Set([botId]);
     const rows = select.all({ channel_type: channel });
     let upgraded = 0;
     for (const row of rows) {
-      if (isAlreadyV2(channel, row.platform_id, botId)) continue;
+      if (isAlreadyV2(channel, row.platform_id, known)) continue;
       const prefix = `${channel}:`;
       if (!row.platform_id.startsWith(prefix)) continue;
       const native = row.platform_id.slice(prefix.length);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -68,7 +68,7 @@ import { wireDmToAgent } from './wire-channel.js';
 import { getChannelAdapter, registerBotAdapter } from '../channels/channel-registry.js';
 import { validateDiscordBotToken } from './discord-validate.js';
 import { validateTelegramBotToken } from './telegram-validate.js';
-import { putSecret } from '../secrets/index.js';
+import { getSecret, putSecret } from '../secrets/index.js';
 import { channelTokenSecretName } from '../startup-bootstrap.js';
 
 const PROJECT_ROOT = process.cwd();
@@ -292,13 +292,15 @@ async function handleApi(
       // Persist before bringing up the adapter so a crash mid-setup still
       // leaves the token recoverable on next boot's spawnSecretsBackedBots.
       const secretName = channelTokenSecretName(adapter, botId);
+      const existing = getSecret(secretName);
+      const isRotation = existing !== undefined && existing !== token;
       putSecret(secretName, token, { kind: 'channel-token', agent_group_id: null });
       const live = await registerBotAdapter(adapter, secretName, token);
       if (!live) {
         error(res, 502, `${adapter} register-bot: spawnFromSecret returned null after a successful validate`);
         return;
       }
-      log.info('Channel bot registered', { adapter, botId });
+      log.info(isRotation ? 'Channel bot token rotated' : 'Channel bot registered', { adapter, botId });
       json(res, 200, { ok: true, botId, username });
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,7 +65,8 @@ import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
 import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 import { wireDmToAgent } from './wire-channel.js';
-import { getChannelAdapter, registerBotAdapter } from '../channels/channel-registry.js';
+import { getChannelAdapterByBotId, registerBotAdapter } from '../channels/channel-registry.js';
+import { recordTrustHint } from '../channels/trust-hint.js';
 import { validateDiscordBotToken } from './discord-validate.js';
 import { validateTelegramBotToken } from './telegram-validate.js';
 import { getSecret, putSecret } from '../secrets/index.js';
@@ -259,11 +260,13 @@ async function handleApi(
     return;
   }
 
-  // Persist + bring up an additional bot adapter at runtime. The wire-
-  // channel UI hits this after a successful /test so the operator can wire
-  // a NEW bot's token without restarting the host. Idempotent on
-  // (channelType, botId): re-posting the same token just refreshes the
-  // ciphertext and returns the already-active adapter's identity.
+  // Validate a bot token + persist it to the secrets table. This DOES NOT
+  // bring the adapter up — adapter spawn is deferred to /wire-channel so
+  // the bot can't start polling before the operator has actually wired it
+  // to an agent group. (The polling loop is what receives messages and,
+  // pre-wire, races into the unwired-channel approval flow that surprised
+  // operators wiring a second bot.) Idempotent: re-posting the same
+  // (channelType, botId) just refreshes the stored ciphertext.
   if (method === 'POST' && /^\/api\/channels\/[^/]+\/register-bot$/.test(pathname)) {
     if (!(await gate(req, res, SCOPE_CLAW_ADMIN))) return;
     const adapter = pathname.split('/')[3];
@@ -278,12 +281,6 @@ async function handleApi(
         error(res, 400, 'token is required');
         return;
       }
-      // Validate first so we have a botId for the secret name and can fail
-      // fast on bad tokens without writing anything to the DB. We emit the
-      // error via the standard `{ error }` shape so the client's request<>
-      // wrapper extracts it cleanly — this endpoint is the SPA's only
-      // upstream-validation hop now that WireChannelPage skips the separate
-      // /test call.
       const validation =
         adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       if (!validation.ok) {
@@ -293,17 +290,10 @@ async function handleApi(
       }
       const botId = String(validation.identity.id);
       const username = validation.identity.username;
-      // Persist before bringing up the adapter so a crash mid-setup still
-      // leaves the token recoverable on next boot's spawnSecretsBackedBots.
       const secretName = channelTokenSecretName(adapter, botId);
       const existing = getSecret(secretName);
       const isRotation = existing !== undefined && existing !== token;
       putSecret(secretName, token, { kind: 'channel-token', agent_group_id: null });
-      const live = await registerBotAdapter(adapter, secretName, token);
-      if (!live) {
-        error(res, 502, `${adapter} register-bot: spawnFromSecret returned null after a successful validate`);
-        return;
-      }
       log.info(isRotation ? 'Channel bot token rotated' : 'Channel bot registered', { adapter, botId });
       json(res, 200, { ok: true, botId, username });
     } catch (err) {
@@ -654,38 +644,69 @@ async function handleApi(
       try {
         const body = await readJsonBody<{
           channelType?: 'discord' | 'telegram';
+          botId?: string;
           botUserId?: string;
+          operatorUserId?: string;
           displayName?: string;
         }>(req);
         if (!body.channelType || (body.channelType !== 'discord' && body.channelType !== 'telegram')) {
           error(res, 400, `channelType must be "discord" or "telegram"`);
           return;
         }
+        const botId = (body.botId ?? '').trim();
+        if (!botId) {
+          error(res, 400, `botId is required`);
+          return;
+        }
         if (!body.botUserId || !body.botUserId.trim()) {
           error(res, 400, `botUserId is required`);
           return;
         }
-        // Read the bot id from the active adapter so the v2 platform_id
-        // matches what the bridge will emit on inbound. If the adapter
-        // hasn't started (missing token, getMe failed), refuse to wire —
-        // a wire that disagrees with the eventual inbound encoding would
-        // silently drop messages once the adapter does come up.
-        const activeAdapter = getChannelAdapter(body.channelType);
-        if (!activeAdapter || !activeAdapter.botId) {
+        // The bot must either be already-live (the .env-seeded primary
+        // adapter the host spawned at boot) OR have a persisted token via
+        // /register-bot. Without one of those, the post-wire spawn step
+        // would have nothing to spawn from, and the operator would face
+        // a silently dead bot on the next host restart.
+        const secretName = channelTokenSecretName(body.channelType, botId);
+        const tokenValue = getSecret(secretName);
+        const liveAdapter = getChannelAdapterByBotId(body.channelType, botId);
+        if (!tokenValue && !liveAdapter) {
           error(
             res,
             409,
-            `cannot wire ${body.channelType}: adapter is not active (missing or unhealthy bot credentials)`,
+            `cannot wire ${body.channelType}: bot ${botId} has no persisted token and no live adapter (call /register-bot first)`,
           );
           return;
         }
         const result = wireDmToAgent({
           channelType: body.channelType,
           agentGroup: { id: group.id, name: group.name, folder: group.folder } as never,
-          botId: activeAdapter.botId,
+          botId,
           botUserId: body.botUserId,
           displayName: body.displayName,
         });
+        // Bring the adapter up after the MGA exists so the polling loop's
+        // first inbound lands on a wired channel instead of racing into the
+        // unwired-channel approval flow. registerBotAdapter is idempotent
+        // on (channelType, botId) — re-wiring the same bot to a second
+        // group leaves the existing live adapter in place. Skip when
+        // there's no token to spawn from but the adapter is already
+        // live (.env-seeded primary).
+        if (tokenValue) {
+          try {
+            await registerBotAdapter(body.channelType, secretName, tokenValue);
+          } catch (err) {
+            log.error('Failed to spawn adapter after wire', {
+              channel: body.channelType,
+              botId,
+              err,
+            });
+          }
+        }
+        // Record the operator-self-wire trust hint so the operator's first
+        // DM to a freshly-wired Telegram bot bypasses any backlog-driven
+        // approval cascade. No-op for Discord (no operator user id captured).
+        recordTrustHint(body.channelType, botId, (body.operatorUserId ?? '').trim());
         json(res, 200, result);
       } catch (err) {
         error(res, 500, err instanceof Error ? err.message : String(err));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -279,12 +279,16 @@ async function handleApi(
         return;
       }
       // Validate first so we have a botId for the secret name and can fail
-      // fast on bad tokens without writing anything to the DB.
+      // fast on bad tokens without writing anything to the DB. We emit the
+      // error via the standard `{ error }` shape so the client's request<>
+      // wrapper extracts it cleanly — this endpoint is the SPA's only
+      // upstream-validation hop now that WireChannelPage skips the separate
+      // /test call.
       const validation =
         adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       if (!validation.ok) {
         const httpStatus = validation.status === 401 ? 400 : validation.status;
-        json(res, httpStatus, validation);
+        error(res, httpStatus, validation.error);
         return;
       }
       const botId = String(validation.identity.id);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,9 +65,11 @@ import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
 import { upsertService } from './services-manifest.js';
 import { makeServeStatic, normalizeMount } from './static-serve.js';
 import { wireDmToAgent } from './wire-channel.js';
-import { getChannelAdapter } from '../channels/channel-registry.js';
+import { getChannelAdapter, registerBotAdapter } from '../channels/channel-registry.js';
 import { validateDiscordBotToken } from './discord-validate.js';
 import { validateTelegramBotToken } from './telegram-validate.js';
+import { putSecret } from '../secrets/index.js';
+import { channelTokenSecretName } from '../startup-bootstrap.js';
 
 const PROJECT_ROOT = process.cwd();
 const UI_DIST = path.resolve(PROJECT_ROOT, 'web/ui/dist');
@@ -251,6 +253,53 @@ async function handleApi(
         adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
       const httpStatus = result.ok ? 200 : result.status === 401 ? 400 : result.status;
       json(res, httpStatus, result);
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+    }
+    return;
+  }
+
+  // Persist + bring up an additional bot adapter at runtime. The wire-
+  // channel UI hits this after a successful /test so the operator can wire
+  // a NEW bot's token without restarting the host. Idempotent on
+  // (channelType, botId): re-posting the same token just refreshes the
+  // ciphertext and returns the already-active adapter's identity.
+  if (method === 'POST' && /^\/api\/channels\/[^/]+\/register-bot$/.test(pathname)) {
+    if (!(await gate(req, res, SCOPE_CLAW_ADMIN))) return;
+    const adapter = pathname.split('/')[3];
+    if (adapter !== 'discord' && adapter !== 'telegram') {
+      error(res, 404, `unknown adapter: ${adapter}`);
+      return;
+    }
+    try {
+      const body = await readJsonBody<{ token?: string }>(req);
+      const token = (body.token ?? '').trim();
+      if (!token) {
+        error(res, 400, 'token is required');
+        return;
+      }
+      // Validate first so we have a botId for the secret name and can fail
+      // fast on bad tokens without writing anything to the DB.
+      const validation =
+        adapter === 'discord' ? await validateDiscordBotToken(token) : await validateTelegramBotToken(token);
+      if (!validation.ok) {
+        const httpStatus = validation.status === 401 ? 400 : validation.status;
+        json(res, httpStatus, validation);
+        return;
+      }
+      const botId = String(validation.identity.id);
+      const username = validation.identity.username;
+      // Persist before bringing up the adapter so a crash mid-setup still
+      // leaves the token recoverable on next boot's spawnSecretsBackedBots.
+      const secretName = channelTokenSecretName(adapter, botId);
+      putSecret(secretName, token, { kind: 'channel-token', agent_group_id: null });
+      const live = await registerBotAdapter(adapter, secretName, token);
+      if (!live) {
+        error(res, 502, `${adapter} register-bot: spawnFromSecret returned null after a successful validate`);
+        return;
+      }
+      log.info('Channel bot registered', { adapter, botId });
+      json(res, 200, { ok: true, botId, username });
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));
     }

--- a/web/ui/src/components/setup/WireChannelStep.tsx
+++ b/web/ui/src/components/setup/WireChannelStep.tsx
@@ -72,7 +72,12 @@ export function WireChannelStep({ state, patchState, next, back }: StepProps) {
     try {
       const r = await wireChannelToGroup(state.agentGroupFolder, {
         channel: adapter,
+        // The bot's identity from test-connection's getMe; for both
+        // adapters this is the bot's user/application id and forms the
+        // bot dimension of the v2 platform_id.
+        botId: state.botUserId ?? '',
         botUserId: wireId,
+        operatorUserId: state.operatorUserId ?? undefined,
         displayName: state.agentGroupName ? `${state.agentGroupName} DM` : undefined,
       });
       setResult(r);

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -244,7 +244,9 @@ describe('wireChannelToGroup — body contract with server', () => {
     const api = await import('./api.ts');
     await api.wireChannelToGroup('forge', {
       channel: 'telegram',
+      botId: '7654321',
       botUserId: '42',
+      operatorUserId: '42',
       displayName: 'Forge DM',
     });
 
@@ -253,7 +255,9 @@ describe('wireChannelToGroup — body contract with server', () => {
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body).toEqual({
       channelType: 'telegram',
+      botId: '7654321',
       botUserId: '42',
+      operatorUserId: '42',
       displayName: 'Forge DM',
     });
     expect(body.channel).toBeUndefined();

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -931,6 +931,35 @@ export async function testTelegramToken(token: string): Promise<{ identity: Tele
   });
 }
 
+// --- Dynamic bot registration (used after token validate, before wire) ---
+
+export interface RegisterChannelBotResult {
+  ok: true;
+  botId: string;
+  username: string;
+}
+
+/**
+ * Persist the validated bot token to /secrets and bring up its adapter at
+ * runtime. Idempotent on `(channel, botId)` — re-posting the same token
+ * refreshes the ciphertext and returns the already-active adapter.
+ *
+ * Run this AFTER `testDiscordToken` / `testTelegramToken` succeeds so the
+ * server can fail fast on bad tokens before any DB write. The returned
+ * `botId` is what the next `wireChannelToGroup` call should pass as
+ * `botUserId` for Discord (where botId == bot's snowflake), and as the
+ * basis of the operator-id for Telegram.
+ */
+export async function registerChannelBot(
+  channel: ChannelKind,
+  token: string,
+): Promise<RegisterChannelBotResult> {
+  return request<RegisterChannelBotResult>(`/channels/${encodeURIComponent(channel)}/register-bot`, {
+    method: 'POST',
+    json: { token },
+  });
+}
+
 // --- Channel wiring (per-group, used by wizard step 7) ---
 
 export interface WireChannelResult {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -972,13 +972,28 @@ export interface WireChannelResult {
 /**
  * Wire a DM channel to an agent group.
  *
- * `botUserId` semantics differ by channel — see web/server/src/wire-channel.ts:
+ * `botId` is the bot's own identity (returned by /register-bot); it forms
+ * the second segment of the v2 platform_id and keys the dynamic adapter
+ * the server brings up after the wire commits.
+ *
+ * `botUserId` semantics differ by channel — see src/web/wire-channel.ts:
  *   - discord  : the BOT's snowflake (DMs are addressee-routed; ANY DM lands on the bot's @me)
  *   - telegram : the OPERATOR's user id (DMs are chat-routed; only that user's DMs match)
+ *
+ * `operatorUserId` is the operator's user id captured by the form (Telegram
+ * only). It seeds the in-memory trust hint that lets the operator's first
+ * post-wire DM bypass the unwired-channel approval cascade. Empty string
+ * is fine for adapters that don't capture an operator id.
  */
 export async function wireChannelToGroup(
   folder: string,
-  input: { channel: ChannelKind; botUserId: string; displayName?: string },
+  input: {
+    channel: ChannelKind;
+    botId: string;
+    botUserId: string;
+    operatorUserId?: string;
+    displayName?: string;
+  },
 ): Promise<WireChannelResult> {
   // Server's body parser keys on `channelType` (matches the DB column
   // and the wire-channel.ts WireDmInput interface). The helper accepts
@@ -987,7 +1002,9 @@ export async function wireChannelToGroup(
     method: 'POST',
     json: {
       channelType: input.channel,
+      botId: input.botId,
       botUserId: input.botUserId,
+      operatorUserId: input.operatorUserId,
       displayName: input.displayName,
     },
   });

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -117,7 +117,9 @@ export function WireChannelPage() {
     try {
       const r = await wireChannelToGroup(picked.folder, {
         channel: adapter.key,
+        botId: identity.id,
         botUserId: wireId,
+        operatorUserId: operatorUserId.trim() || undefined,
         displayName: `${picked.name} DM`,
       });
       setWireResult(r);

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -30,7 +30,7 @@ import {
   type ChannelAdapter,
   type ResolvedIdentity,
 } from '../lib/channel-adapters.ts';
-import { wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
+import { registerChannelBot, wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
 
 export function WireChannelPage() {
   const [adapterKey, setAdapterKey] = useState<ChannelAdapter | null>(null);
@@ -66,8 +66,19 @@ export function WireChannelPage() {
     setValidating(true);
     setValidateError(null);
     try {
-      const r = await adapter.validate(token.trim());
-      setIdentity(r);
+      const trimmed = token.trim();
+      // Hit the per-adapter validator first so the user-facing error from a
+      // bad token names the platform's rejection ("telegram rejected token:
+      // …") rather than a 502 from the register-bot path. Then immediately
+      // register-bot, which persists the token to /secrets and brings up the
+      // adapter at runtime — a single user gesture covers both.
+      const validated = await adapter.validate(trimmed);
+      const registered = await registerChannelBot(adapter.key, trimmed);
+      // Server's register-bot is authoritative on botId — for Discord the
+      // validator returns the user.id which matches application.id for bot
+      // accounts, but in case they ever drift we trust whatever the live
+      // adapter resolved.
+      setIdentity({ id: registered.botId, username: registered.username || validated.username });
       setToken('');
     } catch (err) {
       setValidateError(err instanceof Error ? err.message : String(err));
@@ -191,7 +202,8 @@ export function WireChannelPage() {
         <Section step={2} title={`Bot identity — ${adapter.label}`}>
           <p className="dim" style={{ marginTop: 0 }}>
             We hit <code>{adapter.upstreamProbePath}</code> to confirm the token authenticates and the account
-            is a bot. Get a token from{' '}
+            is a bot, then encrypt-and-store it under <code>secrets</code> and bring up the adapter so
+            the bot is live across host restarts. Get a token from{' '}
             <a href={adapter.tokenHelp.href} target="_blank" rel="noreferrer">
               {adapter.tokenHelp.title}
             </a>
@@ -201,7 +213,7 @@ export function WireChannelPage() {
           {identity ? (
             <div className="empty empty-rich" style={{ marginTop: '0.5rem' }}>
               <p className="empty-headline" style={{ margin: 0 }}>
-                Bot identified: <code>@{identity.username}</code>{' '}
+                Bot registered: <code>@{identity.username}</code>{' '}
                 <span className="dim">
                   (id <code>{identity.id}</code>)
                 </span>
@@ -214,7 +226,7 @@ export function WireChannelPage() {
                   setToken('');
                 }}
               >
-                Re-validate with a different token
+                Use a different token
               </button>
             </div>
           ) : (
@@ -233,7 +245,7 @@ export function WireChannelPage() {
               {validateError && <div className="error-banner">{validateError}</div>}
               <div className="actions" style={{ marginTop: '0.5rem' }}>
                 <button onClick={onValidate} disabled={!token.trim() || validating}>
-                  {validating ? 'Validating…' : 'Validate token'}
+                  {validating ? 'Validating + registering…' : 'Validate & register bot'}
                 </button>
               </div>
             </>

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -67,18 +67,18 @@ export function WireChannelPage() {
     setValidateError(null);
     try {
       const trimmed = token.trim();
-      // Hit the per-adapter validator first so the user-facing error from a
-      // bad token names the platform's rejection ("telegram rejected token:
-      // …") rather than a 502 from the register-bot path. Then immediately
-      // register-bot, which persists the token to /secrets and brings up the
-      // adapter at runtime — a single user gesture covers both.
-      const validated = await adapter.validate(trimmed);
+      // Single hop: register-bot validates upstream, persists to /secrets,
+      // and brings the adapter live in one server round-trip. The server
+      // surfaces the upstream platform's rejection message via the standard
+      // `{ error }` shape on bad tokens, so we don't need a separate /test
+      // pre-call.
+      //
+      // Re-posting the same bot's secret with a new token persists the
+      // rotation immediately but the live polling loop keeps the old token
+      // until the next host restart — same as a `.env` rotation. Operators
+      // doing a forced rotation should restart paraclaw.
       const registered = await registerChannelBot(adapter.key, trimmed);
-      // Server's register-bot is authoritative on botId — for Discord the
-      // validator returns the user.id which matches application.id for bot
-      // accounts, but in case they ever drift we trust whatever the live
-      // adapter resolved.
-      setIdentity({ id: registered.botId, username: registered.username || validated.username });
+      setIdentity({ id: registered.botId, username: registered.username });
       setToken('');
     } catch (err) {
       setValidateError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

PR B of the paraclaw#67 channel-wiring rework. Replaces the earlier "validate+register in one step" framing with two distinct operator-flow proposals (Aaron approved A+B together, C deferred):

- **Proposal A — defer adapter spawn until wire.** `/register-bot` becomes validate + persist only. Adapter spawn now happens atomically with the messaging-group-agents insert in `/wire-channel`. Result: a registered-but-unwired bot can't poll inbounds into the unwired-channel approval cascade.
- **Proposal B — operator self-wire trust hint.** A 5-min single-use map keyed `(channelType, botId, operatorUserId)` records the wire event, and the router consumes the hint on the operator's first DM to auto-wire to the first agent group instead of cutting an approval card aimed at themselves.

Plus a race fix for `pending_channel_approvals` that's been lurking under the unwired-channel flow, and a follow-up bug fix for the v2 platform_id backfill that surfaced in live testing.

## What this lands

### Proposal A — deferred adapter spawn (`channel-registry.ts`, `web/server.ts`)

- `/api/channels/{adapter}/register-bot` no longer calls `registerBotAdapter`. Token is validated upstream, persisted to secrets, and the response returns the resolved identity. No adapter polling loop is spawned at this step.
- `/api/groups/:folder/wire-channel` now requires `botId` on the body. After `wireDmToAgent` inserts the MGA row, it spawns the adapter via `registerBotAdapter` (idempotent on `(channelType, botId)` — re-wiring the same bot to a second group leaves the existing live adapter in place). Tolerates a missing `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret if a live adapter is already active for that pair (covers the wizard's `.env`-seeded primary bot path).
- `getChannelAdapterByBotId(channelType, botId)` exposes a precise lookup so wire-channel can ask the right question.
- `spawnSecretsBackedBots` now skips orphan secrets (registered token, no MGA wiring) at boot. Without this, a stale orphan token would auto-revive its polling loop on every restart and re-feed the unwired-channel cascade. `hasWiringForBot` does the JOIN with a LIKE-and-ESCAPE'd pattern against the v2 platform_id format `<channel>:<botId>:<native>`.

### Proposal B — operator self-wire trust hint (`channels/trust-hint.ts`, `router.ts`)

- New module: in-memory `Map<HintKey, expiresAt>` with TTL = 5 min. `recordTrustHint` is a no-op on empty `operatorUserId` (Discord wires don't capture one). `consumeTrustHint` is single-use — the second consume of the same key returns false.
- `/wire-channel` calls `recordTrustHint(channelType, botId, operatorUserId)` after a successful wire.
- Router intercepts the unwired-channel branch: if the inbound's decoded `(channelType, botId, senderId)` matches a recorded hint, the router updates the messaging group's `unknown_sender_policy` to `strict`, calls `wireDmToAgent` for the first agent group on this install, and re-routes — so the operator's first DM lands on a wired channel as if the wire had been there all along.

### Race fix — atomic dedup on `pending_channel_approvals`

- `createPendingChannelApproval` was a plain INSERT that threw `UNIQUE constraint failed` when two inbounds for the same messaging group raced past the in-flight check. Switched to `ON CONFLICT(messaging_group_id) DO NOTHING` and now returns whether the row was inserted; `channel-approval.ts` silently skips delivery on the loser side.

### v2 backfill bug fix — `isAlreadyV2` must consider all known botIds (`startup-bootstrap.ts`)

Surfaced in live testing on an install with two telegram bots: the v1→v2 platform_id backfill iterates over active adapters and rewrites `<channel>:<native>` rows to `<channel>:<botId>:<native>`. Its idempotency check (`isAlreadyV2`) only compared the row's slot1 against the *current iteration's adapter botId* — so when a row was already-v2 for a *different* bot, the check returned false and the row got re-prefixed under the iteration's botId, producing a 4-segment garbage id like `telegram:primary:secondary:chat`. Combined with PR B's orphan-skip rule, this was a fully silent failure mode for secondary bots.

Fix: pass `isAlreadyV2` the *union* of every known botId per channel — active adapters' botIds plus every botId parsed out of `CHANNEL_BOT_TOKEN:<channel>:<botId>` secret names. The secrets-table read matters because Proposal A defers adapter spawn until `/wire-channel`, so secondary bots persisted via `/register-bot` have their token in secrets but no live adapter at boot. Adds a regression test exercising the multi-bot scenario.

Filed paraclaw#74 for visibility.

### UI (`web/ui/src/lib/api.ts`, `WireChannelPage.tsx`, `WireChannelStep.tsx`)

- `wireChannelToGroup(folder, { channel, botId, botUserId, operatorUserId?, displayName? })` — body now carries `botId` (server requires it) and `operatorUserId` (threads the trust hint).
- WireChannelPage passes `identity.id`. The setup wizard's WireChannelStep passes `state.botUserId`. The wire-body API contract test pins the JSON shape the server expects.

### Versioning

`0.0.14-rc.25 → 0.0.14-rc.27` (rc.26 = A+B+race-fix; rc.27 adds the v2-backfill bug fix).

## Test plan

- [x] Host typecheck: `pnpm typecheck` — clean
- [x] Host tests: `pnpm test` — **412/412 pass** (47 files; +9 over the prior rc.25 count of 403). New: 6 trust-hint tests, 2 race-fix tests, 1 multi-bot backfill regression test; updated channel-registry orphan-skip case in `spawnSecretsBackedBots` test.
- [x] UI typecheck: `cd web/ui && pnpm typecheck` — clean
- [x] UI tests: `cd web/ui && pnpm test` — **18/18 pass** (2 files). `api.test.ts` updated for new wire-channel body shape.
- [ ] Browser exercise (reviewer + Aaron): on a fresh install with the primary bot wired via the wizard, hit `/claw/channels/new`, register a second bot, complete the wire flow, then DM the second bot from the operator account. Confirm: (1) the second bot's first DM lands clean (no approval card to operator), (2) a non-operator's DM still produces an approval card, (3) on host restart, only wired bots come back live (orphan-skip), (4) secondary-bot rows survive a restart without re-prefix corruption.

## Commits

- `c5560cd` feat(channels): defer adapter spawn to wire + operator trust hint (paraclaw#67)
- `6a917c9` fix(approvals): atomic dedup for pending_channel_approvals (paraclaw#67)
- `1505073` feat(ui): pass botId + operatorUserId to wire-channel (paraclaw#67)
- `f0ab65c` chore: bump 0.0.14-rc.25 → 0.0.14-rc.26 (paraclaw#67)
- `1fa1250` fixup(paraclaw#67): reviewer polish — diagnose empty agent groups, document picks
- `f019910` fix(bootstrap): isAlreadyV2 must consider all known botIds, not just current iteration's (paraclaw#67)

Plus the prior rc.25 commits already on this branch (refactor + register-bot endpoint + multi-bot routing tests + reviewer fixup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)