### PR TITLE
feat: bot-aware approval routing + settings UI (paraclaw#67 PR1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.27",
+  "version": "0.0.14-rc.28",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.28",
+  "version": "0.0.14-rc.29",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/migrations/026-user-dms-bot-id.test.ts
+++ b/src/db/migrations/026-user-dms-bot-id.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Coverage for migration 026 — user_dms PK extension to include `bot_id`.
+ *
+ * Strategy: skip 026 via `applyMigrationsExcept`, seed pre-026 rows
+ * against the legacy 2-column PK, run the migration, assert that:
+ *
+ *   - rows survive the rebuild and land at `bot_id = ''` (the
+ *     configurable channel-default slot)
+ *   - PK now permits a second `(user, channel)` row keyed on a real bot
+ *     id (the multi-bot case the legacy schema couldn't represent)
+ *   - the legacy `user_dms_legacy` scaffold is gone
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb } from '../index.js';
+import { migration026 } from './026-user-dms-bot-id.js';
+import { applyMigrationsExcept } from './_test-helpers.js';
+
+function applyAllExcept026(): void {
+  applyMigrationsExcept([migration026]);
+}
+
+function seedUser(id: string, kind: string): void {
+  getDb()
+    .prepare(`INSERT INTO users (id, kind, display_name, created_at) VALUES (?, ?, NULL, datetime('now'))`)
+    .run(id, kind);
+}
+
+function seedMessagingGroup(id: string, channelType: string, platformId: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO messaging_groups (id, channel_type, platform_id, name, is_group, unknown_sender_policy, created_at)
+       VALUES (?, ?, ?, NULL, 0, 'strict', datetime('now'))`,
+    )
+    .run(id, channelType, platformId);
+}
+
+function seedLegacyUserDm(userId: string, channelType: string, mgId: string): void {
+  // Pre-026: PK is (user_id, channel_type). Schema has no bot_id.
+  getDb()
+    .prepare(
+      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
+       VALUES (?, ?, ?, datetime('now'))`,
+    )
+    .run(userId, channelType, mgId);
+}
+
+beforeEach(() => {
+  applyAllExcept026();
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+describe('migration 026 — user_dms.bot_id PK extension', () => {
+  it('preserves legacy rows under bot_id = ""', () => {
+    seedUser('telegram:1190596288', 'telegram');
+    seedMessagingGroup('mg-1', 'telegram', 'telegram:8792496425:1190596288');
+    seedLegacyUserDm('telegram:1190596288', 'telegram', 'mg-1');
+
+    migration026.up(getDb());
+
+    const rows = getDb().prepare(`SELECT user_id, channel_type, bot_id, messaging_group_id FROM user_dms`).all() as {
+      user_id: string;
+      channel_type: string;
+      bot_id: string;
+      messaging_group_id: string;
+    }[];
+    expect(rows).toEqual([
+      {
+        user_id: 'telegram:1190596288',
+        channel_type: 'telegram',
+        bot_id: '',
+        messaging_group_id: 'mg-1',
+      },
+    ]);
+  });
+
+  it('PK now allows a second row for the same (user, channel) under a different bot', () => {
+    seedUser('telegram:1190596288', 'telegram');
+    seedMessagingGroup('mg-primary', 'telegram', 'telegram:primary-bot:1190596288');
+    seedMessagingGroup('mg-secondary', 'telegram', 'telegram:secondary-bot:1190596288');
+    seedLegacyUserDm('telegram:1190596288', 'telegram', 'mg-primary');
+
+    migration026.up(getDb());
+
+    // The legacy row landed under bot_id=''. A bot-pinned write under a
+    // real bot id must succeed (the legacy schema would have rejected
+    // this on the 2-column PK).
+    getDb()
+      .prepare(
+        `INSERT INTO user_dms (user_id, channel_type, bot_id, messaging_group_id, resolved_at)
+         VALUES (?, ?, ?, ?, datetime('now'))`,
+      )
+      .run('telegram:1190596288', 'telegram', 'secondary-bot', 'mg-secondary');
+
+    const count = getDb()
+      .prepare(`SELECT COUNT(*) AS n FROM user_dms WHERE user_id = ? AND channel_type = ?`)
+      .get('telegram:1190596288', 'telegram') as { n: number };
+    expect(count.n).toBe(2);
+  });
+
+  it('drops the legacy rebuild scaffold', () => {
+    seedUser('telegram:1', 'telegram');
+    seedMessagingGroup('mg-1', 'telegram', 'telegram:b:1');
+    seedLegacyUserDm('telegram:1', 'telegram', 'mg-1');
+
+    migration026.up(getDb());
+
+    const tables = getDb()
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'user_dms%'`)
+      .all() as { name: string }[];
+    expect(tables.map((t) => t.name).sort()).toEqual(['user_dms']);
+  });
+});

--- a/src/db/migrations/026-user-dms-bot-id.ts
+++ b/src/db/migrations/026-user-dms-bot-id.ts
@@ -1,0 +1,54 @@
+/**
+ * Extend `user_dms` PK to include `bot_id` so the cache disambiguates
+ * approvals on multi-bot installs (paraclaw#67 follow-up — Proposal C).
+ *
+ * Before:  PRIMARY KEY (user_id, channel_type)
+ * After:   PRIMARY KEY (user_id, channel_type, bot_id)   -- bot_id NOT NULL DEFAULT ''
+ *
+ * Why the column instead of a sibling table: the cache's purpose is
+ * "given an approver and a channel + bot, what messaging_group do I
+ * deliver to?" — a key extension is the honest representation. A
+ * sibling table would force every reader to do an existence check
+ * across both tables to find the right row.
+ *
+ * Backfill: every legacy row migrates with `bot_id = ''`. The empty
+ * string is the configurable system-default slot — a settings UI lets
+ * the operator point it at a specific bot's DM, and the resolver falls
+ * through to it when an exact `(user, channel, originBotId)` cache miss
+ * cold-resolves into a "bots can't DM first" failure (Telegram). See
+ * `pickApprovalDelivery` in `src/modules/approvals/primitive.ts`.
+ *
+ * Idempotency: schema_version gate; uses the rename-rebuild dance
+ * because SQLite can't add a column to an existing PK. Sets
+ * `disableForeignKeys: true` for the same reason 025 does — the
+ * runner toggles `PRAGMA foreign_keys = OFF` connection-scope so
+ * pre-existing orphan rows in referencing tables don't fail the
+ * commit-time deferred check.
+ */
+import type { Database } from '../connection.js';
+import type { Migration } from './index.js';
+
+export const migration026: Migration = {
+  version: 26,
+  name: 'user-dms-bot-id',
+  disableForeignKeys: true,
+  up(db: Database) {
+    db.exec(`
+      CREATE TABLE user_dms_new (
+        user_id            TEXT NOT NULL REFERENCES users(id),
+        channel_type       TEXT NOT NULL,
+        bot_id             TEXT NOT NULL DEFAULT '',
+        messaging_group_id TEXT NOT NULL REFERENCES messaging_groups(id),
+        resolved_at        TEXT NOT NULL,
+        PRIMARY KEY (user_id, channel_type, bot_id)
+      );
+
+      INSERT INTO user_dms_new (user_id, channel_type, bot_id, messaging_group_id, resolved_at)
+        SELECT user_id, channel_type, '', messaging_group_id, resolved_at
+          FROM user_dms;
+
+      DROP TABLE user_dms;
+      ALTER TABLE user_dms_new RENAME TO user_dms;
+    `);
+  },
+};

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -22,6 +22,7 @@ import { migration022 } from './022-app-connections-provider.js';
 import { migration023 } from './023-agent-group-secret-mode.js';
 import { migration024 } from './024-collapse-approvals.js';
 import { migration025 } from './025-secret-mode-check.js';
+import { migration026 } from './026-user-dms-bot-id.js';
 import { moduleApprovalsPendingApprovals } from './module-approvals-pending-approvals.js';
 import { moduleApprovalsTitleOptions } from './module-approvals-title-options.js';
 
@@ -73,6 +74,7 @@ const migrations: Migration[] = [
   migration023,
   migration024,
   migration025,
+  migration026,
 ];
 
 export function runMigrations(db: Database): void {

--- a/src/modules/approvals/picks.test.ts
+++ b/src/modules/approvals/picks.test.ts
@@ -7,11 +7,14 @@ import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 
 import type { ChannelAdapter, OutboundMessage } from '../../channels/adapter.js';
 import {
+  _resetActiveAdaptersForTest,
+  _setActiveAdapterForTest,
   initChannelAdapters,
   registerChannelAdapter,
   teardownChannelAdapters,
 } from '../../channels/channel-registry.js';
-import { closeDb, createAgentGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { closeDb, createAgentGroup, createMessagingGroup, initTestDb, runMigrations } from '../../db/index.js';
+import { upsertUserDm } from '../permissions/db/user-dms.js';
 import { createUser } from '../permissions/db/users.js';
 import { grantRole } from '../permissions/db/user-roles.js';
 import { pickApprovalDelivery, pickApprover } from './primitive.js';
@@ -27,8 +30,45 @@ beforeEach(() => {
 
 afterEach(async () => {
   await teardownChannelAdapters();
+  _resetActiveAdaptersForTest();
   closeDb();
 });
+
+/**
+ * Inject a bot-pinned mock adapter directly into the active registry.
+ * Bypasses `registerChannelAdapter` / `initChannelAdapters` so a single
+ * test can mount more than one adapter on the same channel type — the
+ * factory-based mount overwrites within a channel.
+ */
+function injectBotAdapter(
+  channelType: string,
+  botId: string,
+  openDM?: (handle: string) => Promise<string>,
+): { openDMCalls: string[] } {
+  const openDMCalls: string[] = [];
+  const adapter: ChannelAdapter = {
+    name: `${channelType}:${botId}`,
+    channelType,
+    botId,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected() {
+      return true;
+    },
+    async deliver() {
+      return undefined;
+    },
+  };
+  if (openDM) {
+    adapter.openDM = async (handle: string) => {
+      openDMCalls.push(handle);
+      return openDM(handle);
+    };
+  }
+  _setActiveAdapterForTest(adapter);
+  return { openDMCalls };
+}
 
 async function mountMockAdapter(
   channelType: string,
@@ -142,5 +182,110 @@ describe('pickApprovalDelivery', () => {
   it('returns null when nobody is reachable', async () => {
     seedUser('telegram:111', 'telegram');
     expect(await pickApprovalDelivery(['telegram:111'], 'telegram')).toBeNull();
+  });
+
+  /**
+   * The 3-step fallback chain (paraclaw#67 PR1):
+   *   1. same-channel approver, exact (channel, originBotId) match
+   *   2. same-channel approver, channel-default `bot_id=''` slot
+   *   3. cross-channel approver, channel-default slot
+   * `viaFallbackBot` is true whenever an originBotId was requested but
+   * the delivery landed on the channel-default slot — the caller uses
+   * that to surface "this card was routed via your default bot, not the
+   * one the inbound came from" in the body.
+   */
+  describe('bot-aware fallback chain (migration 026)', () => {
+    function seedMg(id: string, channelType: string, platformId: string): void {
+      createMessagingGroup({
+        id,
+        channel_type: channelType,
+        platform_id: platformId,
+        name: null,
+        is_group: 0,
+        unknown_sender_policy: 'strict',
+        created_at: now(),
+      });
+    }
+    function seedUserDm(userId: string, channelType: string, botId: string, mgId: string): void {
+      upsertUserDm({
+        user_id: userId,
+        channel_type: channelType,
+        bot_id: botId,
+        messaging_group_id: mgId,
+        resolved_at: now(),
+      });
+    }
+
+    it('step 1: prefers exact bot match over channel-default slot', async () => {
+      injectBotAdapter('telegram', 'primary-bot');
+      injectBotAdapter('telegram', 'secondary-bot');
+      seedUser('telegram:111', 'telegram');
+      seedMg('mg-default', 'telegram', 'telegram::111');
+      seedMg('mg-secondary', 'telegram', 'telegram:secondary-bot:111');
+      seedUserDm('telegram:111', 'telegram', '', 'mg-default');
+      seedUserDm('telegram:111', 'telegram', 'secondary-bot', 'mg-secondary');
+
+      const result = await pickApprovalDelivery(['telegram:111'], 'telegram', 'secondary-bot');
+      expect(result?.userId).toBe('telegram:111');
+      expect(result?.messagingGroup.id).toBe('mg-secondary');
+      expect(result?.viaFallbackBot).toBe(false);
+    });
+
+    it('step 2: falls back to channel-default when origin bot has no DM cached and openDM fails', async () => {
+      injectBotAdapter('telegram', 'primary-bot');
+      // secondary-bot adapter throws on openDM — Telegram's "bots can't
+      // initiate" error. Step 1 returns null, step 2 hits the cached
+      // channel-default row.
+      injectBotAdapter('telegram', 'secondary-bot', async () => {
+        throw new Error("bots can't initiate DMs");
+      });
+      seedUser('telegram:111', 'telegram');
+      seedMg('mg-default', 'telegram', 'telegram::111');
+      seedUserDm('telegram:111', 'telegram', '', 'mg-default');
+
+      const result = await pickApprovalDelivery(['telegram:111'], 'telegram', 'secondary-bot');
+      expect(result?.userId).toBe('telegram:111');
+      expect(result?.messagingGroup.id).toBe('mg-default');
+      expect(result?.viaFallbackBot).toBe(true);
+    });
+
+    it('step 2: cold-resolves the channel-default slot when nothing is cached but a default adapter exists', async () => {
+      // Single bot active for telegram. Step 1 (exact 'secondary-bot' match)
+      // can't run — no adapter for that bot id. Step 2 calls ensureUserDm
+      // with no bot id, which hits the first telegram adapter and
+      // cold-resolves through it.
+      const fallback = injectBotAdapter('telegram', 'primary-bot', async (h) => `tg:${h}`);
+      seedUser('telegram:111', 'telegram');
+
+      const result = await pickApprovalDelivery(['telegram:111'], 'telegram', 'secondary-bot');
+      expect(result?.userId).toBe('telegram:111');
+      expect(result?.viaFallbackBot).toBe(true);
+      expect(fallback.openDMCalls).toEqual(['111']);
+    });
+
+    it('step 3: cross-channel fallback when no same-channel approver is reachable', async () => {
+      // No discord adapter at all. Step 1 + 2 (same channel = discord)
+      // find no approver to reach. Step 3 walks any channel and lands on
+      // the cached telegram DM.
+      injectBotAdapter('telegram', 'primary-bot');
+      seedUser('telegram:111', 'telegram');
+      seedUser('discord:222', 'discord');
+      seedMg('mg-tg-default', 'telegram', 'telegram::111');
+      seedUserDm('telegram:111', 'telegram', '', 'mg-tg-default');
+
+      const result = await pickApprovalDelivery(['discord:222', 'telegram:111'], 'discord', 'discord-bot-1');
+      expect(result?.userId).toBe('telegram:111');
+      expect(result?.messagingGroup.id).toBe('mg-tg-default');
+      expect(result?.viaFallbackBot).toBe(true);
+    });
+
+    it('viaFallbackBot=false when no originBotId is supplied (legacy single-bot install)', async () => {
+      injectBotAdapter('telegram', 'primary-bot', async (h) => `tg:${h}`);
+      seedUser('telegram:111', 'telegram');
+
+      const result = await pickApprovalDelivery(['telegram:111'], 'telegram', null);
+      expect(result?.userId).toBe('telegram:111');
+      expect(result?.viaFallbackBot).toBe(false);
+    });
   });
 });

--- a/src/modules/approvals/primitive.ts
+++ b/src/modules/approvals/primitive.ts
@@ -28,6 +28,7 @@ import { createApproval, getSession } from '../../db/sessions.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { wakeContainer } from '../../container-runner.js';
 import { log } from '../../log.js';
+import { decodePlatformIdAs } from '../../platform-id.js';
 import { writeSessionMessage } from '../../session-manager.js';
 import type { MessagingGroup, Session } from '../../types.js';
 import { getAdminsOfAgentGroup, getGlobalAdmins, getOwners } from '../permissions/db/user-roles.js';
@@ -94,27 +95,59 @@ export function pickApprover(agentGroupId: string | null): string[] {
 }
 
 /**
- * Walk the approver list and return the first (approverId, messagingGroup)
- * pair we can actually deliver to. Returns null if nobody is reachable.
+ * Walk the approver list and return the first reachable
+ * (approverId, messagingGroup, viaFallbackBot) tuple. Returns null if
+ * nobody is reachable.
  *
- * Tie-break: prefer approvers reachable on the same channel kind as the
- * origin; else first in list. Resolution uses ensureUserDm, which may
- * trigger a platform openDM call on cache miss.
+ * Resolution order, when both `originChannelType` and `originBotId` are set:
+ *
+ *   1. Same-channel approver, exact `(channel, originBotId)` match —
+ *      best case, the card delivers via the same bot the inbound
+ *      came in on.
+ *   2. Same-channel approver, channel-default DM (`bot_id = ''` slot
+ *      in `user_dms`, configured via `/claw/settings/approvals`) —
+ *      `viaFallbackBot: true`, so callers can name the origin bot in
+ *      the card body to avoid confusion.
+ *   3. Cross-channel approver, channel-default DM — same-channel
+ *      delivery wasn't possible at all (no approver on this channel,
+ *      or none of them have any DM cached).
+ *   4. None — null.
+ *
+ * When only `originChannelType` is provided (single-bot install,
+ * legacy callers), step 1 collapses into step 2: the bot id is
+ * effectively `''` and the channel-default row is the cache.
+ *
+ * Cold-resolve at step 1 hits the adapter registered for
+ * `(channel, originBotId)` directly — see `ensureUserDm` — so a
+ * cache miss for an active secondary bot triggers `openDM` on that
+ * bot, not on whichever bot happens to be first in the registry.
  */
 export async function pickApprovalDelivery(
   approvers: string[],
   originChannelType: string,
-): Promise<{ userId: string; messagingGroup: MessagingGroup } | null> {
+  originBotId: string | null = null,
+): Promise<{ userId: string; messagingGroup: MessagingGroup; viaFallbackBot: boolean } | null> {
+  // Step 1 — same channel, exact bot match.
+  if (originChannelType && originBotId) {
+    for (const userId of approvers) {
+      if (channelTypeOf(userId) !== originChannelType) continue;
+      const mg = await ensureUserDm(userId, { botId: originBotId });
+      if (mg) return { userId, messagingGroup: mg, viaFallbackBot: false };
+    }
+  }
+  // Step 2 — same channel, channel-default DM. `viaFallbackBot` is true
+  // only when an originBotId was requested but didn't resolve.
   if (originChannelType) {
     for (const userId of approvers) {
       if (channelTypeOf(userId) !== originChannelType) continue;
       const mg = await ensureUserDm(userId);
-      if (mg) return { userId, messagingGroup: mg };
+      if (mg) return { userId, messagingGroup: mg, viaFallbackBot: !!originBotId };
     }
   }
+  // Step 3 — cross-channel any.
   for (const userId of approvers) {
     const mg = await ensureUserDm(userId);
-    if (mg) return { userId, messagingGroup: mg };
+    if (mg) return { userId, messagingGroup: mg, viaFallbackBot: !!originBotId };
   }
   return null;
 }
@@ -171,13 +204,18 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
     return;
   }
 
-  const originChannelType = session.messaging_group_id
-    ? (getMessagingGroup(session.messaging_group_id)?.channel_type ?? '')
-    : '';
+  const originMg = session.messaging_group_id ? (getMessagingGroup(session.messaging_group_id) ?? null) : null;
+  const originChannelType = originMg?.channel_type ?? '';
+  // The session's MG is paraclaw-managed and gets v2-shaped on creation
+  // (or backfilled by startup-bootstrap), so slot1 of the platform_id is
+  // the bot id. v1 rows return botId=null and we route by channel only —
+  // same path as a single-bot install.
+  const originBotId = originMg ? decodePlatformIdAs(originMg.platform_id, 'v2').botId : null;
 
-  const target = await pickApprovalDelivery(approvers, originChannelType);
+  const target = await pickApprovalDelivery(approvers, originChannelType, originBotId);
   if (!target) {
-    notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.`);
+    const hint = originBotId ? ` Ask them to DM ${originBotId} once so the bot can reach them, then retry.` : '';
+    notifyAgent(session, `${action} failed: no DM channel found for any eligible approver.${hint}`);
     return;
   }
 
@@ -213,7 +251,7 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
           type: 'ask_question',
           questionId: approvalId,
           title,
-          question,
+          question: appendFallbackNotice(question, target.viaFallbackBot, originBotId),
           options: APPROVAL_OPTIONS,
         }),
       );
@@ -225,4 +263,17 @@ export async function requestApproval(opts: RequestApprovalOptions): Promise<voi
   }
 
   log.info('Approval requested', { action, approvalId, agentName, approver: target.userId });
+}
+
+/**
+ * When `pickApprovalDelivery` falls back to the channel-default bot
+ * (because the inbound bot can't DM this approver), append a one-line
+ * notice to the card body. Surfaces the mismatch at the moment the
+ * approver is making a decision, with a pointer to where they can
+ * change the default if they want cards on the originating bot.
+ */
+export function appendFallbackNotice(question: string, viaFallbackBot: boolean, originBotId: string | null): string {
+  if (!viaFallbackBot) return question;
+  const hint = originBotId ? ` (inbound bot ${originBotId})` : '';
+  return `${question}\n\n_Routed via your default approval bot${hint}. Change in /claw/settings/approvals._`;
 }

--- a/src/modules/permissions/channel-approval.ts
+++ b/src/modules/permissions/channel-approval.ts
@@ -41,8 +41,9 @@ import { getAllAgentGroups } from '../../db/agent-groups.js';
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { log } from '../../log.js';
+import { decodePlatformIdAs } from '../../platform-id.js';
 import type { InboundEvent } from '../../channels/adapter.js';
-import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
+import { appendFallbackNotice, pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingChannelApproval, hasInFlightChannelApproval } from './db/pending-channel-approvals.js';
 
 const APPROVAL_OPTIONS: RawOption[] = [
@@ -92,7 +93,8 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
 
   const originMg = getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
-  const delivery = await pickApprovalDelivery(approvers, originChannelType);
+  const originBotId = originMg ? decodePlatformIdAs(originMg.platform_id, 'v2').botId : null;
+  const delivery = await pickApprovalDelivery(approvers, originChannelType, originBotId);
   if (!delivery) {
     log.warn('Channel registration skipped — no DM channel for any approver', {
       messagingGroupId,
@@ -165,7 +167,7 @@ export async function requestChannelApproval(input: RequestChannelApprovalInput)
         // up the pending row directly without another index.
         questionId: messagingGroupId,
         title,
-        question,
+        question: appendFallbackNotice(question, delivery.viaFallbackBot, originBotId),
         options,
       }),
     );

--- a/src/modules/permissions/db/user-dms.ts
+++ b/src/modules/permissions/db/user-dms.ts
@@ -1,28 +1,58 @@
 import type { UserDm } from '../../../types.js';
 import { getDb } from '../../../db/connection.js';
 
+/**
+ * Insert or replace a user DM cache row. Migration 026 added the
+ * `bot_id` column to the PK; callers may pass `''` (empty string) to
+ * write the configurable channel-default slot, or a real bot id for a
+ * specific cache.
+ */
 export function upsertUserDm(row: UserDm): void {
   getDb()
     .prepare(
-      `INSERT INTO user_dms (user_id, channel_type, messaging_group_id, resolved_at)
-       VALUES (@user_id, @channel_type, @messaging_group_id, @resolved_at)
-       ON CONFLICT(user_id, channel_type) DO UPDATE SET
+      `INSERT INTO user_dms (user_id, channel_type, bot_id, messaging_group_id, resolved_at)
+       VALUES (@user_id, @channel_type, @bot_id, @messaging_group_id, @resolved_at)
+       ON CONFLICT(user_id, channel_type, bot_id) DO UPDATE SET
          messaging_group_id = excluded.messaging_group_id,
          resolved_at = excluded.resolved_at`,
     )
     .run(row);
 }
 
-export function getUserDm(userId: string, channelType: string): UserDm | undefined {
-  return getDb().prepare('SELECT * FROM user_dms WHERE user_id = ? AND channel_type = ?').get(userId, channelType) as
-    | UserDm
-    | undefined;
+/**
+ * Look up the cache row for `(user, channel, bot)`. `botId` defaults to
+ * `''` so legacy callers that don't yet know about bots get the
+ * channel-default slot — which is what they want before
+ * `pickApprovalDelivery` was extended to thread the origin bot through.
+ */
+export function getUserDm(userId: string, channelType: string, botId: string = ''): UserDm | undefined {
+  return getDb()
+    .prepare('SELECT * FROM user_dms WHERE user_id = ? AND channel_type = ? AND bot_id = ?')
+    .get(userId, channelType, botId) as UserDm | undefined;
 }
 
+/**
+ * All cache rows for one user, across every `(channel_type, bot_id)`
+ * pair. Order is unspecified — callers that care about a specific bot
+ * should use {@link getUserDm} directly.
+ */
 export function getUserDmsForUser(userId: string): UserDm[] {
   return getDb().prepare('SELECT * FROM user_dms WHERE user_id = ?').all(userId) as UserDm[];
 }
 
-export function deleteUserDm(userId: string, channelType: string): void {
-  getDb().prepare('DELETE FROM user_dms WHERE user_id = ? AND channel_type = ?').run(userId, channelType);
+export function deleteUserDm(userId: string, channelType: string, botId: string = ''): void {
+  getDb()
+    .prepare('DELETE FROM user_dms WHERE user_id = ? AND channel_type = ? AND bot_id = ?')
+    .run(userId, channelType, botId);
+}
+
+/**
+ * List the channel-default rows (`bot_id = ''`) for one user. The
+ * settings UI uses this to render "default approval bot per channel"
+ * — one row per channel where the user has any DM cached.
+ */
+export function getDefaultUserDmsForUser(userId: string): UserDm[] {
+  return getDb()
+    .prepare("SELECT * FROM user_dms WHERE user_id = ? AND bot_id = '' ORDER BY channel_type")
+    .all(userId) as UserDm[];
 }

--- a/src/modules/permissions/permissions.test.ts
+++ b/src/modules/permissions/permissions.test.ts
@@ -7,6 +7,8 @@ import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 
 import type { ChannelAdapter, OutboundMessage } from '../../channels/adapter.js';
 import {
+  _resetActiveAdaptersForTest,
+  _setActiveAdapterForTest,
   initChannelAdapters,
   registerChannelAdapter,
   teardownChannelAdapters,
@@ -30,8 +32,45 @@ beforeEach(() => {
 
 afterEach(async () => {
   await teardownChannelAdapters();
+  _resetActiveAdaptersForTest();
   closeDb();
 });
+
+/**
+ * Inject a bot-pinned mock adapter directly into the active registry.
+ * Bypasses `registerChannelAdapter` / `initChannelAdapters` so a single
+ * test can mount more than one adapter on the same channel type — the
+ * factory-based mount overwrites within a channel.
+ */
+function injectBotAdapter(
+  channelType: string,
+  botId: string,
+  openDM?: (handle: string) => Promise<string>,
+): { openDMCalls: string[] } {
+  const openDMCalls: string[] = [];
+  const adapter: ChannelAdapter = {
+    name: `${channelType}:${botId}`,
+    channelType,
+    botId,
+    supportsThreads: false,
+    async setup() {},
+    async teardown() {},
+    isConnected() {
+      return true;
+    },
+    async deliver() {
+      return undefined;
+    },
+  };
+  if (openDM) {
+    adapter.openDM = async (handle: string) => {
+      openDMCalls.push(handle);
+      return openDM(handle);
+    };
+  }
+  _setActiveAdapterForTest(adapter);
+  return { openDMCalls };
+}
 
 async function mountMockAdapter(
   channelType: string,
@@ -238,5 +277,82 @@ describe('ensureUserDm', () => {
     const mg = await ensureUserDm('telegram:555');
     expect(mg?.id).toBe('mg-preexisting');
     expect(getUserDm('telegram:555', 'telegram')?.messaging_group_id).toBe('mg-preexisting');
+  });
+
+  describe('bot-aware resolution (migration 026)', () => {
+    it('opts.botId pins cold-resolve to that exact bot, caches under that bot id', async () => {
+      const primary = injectBotAdapter('telegram', 'primary-bot', async (h) => `tg-primary:${h}`);
+      const secondary = injectBotAdapter('telegram', 'secondary-bot', async (h) => `tg-secondary:${h}`);
+      seedUser('telegram:1190596288', 'telegram');
+
+      const mg = await ensureUserDm('telegram:1190596288', { botId: 'secondary-bot' });
+      expect(mg).toBeDefined();
+      expect(mg!.platform_id).toBe('tg-secondary:1190596288');
+
+      // Only the secondary bot's adapter saw the openDM call.
+      expect(primary.openDMCalls).toEqual([]);
+      expect(secondary.openDMCalls).toEqual(['1190596288']);
+
+      // Cache row is keyed under the requested bot id.
+      const cached = getUserDm('telegram:1190596288', 'telegram', 'secondary-bot');
+      expect(cached?.messaging_group_id).toBe(mg!.id);
+
+      // Channel-default slot is untouched.
+      expect(getUserDm('telegram:1190596288', 'telegram', '')).toBeUndefined();
+    });
+
+    it('cache hits scope to the bot id — same user/channel, different bot resolves separately', async () => {
+      const primary = injectBotAdapter('telegram', 'primary-bot', async (h) => `tg-primary:${h}`);
+      const secondary = injectBotAdapter('telegram', 'secondary-bot', async (h) => `tg-secondary:${h}`);
+      seedUser('telegram:42', 'telegram');
+
+      const mg1 = await ensureUserDm('telegram:42', { botId: 'primary-bot' });
+      const mg2 = await ensureUserDm('telegram:42', { botId: 'secondary-bot' });
+      expect(mg1!.platform_id).toBe('tg-primary:42');
+      expect(mg2!.platform_id).toBe('tg-secondary:42');
+      expect(mg1!.id).not.toBe(mg2!.id);
+      expect(primary.openDMCalls).toEqual(['42']);
+      expect(secondary.openDMCalls).toEqual(['42']);
+
+      // Re-resolving each is a pure cache read — no second openDM.
+      await ensureUserDm('telegram:42', { botId: 'primary-bot' });
+      await ensureUserDm('telegram:42', { botId: 'secondary-bot' });
+      expect(primary.openDMCalls).toEqual(['42']);
+      expect(secondary.openDMCalls).toEqual(['42']);
+    });
+
+    it('returns null when the requested bot has no adapter — does not silently fall back', async () => {
+      injectBotAdapter('telegram', 'primary-bot', async (h) => `tg-primary:${h}`);
+      seedUser('telegram:9', 'telegram');
+
+      // secondary-bot's adapter never spawned (e.g. its token is in
+      // secrets but `/wire-channel` hasn't completed). Asking for its
+      // DM specifically must NOT fall through to the primary bot.
+      const mg = await ensureUserDm('telegram:9', { botId: 'secondary-bot' });
+      expect(mg).toBeNull();
+      expect(getUserDm('telegram:9', 'telegram', 'secondary-bot')).toBeUndefined();
+      expect(getUserDm('telegram:9', 'telegram', '')).toBeUndefined();
+    });
+
+    it('returns null when the bot-pinned adapter.openDM throws (Telegram "bots can\'t initiate")', async () => {
+      injectBotAdapter('telegram', 'fresh-bot', async () => {
+        throw new Error("bots can't initiate DMs");
+      });
+      seedUser('telegram:5', 'telegram');
+
+      const mg = await ensureUserDm('telegram:5', { botId: 'fresh-bot' });
+      expect(mg).toBeNull();
+      // No cache row written — caller can retry once the user DMs the bot.
+      expect(getUserDm('telegram:5', 'telegram', 'fresh-bot')).toBeUndefined();
+    });
+
+    it('legacy 1-arg call writes the channel-default slot (bot_id="")', async () => {
+      await mountMockAdapter('telegram', async (h) => `telegram:${h}`);
+      seedUser('telegram:7', 'telegram');
+
+      const mg = await ensureUserDm('telegram:7');
+      expect(mg).toBeDefined();
+      expect(getUserDm('telegram:7', 'telegram', '')?.messaging_group_id).toBe(mg!.id);
+    });
   });
 });

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -30,8 +30,9 @@ import { normalizeOptions, type RawOption } from '../../channels/ask-question.js
 import { getMessagingGroup } from '../../db/messaging-groups.js';
 import { getDeliveryAdapter } from '../../delivery.js';
 import { log } from '../../log.js';
+import { decodePlatformIdAs } from '../../platform-id.js';
 import type { InboundEvent } from '../../channels/adapter.js';
-import { pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
+import { appendFallbackNotice, pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingSenderApproval, hasInFlightSenderApproval } from './db/pending-sender-approvals.js';
 
 const APPROVAL_OPTIONS: RawOption[] = [
@@ -76,7 +77,8 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
 
   const originMg = getMessagingGroup(messagingGroupId);
   const originChannelType = originMg?.channel_type ?? '';
-  const target = await pickApprovalDelivery(approvers, originChannelType);
+  const originBotId = originMg ? decodePlatformIdAs(originMg.platform_id, 'v2').botId : null;
+  const target = await pickApprovalDelivery(approvers, originChannelType, originBotId);
   if (!target) {
     log.warn('Unknown-sender approval skipped — no DM channel for any approver', {
       messagingGroupId,
@@ -128,7 +130,7 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
         type: 'ask_question',
         questionId: approvalId,
         title,
-        question,
+        question: appendFallbackNotice(question, target.viaFallbackBot, originBotId),
         options,
       }),
     );

--- a/src/modules/permissions/user-dm.ts
+++ b/src/modules/permissions/user-dm.ts
@@ -1,10 +1,11 @@
 /**
  * User DM resolution.
  *
- * Exposes one primitive: `ensureUserDm(userId)` returns (or lazily creates)
- * the `messaging_groups` row that the host should deliver to when it wants
- * to DM a given user. Everything that needs to cold-DM a user — approvals,
- * pairing handshakes, host notifications — goes through this function.
+ * Exposes one primitive: `ensureUserDm(userId, opts?)` returns (or lazily
+ * creates) the `messaging_groups` row that the host should deliver to
+ * when it wants to DM a given user. Everything that needs to cold-DM a
+ * user — approvals, pairing handshakes, host notifications — goes
+ * through this function.
  *
  * ## Two-class resolution
  *
@@ -20,36 +21,67 @@
  *     `openDM(handle)`, which Chat SDK's `chat.openDM` handles for us via
  *     the bridge. The returned channel id becomes the `platform_id`.
  *
+ * ## Bot-aware caching (migration 026)
+ *
+ * The cache PK is `(user_id, channel_type, bot_id)`. Callers that know
+ * which bot the DM should reach pass `opts.botId` and get bot-pinned
+ * resolution: cache reads scope to that bot, cold-resolve goes through
+ * the live adapter for `(channel, botId)` (not just the first adapter
+ * for that channel), and the resulting cache row is written under that
+ * bot's id.
+ *
+ * Callers that don't pass a bot id get the legacy "first adapter for
+ * this channel" behavior, with cache rows under `bot_id = ''` — the
+ * configurable channel-default slot. The settings UI lets the operator
+ * point that slot at a specific bot's DM, and `pickApprovalDelivery`
+ * falls through to it when an exact-bot resolve fails.
+ *
  * ## Caching
  *
- * Successful resolutions are persisted in `user_dms (user_id, channel_type
- * → messaging_group_id)`. The cache survives restarts; first-time DMs on a
- * given channel pay one `openDM` round trip, everyone after is a pure DB
- * read.
+ * Successful resolutions are persisted in `user_dms`. The cache survives
+ * restarts; first-time DMs on a given `(channel, bot)` pair pay one
+ * `openDM` round trip, everyone after is a pure DB read.
  *
  * The underlying platform APIs (`POST /users/@me/channels` on Discord,
- * `conversations.open` on Slack, etc.) are idempotent and return the same
- * channel on repeated calls, so re-resolving after a cache miss is always
- * safe — worst case we round-trip redundantly.
+ * `conversations.open` on Slack, etc.) are idempotent and return the
+ * same channel on repeated calls, so re-resolving after a cache miss is
+ * always safe — worst case we round-trip redundantly.
  */
-import { getChannelAdapter } from '../../channels/channel-registry.js';
+import { getChannelAdapter, getChannelAdapterByBotId } from '../../channels/channel-registry.js';
 import { getMessagingGroup, getMessagingGroupByPlatform, createMessagingGroup } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
+import type { ChannelAdapter } from '../../channels/adapter.js';
 import type { MessagingGroup, User } from '../../types.js';
 import { getUser } from './db/users.js';
 import { getUserDm, upsertUserDm } from './db/user-dms.js';
+
+export interface EnsureUserDmOptions {
+  /**
+   * Pin the resolution to a specific bot. When set, the cache is read /
+   * written under that exact bot id and cold-resolve uses the adapter
+   * registered for `(channelType, botId)`. When omitted (or empty
+   * string), the legacy "first adapter for this channel" path runs and
+   * the cache row lands under `bot_id = ''` (the configurable
+   * channel-default slot).
+   */
+  botId?: string | null;
+}
 
 /**
  * Return a messaging_group usable to DM this user, creating it lazily if
  * needed. Returns null when:
  *   - the user id isn't namespaced (no `kind:handle` prefix)
- *   - the user's channel has no adapter registered
+ *   - the user's channel has no adapter registered (or, when `opts.botId`
+ *     is set, no adapter is registered for that exact `(channel, bot)`)
  *   - the channel needs openDM but its adapter doesn't implement it
- *   - openDM throws (platform error, user blocked bot, etc.)
+ *   - openDM throws (platform error, user blocked bot, the bot can't
+ *     initiate a DM until the user has messaged it first, etc.)
  *
- * Callers should treat null as "this user is unreachable on this channel".
+ * Callers should treat null as "this user is unreachable on this
+ * channel + bot pair." `pickApprovalDelivery` translates that into a
+ * channel-default fallback before giving up entirely.
  */
-export async function ensureUserDm(userId: string): Promise<MessagingGroup | null> {
+export async function ensureUserDm(userId: string, opts?: EnsureUserDmOptions): Promise<MessagingGroup | null> {
   const user = getUser(userId);
   if (!user) {
     log.warn('ensureUserDm: user not found', { userId });
@@ -62,20 +94,31 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
     return null;
   }
 
+  const botId = opts?.botId ?? '';
+
   // Cache hit: existing user_dms row → load and return the messaging_group.
-  const cached = getUserDm(userId, channelType);
+  const cached = getUserDm(userId, channelType, botId);
   if (cached) {
     const mg = getMessagingGroup(cached.messaging_group_id);
     if (mg) return mg;
     // Row points to a deleted messaging_group — fall through and re-resolve.
     log.warn('ensureUserDm: cached row references missing messaging_group, re-resolving', {
       userId,
+      botId,
       messagingGroupId: cached.messaging_group_id,
     });
   }
 
-  // Cache miss: resolve the DM platform_id either via openDM or directly.
-  const dmPlatformId = await resolveDmPlatformId(channelType, handle);
+  // Cache miss: pick the adapter. With a bot id we MUST use that exact
+  // bot's adapter — falling back to "any adapter for this channel" would
+  // re-introduce the bug Proposal C is fixing (cross-bot delivery).
+  const adapter = botId ? getChannelAdapterByBotId(channelType, botId) : getChannelAdapter(channelType);
+  if (!adapter) {
+    log.warn('ensureUserDm: no adapter for channel/bot', { channelType, botId });
+    return null;
+  }
+
+  const dmPlatformId = await resolveDmPlatformId(adapter, channelType, handle);
   if (!dmPlatformId) return null;
 
   // Find-or-create the underlying messaging_group. A DM we received
@@ -97,6 +140,7 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
     log.info('ensureUserDm: created DM messaging_group', {
       userId,
       channelType,
+      botId,
       messagingGroupId: mgId,
     });
   }
@@ -104,6 +148,7 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
   upsertUserDm({
     user_id: userId,
     channel_type: channelType,
+    bot_id: botId,
     messaging_group_id: mg.id,
     resolved_at: now,
   });
@@ -113,14 +158,15 @@ export async function ensureUserDm(userId: string): Promise<MessagingGroup | nul
 
 /**
  * Call the adapter's openDM if it has one; otherwise fall through to using
- * the handle directly. Returns null if the adapter is missing entirely.
+ * the handle directly. Returns null if openDM throws (platform-side
+ * refusal — Telegram bots can't DM first, Discord blocked-by-recipient,
+ * etc.).
  */
-async function resolveDmPlatformId(channelType: string, handle: string): Promise<string | null> {
-  const adapter = getChannelAdapter(channelType);
-  if (!adapter) {
-    log.warn('ensureUserDm: no adapter for channel', { channelType });
-    return null;
-  }
+async function resolveDmPlatformId(
+  adapter: ChannelAdapter,
+  channelType: string,
+  handle: string,
+): Promise<string | null> {
   if (!adapter.openDM) {
     // Direct-addressable channel — handle doubles as the DM chat id.
     return handle;
@@ -128,7 +174,12 @@ async function resolveDmPlatformId(channelType: string, handle: string): Promise
   try {
     return await adapter.openDM(handle);
   } catch (err) {
-    log.error('ensureUserDm: adapter.openDM failed', { channelType, handle, err });
+    log.error('ensureUserDm: adapter.openDM failed', {
+      channelType,
+      botId: adapter.botId ?? null,
+      handle,
+      err,
+    });
     return null;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,10 +78,19 @@ export interface AgentGroupMember {
   added_at: string;
 }
 
-/** Cached DM channel for a user on a specific channel_type. */
+/**
+ * Cached DM channel for a user on a specific `(channel_type, bot_id)` pair.
+ *
+ * `bot_id = ''` (empty string) is the configurable channel-default slot —
+ * the operator points it at whichever bot they want approvals to fall
+ * back to when a `(user, channel, originBotId)` exact-bot lookup misses
+ * AND the cold-DM resolve also fails. Migration 026 added the column;
+ * pre-multi-bot installs land every row at `bot_id = ''`.
+ */
 export interface UserDm {
   user_id: string;
   channel_type: string;
+  bot_id: string;
   messaging_group_id: string;
   resolved_at: string;
 }

--- a/src/web/routes/settings.test.ts
+++ b/src/web/routes/settings.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for `/api/settings/operator-identity` and the underlying
+ * `listOperatorIdentities` helper. Exercises the "first owner per
+ * channel" derivation against a real in-memory DB seeded with
+ * representative `users` + `user_roles` rows.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { upsertUser } from '../../modules/permissions/db/users.js';
+import { grantRole } from '../../modules/permissions/db/user-roles.js';
+import { listOperatorIdentities } from './settings.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+const now = (): string => new Date().toISOString();
+
+function seedUser(id: string, kind: string): void {
+  upsertUser({ id, kind, display_name: null, created_at: now() });
+}
+
+describe('listOperatorIdentities', () => {
+  it('returns empty record on a fresh install with no owners', () => {
+    expect(listOperatorIdentities()).toEqual({});
+  });
+
+  it('returns the owner native id for each channel', () => {
+    seedUser('telegram:1190596288', 'telegram');
+    grantRole({
+      user_id: 'telegram:1190596288',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+
+    expect(listOperatorIdentities()).toEqual({
+      telegram: '1190596288',
+    });
+  });
+
+  it('returns oldest owner per channel when multiple owners exist', () => {
+    seedUser('telegram:1111', 'telegram');
+    seedUser('telegram:2222', 'telegram');
+    grantRole({
+      user_id: 'telegram:1111',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: '2026-01-01T00:00:00.000Z',
+    });
+    grantRole({
+      user_id: 'telegram:2222',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: '2026-02-01T00:00:00.000Z',
+    });
+
+    expect(listOperatorIdentities()).toEqual({ telegram: '1111' });
+  });
+
+  it('groups one identity per channel when owner has multi-channel presence', () => {
+    seedUser('telegram:1190596288', 'telegram');
+    seedUser('discord:9876543210', 'discord');
+    grantRole({
+      user_id: 'telegram:1190596288',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: '2026-01-01T00:00:00.000Z',
+    });
+    grantRole({
+      user_id: 'discord:9876543210',
+      role: 'owner',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: '2026-01-02T00:00:00.000Z',
+    });
+
+    expect(listOperatorIdentities()).toEqual({
+      telegram: '1190596288',
+      discord: '9876543210',
+    });
+  });
+
+  it('ignores admins (only owners count as the install operator)', () => {
+    seedUser('telegram:7777', 'telegram');
+    grantRole({
+      user_id: 'telegram:7777',
+      role: 'admin',
+      agent_group_id: null,
+      granted_by: null,
+      granted_at: now(),
+    });
+
+    expect(listOperatorIdentities()).toEqual({});
+  });
+});

--- a/src/web/routes/settings.ts
+++ b/src/web/routes/settings.ts
@@ -1,0 +1,213 @@
+/**
+ * /api/settings/approval-routing — read + write the channel-default bot
+ * for approval delivery.
+ *
+ * Backs the `/claw/settings/approvals` page. The shape it exposes is
+ * one row per (approver, channel) pair: which bot's DM currently sits
+ * in the `bot_id = ''` slot of `user_dms`, and which other bots on
+ * that channel are reachable.
+ *
+ * Why a per-(approver, channel) view: the channel-default cache is
+ * keyed on `(user_id, channel_type, '')`, so each owner / admin has
+ * their own configurable default. With one owner today (Aaron's
+ * install) it collapses to "my settings"; with future co-admins it
+ * naturally extends without a schema change.
+ *
+ * Available bots are sourced from active adapters only — operators
+ * can't route through a bot whose token is in secrets but never
+ * spawned (orphan secret rule, see channel-registry.spawnSecretsBackedBots).
+ */
+import http from 'node:http';
+
+import { getActiveAdapters } from '../../channels/channel-registry.js';
+import { decodePlatformIdAs } from '../../platform-id.js';
+import { getMessagingGroup } from '../../db/messaging-groups.js';
+import { log } from '../../log.js';
+import { ensureUserDm } from '../../modules/permissions/user-dm.js';
+import { getUserDm, getUserDmsForUser, upsertUserDm } from '../../modules/permissions/db/user-dms.js';
+import { getGlobalAdmins, getOwners } from '../../modules/permissions/db/user-roles.js';
+
+interface BotChoice {
+  botId: string;
+  /** Adapter `name` field — usually `<channelType>:<botId>` for multi-bot or just `<channelType>`. */
+  label: string;
+}
+
+interface ApprovalRoutingRow {
+  /** Namespaced approver user id (`<channel>:<handle>`). */
+  userId: string;
+  /** Channel-type the row applies to (`telegram`, `discord`, …). */
+  channelType: string;
+  /**
+   * Bot id currently sitting in the channel-default slot. Decoded from
+   * the `messaging_groups.platform_id` of the row at `bot_id = ''`.
+   * Null when no channel-default is set (no `pickApprovalDelivery`
+   * fallback exists for this user yet).
+   */
+  currentBotId: string | null;
+  /** Active bots on this channel the operator can route through. */
+  availableBots: BotChoice[];
+}
+
+const json = (res: http.ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+const error = (res: http.ServerResponse, status: number, message: string): void =>
+  json(res, status, { error: message });
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return {} as T;
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+}
+
+/**
+ * Approver users today are the union of owners + global admins. Scoped
+ * admins are excluded — their channel-default is per-agent-group at
+ * the call site, not a global routing concern.
+ */
+function listApproverUserIds(): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  const add = (id: string): void => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      ordered.push(id);
+    }
+  };
+  for (const r of getOwners()) add(r.user_id);
+  for (const r of getGlobalAdmins()) add(r.user_id);
+  return ordered;
+}
+
+export function listSettings(): ApprovalRoutingRow[] {
+  // Pre-bucket active adapters by channel type so we can query once per
+  // (user, channel) row without re-scanning the registry.
+  const adaptersByChannel = new Map<string, BotChoice[]>();
+  for (const adapter of getActiveAdapters()) {
+    const list = adaptersByChannel.get(adapter.channelType) ?? [];
+    list.push({ botId: adapter.botId ?? '', label: adapter.name });
+    adaptersByChannel.set(adapter.channelType, list);
+  }
+
+  const rows: ApprovalRoutingRow[] = [];
+  for (const userId of listApproverUserIds()) {
+    // Channel set for this user = channels they have ANY DM cached on,
+    // unioned with channels that have at least one active adapter (so
+    // an approver who's never been DMed yet still appears in the UI
+    // and the operator can pre-configure routing).
+    const channelTypes = new Set<string>();
+    for (const dm of getUserDmsForUser(userId)) channelTypes.add(dm.channel_type);
+    for (const channelType of adaptersByChannel.keys()) channelTypes.add(channelType);
+
+    for (const channelType of channelTypes) {
+      const defaultDm = getUserDm(userId, channelType, '');
+      let currentBotId: string | null = null;
+      if (defaultDm) {
+        const mg = getMessagingGroup(defaultDm.messaging_group_id);
+        if (mg) {
+          // platform_id is v2-shaped after startup-bootstrap. For v1 rows
+          // the decoder returns botId=null, which surfaces as "default
+          // not pinned to a specific bot" in the UI.
+          currentBotId = decodePlatformIdAs(mg.platform_id, 'v2').botId;
+        }
+      }
+      const availableBots = adaptersByChannel.get(channelType) ?? [];
+      rows.push({ userId, channelType, currentBotId, availableBots });
+    }
+  }
+  return rows;
+}
+
+interface SetDefaultBody {
+  userId?: string;
+  channelType?: string;
+  botId?: string;
+}
+
+export async function setDefault(
+  body: SetDefaultBody,
+): Promise<{ ok: true; row: ApprovalRoutingRow } | { ok: false; status: number; message: string }> {
+  const { userId, channelType, botId } = body;
+  if (!userId || !channelType || !botId) {
+    return { ok: false, status: 400, message: 'userId, channelType, and botId are required' };
+  }
+  if (!listApproverUserIds().includes(userId)) {
+    return { ok: false, status: 404, message: `not an approver: ${userId}` };
+  }
+
+  // Cold-resolve via the requested bot. Two purposes: confirms the bot
+  // can actually DM this user (catches Telegram's "bots can't initiate"
+  // before we silently re-point routing at a dead bot) and, on success,
+  // produces the messaging_group whose id we'll write into the
+  // channel-default slot.
+  const mg = await ensureUserDm(userId, { botId });
+  if (!mg) {
+    return {
+      ok: false,
+      status: 422,
+      message:
+        `Bot ${botId} cannot DM ${userId}. The user may need to message the bot first ` +
+        `(common on Telegram), or the adapter for that bot may not be running.`,
+    };
+  }
+  upsertUserDm({
+    user_id: userId,
+    channel_type: channelType,
+    bot_id: '',
+    messaging_group_id: mg.id,
+    resolved_at: new Date().toISOString(),
+  });
+
+  // Recompute the row so the client gets a fresh view without a second
+  // round-trip — same shape the list endpoint emits.
+  const all = listSettings();
+  const updated = all.find((r) => r.userId === userId && r.channelType === channelType);
+  if (!updated) {
+    // Defensive: shouldn't happen since we just wrote the row.
+    return { ok: false, status: 500, message: 'row written but disappeared on re-list' };
+  }
+  return { ok: true, row: updated };
+}
+
+export interface SettingsRouteContext {
+  pathname: string;
+  method: string;
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+}
+
+export async function handleSettingsRoute(ctx: SettingsRouteContext): Promise<boolean> {
+  const { pathname, method, req, res } = ctx;
+
+  if (pathname === '/api/settings/approval-routing' && method === 'GET') {
+    json(res, 200, { rows: listSettings() });
+    return true;
+  }
+
+  if (pathname === '/api/settings/approval-routing' && method === 'POST') {
+    let body: SetDefaultBody;
+    try {
+      body = await readJsonBody<SetDefaultBody>(req);
+    } catch {
+      error(res, 400, 'invalid JSON body');
+      return true;
+    }
+    const result = await setDefault(body);
+    if (!result.ok) {
+      error(res, result.status, result.message);
+      return true;
+    }
+    log.info('approval-routing default updated', {
+      userId: body.userId,
+      channelType: body.channelType,
+      botId: body.botId,
+    });
+    json(res, 200, { row: result.row });
+    return true;
+  }
+
+  return false;
+}

--- a/src/web/routes/settings.ts
+++ b/src/web/routes/settings.ts
@@ -27,6 +27,35 @@ import { ensureUserDm } from '../../modules/permissions/user-dm.js';
 import { getUserDm, getUserDmsForUser, upsertUserDm } from '../../modules/permissions/db/user-dms.js';
 import { getGlobalAdmins, getOwners } from '../../modules/permissions/db/user-roles.js';
 
+/**
+ * Per-channel native id for the install's primary operator. Backs the
+ * `/channels/new` form's "bot admin user" pre-fill so an operator wiring
+ * a second telegram bot doesn't have to look up their user id again.
+ *
+ * The "operator" is the oldest global owner (from `user_roles`); their
+ * `users.id` carries the channel-prefixed identity already (`telegram:1190596288`),
+ * so the lookup is just "split on first colon, group by channel". No new
+ * schema needed — the row already represents the privileged user for
+ * approvals, which is the same user the form is asking to capture.
+ *
+ * Returns the FIRST owner identity per channel — multi-owner installs
+ * settle to whichever owner was granted first. Edge case: a fresh install
+ * with no owner yet returns an empty record, and the form falls back to
+ * the empty input.
+ */
+export function listOperatorIdentities(): Record<string, string> {
+  const owners = getOwners();
+  const byChannel: Record<string, string> = {};
+  for (const owner of owners) {
+    const sep = owner.user_id.indexOf(':');
+    if (sep < 0) continue;
+    const channelType = owner.user_id.slice(0, sep);
+    const nativeId = owner.user_id.slice(sep + 1);
+    if (!byChannel[channelType]) byChannel[channelType] = nativeId;
+  }
+  return byChannel;
+}
+
 interface BotChoice {
   botId: string;
   /** Adapter `name` field — usually `<channelType>:<botId>` for multi-bot or just `<channelType>`. */
@@ -184,6 +213,11 @@ export async function handleSettingsRoute(ctx: SettingsRouteContext): Promise<bo
 
   if (pathname === '/api/settings/approval-routing' && method === 'GET') {
     json(res, 200, { rows: listSettings() });
+    return true;
+  }
+
+  if (pathname === '/api/settings/operator-identity' && method === 'GET') {
+    json(res, 200, { byChannel: listOperatorIdentities() });
     return true;
   }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -59,6 +59,7 @@ import { handleActivityRoute } from './routes/activity.js';
 import { handleOauthProvidersRoute } from './routes/oauth-providers.js';
 import { handleSecretsRoute } from './routes/secrets.js';
 import { handleSessionsRoute } from './routes/sessions.js';
+import { handleSettingsRoute } from './routes/settings.js';
 import { handleSetupStatusRoute } from './routes/setup-status.js';
 import { handleVaultsRoute } from './routes/vaults.js';
 import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
@@ -222,6 +223,21 @@ async function handleApi(
     }
     try {
       const handled = await handleApprovalsRoute({ pathname, method, req, res, claims: auth.claims });
+      if (handled) return;
+    } catch (err) {
+      error(res, 500, err instanceof Error ? err.message : String(err));
+      return;
+    }
+  }
+
+  if (pathname === '/api/settings/approval-routing') {
+    // Write touches DM cache + cold-resolves through an adapter; gate it
+    // at admin so a write-only token can't silently re-point an owner's
+    // approval delivery at a different bot.
+    const required: ClawScope = method === 'GET' ? SCOPE_CLAW_READ : SCOPE_CLAW_ADMIN;
+    if (!(await gate(req, res, required))) return;
+    try {
+      const handled = await handleSettingsRoute({ pathname, method, req, res });
       if (handled) return;
     } catch (err) {
       error(res, 500, err instanceof Error ? err.message : String(err));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -230,10 +230,10 @@ async function handleApi(
     }
   }
 
-  if (pathname === '/api/settings/approval-routing') {
-    // Write touches DM cache + cold-resolves through an adapter; gate it
-    // at admin so a write-only token can't silently re-point an owner's
-    // approval delivery at a different bot.
+  if (pathname === '/api/settings/approval-routing' || pathname === '/api/settings/operator-identity') {
+    // approval-routing write touches DM cache + cold-resolves through an
+    // adapter; gate writes at admin. operator-identity is read-only — the
+    // /channels/new form pre-fills from it.
     const required: ClawScope = method === 'GET' ? SCOPE_CLAW_READ : SCOPE_CLAW_ADMIN;
     if (!(await gate(req, res, required))) return;
     try {

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { NewGroupWizard } from "./routes/NewGroupWizard.tsx";
 import { OAuthCallback } from "./routes/OAuthCallback.tsx";
 import { SecretsList } from "./routes/SecretsList.tsx";
 import { SessionsList } from "./routes/SessionsList.tsx";
+import { SettingsApprovals } from "./routes/SettingsApprovals.tsx";
 import { SetupWizard } from "./routes/SetupWizard.tsx";
 import { VaultDetail } from "./routes/VaultDetail.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
@@ -42,6 +43,7 @@ export function App() {
         <Link to="/secrets">Secrets</Link>
         <Link to="/apps">Apps</Link>
         <Link to="/approvals">Approvals</Link>
+        <Link to="/settings/approvals">Settings</Link>
         <Link to="/setup">Setup</Link>
         <a
           href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
@@ -62,6 +64,7 @@ export function App() {
         <Route path="/channels/new" element={<WireChannelPage />} />
         <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />
+        <Route path="/settings/approvals" element={<SettingsApprovals />} />
         <Route path="/setup" element={<SetupWizard />} />
         <Route path="/groups/new" element={<NewGroupWizard />} />
         <Route path="/groups/:folder" element={<GroupDetail />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -792,6 +792,43 @@ export async function decideApproval(id: string, decision: ApprovalDecision): Pr
   return r.approval;
 }
 
+// --- Settings: approval routing ---
+
+export interface ApprovalRoutingBot {
+  botId: string;
+  label: string;
+}
+
+export interface ApprovalRoutingRow {
+  userId: string;
+  channelType: string;
+  /**
+   * Bot id sitting in the channel-default `bot_id=''` slot. Null when
+   * no default has been resolved yet — the operator hasn't been DMed
+   * on that channel and `pickApprovalDelivery` has nothing to fall
+   * back to.
+   */
+  currentBotId: string | null;
+  availableBots: ApprovalRoutingBot[];
+}
+
+export async function listApprovalRouting(): Promise<ApprovalRoutingRow[]> {
+  const r = await request<{ rows: ApprovalRoutingRow[] }>('/settings/approval-routing');
+  return r.rows;
+}
+
+export async function setApprovalRoutingDefault(
+  userId: string,
+  channelType: string,
+  botId: string,
+): Promise<ApprovalRoutingRow> {
+  const r = await request<{ row: ApprovalRoutingRow }>('/settings/approval-routing', {
+    method: 'POST',
+    json: { userId, channelType, botId },
+  });
+  return r.row;
+}
+
 // --- Channel wirings (global view) ---
 
 export type ChannelKind = 'discord' | 'telegram' | 'cli';

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -829,6 +829,17 @@ export async function setApprovalRoutingDefault(
   return r.row;
 }
 
+/**
+ * Per-channel native id of the install's primary operator (oldest global
+ * owner). Used to pre-fill the "bot admin user" field on /channels/new so
+ * the operator doesn't re-enter their own user id every time. Empty record
+ * on a fresh install with no owner yet.
+ */
+export async function listOperatorIdentities(): Promise<Record<string, string>> {
+  const r = await request<{ byChannel: Record<string, string> }>('/settings/operator-identity');
+  return r.byChannel;
+}
+
 // --- Channel wirings (global view) ---
 
 export type ChannelKind = 'discord' | 'telegram' | 'cli';

--- a/web/ui/src/lib/channel-adapters.ts
+++ b/web/ui/src/lib/channel-adapters.ts
@@ -94,8 +94,10 @@ export const SUPPORTED_ADAPTERS: ChannelAdapterDescriptor[] = [
     operatorFields: [
       {
         key: 'operatorUserId',
-        label: 'Your Telegram user id',
-        hint: 'DM @userinfobot to get yours. Telegram routes DMs by chat id (= your user id).',
+        label: 'Telegram admin user ID',
+        hint:
+          'The user this bot serves — usually you. Telegram routes DMs by chat id (= your user id); ' +
+          'this is the user whose DMs reach your agent. New here? DM @userinfobot to get your ID.',
         helpHref: 'https://t.me/userinfobot',
         pattern: /^[0-9]+$/,
       },

--- a/web/ui/src/routes/SettingsApprovals.tsx
+++ b/web/ui/src/routes/SettingsApprovals.tsx
@@ -1,0 +1,228 @@
+/**
+ * /settings/approvals — default approval-routing bot per (approver, channel).
+ *
+ * Backs the `bot_id = ''` channel-default slot in `user_dms`. When an
+ * approval card needs to land for a given approver and the inbound
+ * came in on a bot we don't have a cached DM for, the picker falls
+ * through to this configured default. Without a default the picker
+ * cold-resolves through whichever adapter happens to be registered
+ * first — fine on single-bot installs, surprising on multi-bot.
+ *
+ * One row per (approver, channel) pair where either the approver has a
+ * cached DM or there's at least one active adapter for the channel.
+ * Operator changes the default by picking from the channel's active
+ * bots; the server cold-resolves through the chosen bot to confirm it
+ * can DM the user before re-pointing the slot.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  listApprovalRouting,
+  setApprovalRoutingDefault,
+  type ApprovalRoutingRow,
+} from '../lib/api.ts';
+
+interface SaveError {
+  rowKey: string;
+  message: string;
+}
+
+function rowKey(r: ApprovalRoutingRow): string {
+  return `${r.userId}|${r.channelType}`;
+}
+
+export function SettingsApprovals() {
+  const [state, setState] = useState<
+    | { kind: 'loading' }
+    | { kind: 'ok'; rows: ApprovalRoutingRow[] }
+    | { kind: 'error'; message: string }
+  >({ kind: 'loading' });
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<SaveError | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    listApprovalRouting()
+      .then((rows) => !cancelled && setState({ kind: 'ok', rows }))
+      .catch((err) => {
+        if (!cancelled) {
+          setState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const onPickBot = async (row: ApprovalRoutingRow, botId: string) => {
+    if (botId === (row.currentBotId ?? '')) return;
+    const key = rowKey(row);
+    setBusyKey(key);
+    setSaveError(null);
+    try {
+      const updated = await setApprovalRoutingDefault(row.userId, row.channelType, botId);
+      setState((s) => {
+        if (s.kind !== 'ok') return s;
+        return {
+          kind: 'ok',
+          rows: s.rows.map((r) => (rowKey(r) === key ? updated : r)),
+        };
+      });
+    } catch (err) {
+      setSaveError({ rowKey: key, message: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  if (state.kind === 'loading') {
+    return (
+      <div>
+        <h2>Settings · Approval routing</h2>
+        <ul className="skeleton-list" aria-busy="true">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div>
+        <h2>Settings · Approval routing</h2>
+        <div className="error-banner">
+          Couldn't load settings: <code>{state.message}</code>
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
+          <button onClick={reload}>Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Settings · Approval routing</h2>
+        <button className="secondary" onClick={reload}>Refresh</button>
+      </div>
+
+      <p className="muted">
+        Pick the bot that should deliver approval cards when the inbound bot can't reach you. Each
+        approver has their own per-channel default. Adding a new bot? Wire it from{' '}
+        <a href="channels/new">Channels → New</a> first — only running adapters appear here.
+      </p>
+
+      {state.rows.length === 0 && (
+        <div className="empty empty-rich" style={{ marginTop: '1rem' }}>
+          <p className="empty-headline">Nothing to configure yet.</p>
+          <p className="muted">
+            Add an owner or admin (and wire at least one channel) and they'll show up here.
+          </p>
+        </div>
+      )}
+
+      {state.rows.map((row) => (
+        <SettingsRow
+          key={rowKey(row)}
+          row={row}
+          busy={busyKey === rowKey(row)}
+          error={saveError && saveError.rowKey === rowKey(row) ? saveError.message : null}
+          onPick={(botId) => onPickBot(row, botId)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SettingsRow({
+  row,
+  busy,
+  error,
+  onPick,
+}: {
+  row: ApprovalRoutingRow;
+  busy: boolean;
+  error: string | null;
+  onPick: (botId: string) => void;
+}) {
+  const value = row.currentBotId ?? '';
+  // Multi-bot install OR a default already pinned to a specific bot.
+  // If there's only one available bot AND the default is either unset
+  // or already that bot, we render an info row — there's no choice
+  // to be made and a dropdown of one option is just visual noise.
+  const trivial = useMemo(() => {
+    if (row.availableBots.length <= 1) {
+      const only = row.availableBots[0]?.botId ?? '';
+      if (!value || value === only) return true;
+    }
+    return false;
+  }, [row.availableBots, value]);
+
+  return (
+    <div
+      style={{
+        background: 'white',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        padding: '1rem 1.25rem',
+        marginBottom: '0.75rem',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <strong>{row.channelType}</strong>
+        <span className="tag muted">{row.userId}</span>
+      </div>
+
+      <div style={{ marginTop: '0.5rem' }}>
+        {trivial ? (
+          <p className="muted" style={{ margin: 0 }}>
+            {row.availableBots.length === 0 ? (
+              <>No active bot for this channel — wire one to enable routing.</>
+            ) : (
+              <>
+                Routing through <code>{row.availableBots[0]!.label}</code> (the only active bot).
+              </>
+            )}
+          </p>
+        ) : (
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <span className="muted">Default bot:</span>
+            <select
+              value={value}
+              disabled={busy}
+              onChange={(e) => onPick(e.target.value)}
+              style={{ minWidth: '14rem' }}
+            >
+              {value === '' && <option value="">(unset — first adapter wins)</option>}
+              {row.availableBots.map((b) => (
+                <option key={b.botId} value={b.botId}>
+                  {b.label}
+                </option>
+              ))}
+              {/* Surface a stale current selection (e.g. its adapter was
+                  taken offline) so the operator sees what's there before
+                  switching it. */}
+              {value !== '' && !row.availableBots.find((b) => b.botId === value) && (
+                <option value={value}>{value} (offline)</option>
+              )}
+            </select>
+            {busy && <span className="dim">saving…</span>}
+          </label>
+        )}
+      </div>
+
+      {error && (
+        <div className="error-banner" style={{ marginTop: '0.5rem' }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/ui/src/routes/WireChannelPage.tsx
+++ b/web/ui/src/routes/WireChannelPage.tsx
@@ -20,7 +20,7 @@
  * If the user navigates away mid-flow, they restart cleanly. The setup
  * wizard remains the resumable surface; this page is the "fast path".
  */
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { AgentGroupPicker, type PickedGroup } from '../components/AgentGroupPicker.tsx';
@@ -30,7 +30,12 @@ import {
   type ChannelAdapter,
   type ResolvedIdentity,
 } from '../lib/channel-adapters.ts';
-import { registerChannelBot, wireChannelToGroup, type WireChannelResult } from '../lib/api.ts';
+import {
+  listOperatorIdentities,
+  registerChannelBot,
+  wireChannelToGroup,
+  type WireChannelResult,
+} from '../lib/api.ts';
 
 export function WireChannelPage() {
   const [adapterKey, setAdapterKey] = useState<ChannelAdapter | null>(null);
@@ -45,6 +50,16 @@ export function WireChannelPage() {
   const [identity, setIdentity] = useState<ResolvedIdentity | null>(null);
 
   const [operatorUserId, setOperatorUserId] = useState('');
+  // Per-channel default for the "bot admin user" field, derived from the
+  // install's owner row in user_roles. Pre-fills the input when the
+  // operator picks an adapter that captures one (telegram). Loaded once
+  // on mount; null until resolved.
+  const [operatorDefaults, setOperatorDefaults] = useState<Record<string, string> | null>(null);
+  const [operatorPrefilled, setOperatorPrefilled] = useState(false);
+
+  useEffect(() => {
+    listOperatorIdentities().then(setOperatorDefaults).catch(() => setOperatorDefaults({}));
+  }, []);
 
   const [picked, setPicked] = useState<PickedGroup | null>(null);
 
@@ -58,7 +73,12 @@ export function WireChannelPage() {
     setToken('');
     setIdentity(null);
     setValidateError(null);
-    setOperatorUserId('');
+    // Pre-fill operatorUserId from the install's owner identity for this
+    // channel, if any. Operator can still edit; the prefilled flag drives
+    // the "(auto-filled)" hint so they know it came from prior setup.
+    const prefill = operatorDefaults?.[key] ?? '';
+    setOperatorUserId(prefill);
+    setOperatorPrefilled(prefill.length > 0);
   };
 
   const onValidate = async () => {
@@ -262,10 +282,19 @@ export function WireChannelPage() {
                   type="text"
                   inputMode="numeric"
                   value={operatorUserId}
-                  onChange={(e) => setOperatorUserId(e.target.value)}
+                  onChange={(e) => {
+                    setOperatorUserId(e.target.value);
+                    setOperatorPrefilled(false);
+                  }}
                   placeholder="123456789"
                 />
                 <p className="dim" style={{ marginTop: '0.25rem', fontSize: '0.8rem' }}>
+                  {operatorPrefilled && (
+                    <>
+                      <em>Auto-filled from your prior setup. Edit only if wiring on behalf of someone else.</em>
+                      <br />
+                    </>
+                  )}
                   {f.hint}
                   {f.helpHref && (
                     <>


### PR DESCRIPTION
## Summary

- **Migration 026**: extend `user_dms` PK from `(user_id, channel_type)` → `(user_id, channel_type, bot_id)`. Existing rows land at `bot_id=''`, the configurable channel-default slot.
- **Bot-aware `pickApprovalDelivery`**: 3-step fallback chain — exact `(channel, originBotId)` match → same-channel default DM (`bot_id=''`) → cross-channel any. Returns `viaFallbackBot` so callers know whether the card got rerouted.
- **Bot-aware `ensureUserDm`**: optional `{ botId }` arg pins cold-resolve to that exact bot (caches under `(user, channel, botId)`); legacy 1-arg call writes the channel-default slot. Catches Telegram "bots can't initiate DMs" up front instead of silently falling back.
- **`appendFallbackNotice`**: appends a one-line hint to card body when steps 2/3 fire, naming the inbound bot and pointing at `/claw/settings/approvals`. Wired into `requestApproval`, `requestSenderApproval`, `requestChannelApproval`.
- **Approval routing settings** at `/claw/settings/approvals`: per `(approver, channel)`, operator picks which bot's DM owns the channel-default slot. POST cold-resolves via `ensureUserDm` before writing. Returns 422 with actionable instruction text when the bot can't DM.
- **Bot admin user pre-fill** on `/channels/new`: derive per-channel native id from the install's owner row (`user_roles WHERE role='owner'`) and pre-fill the form. New `GET /api/settings/operator-identity`. No new schema — owner's `users.id` already carries the channel-prefixed identity. Field copy refreshed: "Telegram admin user ID" with hint clarifying it's the user the bot serves.
- Bumps `0.0.14-rc.27` → `0.0.14-rc.29`.

## Why

PR A (v2 platform_ids with botId) and PR B (multi-bot wiring UX) made the host multi-bot aware. The approval-routing layer still picked "first DM we ever cached for this user," which silently sends cards through whichever bot DMed the approver first. PR1 makes the routing decision unambiguous and operator-configurable, with a visible breadcrumb on cards that got rerouted, plus saves the operator from retyping their own user id on every wire.

Design context: `docs/2026-04-30-channel-policy-and-approval-routing.md` from PR #71. Aaron's Q1 answer (rows under `bot_id=''` are configurable + settings page), Q4 (auto-resolve cold-DM with fallback instruction), and the operator-identity pre-fill are all in scope here as one cohesive "approval routing identity model" change.

## Tests — 18 new

- **`src/modules/approvals/picks.test.ts`** — 5 bot-aware fallback-chain tests: exact match preferred over default; falls back to default when origin bot's openDM throws; cold-resolves via default adapter when origin bot is offline; cross-channel last-resort path; `viaFallbackBot=false` legacy single-bot path.
- **`src/db/migrations/026-user-dms-bot-id.test.ts`** — 3 migration tests: PK shape after migration; pre-existing rows land at `bot_id=''`; mixed bot_id rows coexist correctly.
- **`src/modules/permissions/permissions.test.ts`** — 5 `ensureUserDm` bot-aware tests: `opts.botId` pins cold-resolve to exact bot; cache hits scope to bot id; returns null when requested bot has no adapter (no silent fallback); returns null when bot-pinned `openDM` throws (Telegram "bots can't initiate"); legacy 1-arg call writes channel-default slot.
- **`src/web/routes/settings.test.ts`** — 5 operator-identity tests: fresh install returns empty; single owner returns identity; oldest-wins on multi-owner; multi-channel grouping; admin role correctly ignored (only owners count).

**All 430 vitest tests pass** (412 → 430), host typecheck clean, web/ui typecheck + build clean, prettier clean. Paraclaw repo has no CI checks — local-only gating.

## Local exercise

Smoke against a `sqlite3 .backup` of the live install:

- Migration 026 applied cleanly: schema_version 23 → 24, no orphan errors on real-shape data.
- `user_dms` PK now `(user_id, channel_type, bot_id)`; the pre-existing telegram row landed at `bot_id=''` as designed.
- `listSettings()` emitted the expected per-(approver, channel) row with `currentBotId` decoded from the v2 platform_id.
- `setDefault({botId: 'fake-bot-that-cannot-dm'})` returned 422 with the actionable "user may need to message the bot first" message — Q4 fallback path verified.
- `listOperatorIdentities()` resolved Aaron's owner row to `{ telegram: '1190596288' }` — pre-fill payload verified against live data.

## Known gaps (follow-up, not in PR1)

- Clearing the channel-default slot (passing `botId=''` to `setDefault`) is currently rejected by the same required-field check. Filed as #77 — not blocking PR1.

## Test plan

- [ ] Reviewer cleared
- [ ] Verify migration 026 applies on the actual install (`launchctl kickstart` after merge; check `schema_version` table)
- [ ] Visit `/claw/settings/approvals` and confirm telegram row appears with current bot id
- [ ] Switch bot id (when a second bot exists) and confirm next approval card delivers via the new bot
- [ ] Confirm fallback notice appears on cards rerouted via channel-default
- [ ] Visit `/claw/channels/new`, pick Telegram → confirm "Telegram admin user ID" pre-fills with `1190596288` and shows the auto-filled hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
