### PR TITLE
feat: per-MG detail page + 3-radio policy editor (paraclaw#67 PR2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.29",
+  "version": "0.0.14-rc.30",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/web/routes/channels-mg-detail.test.ts
+++ b/src/web/routes/channels-mg-detail.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for `getMessagingGroupDetail` and the policy-edit branch of
+ * `handleChannelsRoute`. Exercises against a real in-memory DB seeded
+ * with `agent_groups`, `messaging_groups`, and `messaging_group_agents`
+ * rows so the join in `getMessagingGroupDetail` is covered too.
+ *
+ * The route handler is tested directly (not via the HTTP server) — auth
+ * gating lives in `web/server.ts` and is covered by `auth.test.ts`; this
+ * file is about the handler's input validation, the 404/200/405 status
+ * shape, and the DB write side effect on PATCH.
+ */
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, getDb, initTestDb, runMigrations } from '../../db/index.js';
+import { createMessagingGroup, createMessagingGroupAgent, getMessagingGroup } from '../../db/messaging-groups.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import type { MessagingGroup, MessagingGroupAgent, AgentGroup } from '../../types.js';
+import { getMessagingGroupDetail, handleChannelsRoute } from './channels.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+const now = (): string => new Date().toISOString();
+
+function seedAgentGroup(over: Partial<AgentGroup> = {}): AgentGroup {
+  const ag: AgentGroup = {
+    id: over.id ?? 'ag_test',
+    name: over.name ?? 'Test agents',
+    folder: over.folder ?? 'test-agents',
+    agent_provider: over.agent_provider ?? null,
+    secret_mode: over.secret_mode ?? 'all',
+    created_at: over.created_at ?? now(),
+  };
+  createAgentGroup(ag);
+  return ag;
+}
+
+function seedMg(over: Partial<MessagingGroup> = {}): MessagingGroup {
+  const mg: MessagingGroup = {
+    id: over.id ?? 'mg_test',
+    channel_type: over.channel_type ?? 'telegram',
+    platform_id: over.platform_id ?? 'telegram:111111:222222',
+    name: over.name ?? null,
+    is_group: over.is_group ?? 0,
+    unknown_sender_policy: over.unknown_sender_policy ?? 'request_approval',
+    created_at: over.created_at ?? now(),
+  };
+  createMessagingGroup(mg);
+  return mg;
+}
+
+function seedMga(mgaOver: Partial<MessagingGroupAgent>): MessagingGroupAgent {
+  const mga: MessagingGroupAgent = {
+    id: mgaOver.id ?? 'mga_test',
+    messaging_group_id: mgaOver.messaging_group_id ?? 'mg_test',
+    agent_group_id: mgaOver.agent_group_id ?? 'ag_test',
+    engage_mode: mgaOver.engage_mode ?? 'mention',
+    engage_pattern: mgaOver.engage_pattern ?? null,
+    sender_scope: mgaOver.sender_scope ?? 'all',
+    ignored_message_policy: mgaOver.ignored_message_policy ?? 'drop',
+    session_mode: mgaOver.session_mode ?? 'shared',
+    priority: mgaOver.priority ?? 0,
+    created_at: mgaOver.created_at ?? now(),
+  };
+  createMessagingGroupAgent(mga);
+  return mga;
+}
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  json(): unknown;
+}
+
+function makeReq(body?: unknown): http.IncomingMessage {
+  const stream = body === undefined ? Readable.from([]) : Readable.from([Buffer.from(JSON.stringify(body))]);
+  return stream as unknown as http.IncomingMessage;
+}
+
+function makeRes(): MockRes & http.ServerResponse {
+  const captured: { status: number; headers: Record<string, string>; chunks: string[] } = {
+    status: 0,
+    headers: {},
+    chunks: [],
+  };
+  const res = {
+    writeHead(status: number, headers?: Record<string, string>) {
+      captured.status = status;
+      if (headers) Object.assign(captured.headers, headers);
+      return this;
+    },
+    end(chunk?: string) {
+      if (chunk) captured.chunks.push(chunk);
+    },
+    get statusCode() {
+      return captured.status;
+    },
+    get headers() {
+      return captured.headers;
+    },
+    get body() {
+      return captured.chunks.join('');
+    },
+    json() {
+      return JSON.parse(captured.chunks.join(''));
+    },
+  } as unknown as MockRes & http.ServerResponse;
+  return res;
+}
+
+describe('getMessagingGroupDetail', () => {
+  it('returns null when the messaging group does not exist', () => {
+    expect(getMessagingGroupDetail('mg_missing')).toBeNull();
+  });
+
+  it('returns metadata + empty wired-agents when no MGAs are wired', () => {
+    seedMg({ id: 'mg_empty', name: 'Aaron DM' });
+    const view = getMessagingGroupDetail('mg_empty');
+    expect(view).not.toBeNull();
+    expect(view).toMatchObject({
+      id: 'mg_empty',
+      channelType: 'telegram',
+      platformId: 'telegram:111111:222222',
+      displayName: 'Aaron DM',
+      unknownSenderPolicy: 'request_approval',
+      isGroup: false,
+      deniedAt: null,
+      wiredAgents: [],
+    });
+    expect(view!.createdAt).toBeTruthy();
+  });
+
+  it('joins wired agents and translates DB engage shape to API shape', () => {
+    seedAgentGroup({ id: 'ag_one', folder: 'one', name: 'Agent One' });
+    seedMg({ id: 'mg_with_agents' });
+    seedMga({
+      id: 'mga_engage_all',
+      messaging_group_id: 'mg_with_agents',
+      agent_group_id: 'ag_one',
+      engage_mode: 'pattern',
+      engage_pattern: '.',
+      sender_scope: 'known',
+      ignored_message_policy: 'accumulate',
+      priority: 5,
+    });
+    const view = getMessagingGroupDetail('mg_with_agents');
+    expect(view!.wiredAgents).toHaveLength(1);
+    expect(view!.wiredAgents[0]).toMatchObject({
+      messagingGroupAgentId: 'mga_engage_all',
+      agentGroupId: 'ag_one',
+      agentGroupFolder: 'one',
+      agentGroupName: 'Agent One',
+      engageMode: 'all',
+      engagePattern: null,
+      senderScope: 'allowlist',
+      ignoredMessagePolicy: 'silent',
+      priority: 5,
+    });
+  });
+
+  it('orders wired agents by priority desc, created_at asc', () => {
+    seedAgentGroup({ id: 'ag_a', folder: 'a', name: 'A' });
+    seedAgentGroup({ id: 'ag_b', folder: 'b', name: 'B' });
+    seedAgentGroup({ id: 'ag_c', folder: 'c', name: 'C' });
+    seedMg({ id: 'mg_priority' });
+    seedMga({
+      id: 'mga_low_old',
+      messaging_group_id: 'mg_priority',
+      agent_group_id: 'ag_a',
+      priority: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    seedMga({
+      id: 'mga_high_new',
+      messaging_group_id: 'mg_priority',
+      agent_group_id: 'ag_b',
+      priority: 5,
+      created_at: '2026-02-01T00:00:00.000Z',
+    });
+    seedMga({
+      id: 'mga_low_new',
+      messaging_group_id: 'mg_priority',
+      agent_group_id: 'ag_c',
+      priority: 0,
+      created_at: '2026-02-02T00:00:00.000Z',
+    });
+    const view = getMessagingGroupDetail('mg_priority');
+    expect(view!.wiredAgents.map((w) => w.messagingGroupAgentId)).toEqual([
+      'mga_high_new',
+      'mga_low_old',
+      'mga_low_new',
+    ]);
+  });
+});
+
+describe('handleChannelsRoute — GET /api/channels/mg/:id', () => {
+  it('returns 200 with detail body on hit', async () => {
+    seedAgentGroup({ id: 'ag_one', folder: 'one', name: 'Agent One' });
+    seedMg({ id: 'mg_get' });
+    seedMga({ id: 'mga_get', messaging_group_id: 'mg_get', agent_group_id: 'ag_one' });
+
+    const res = makeRes();
+    const handled = await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_get',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { messagingGroup: { id: string; wiredAgents: unknown[] } };
+    expect(body.messagingGroup.id).toBe('mg_get');
+    expect(body.messagingGroup.wiredAgents).toHaveLength(1);
+  });
+
+  it('returns 404 on unknown id', async () => {
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_missing',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/messaging group not found/) });
+  });
+});
+
+describe('handleChannelsRoute — PATCH /api/channels/mg/:id', () => {
+  it('updates unknown_sender_policy and returns the new view', async () => {
+    seedMg({ id: 'mg_patch', unknown_sender_policy: 'request_approval' });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_patch',
+      method: 'PATCH',
+      req: makeReq({ unknownSenderPolicy: 'public' }),
+      res,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { messagingGroup: { unknownSenderPolicy: string } };
+    expect(body.messagingGroup.unknownSenderPolicy).toBe('public');
+    expect(getMessagingGroup('mg_patch')!.unknown_sender_policy).toBe('public');
+  });
+
+  it('rejects invalid policy value with 400', async () => {
+    seedMg({ id: 'mg_patch_bad' });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_patch_bad',
+      method: 'PATCH',
+      req: makeReq({ unknownSenderPolicy: 'open' }),
+      res,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/invalid unknownSenderPolicy: open/) });
+    expect(getMessagingGroup('mg_patch_bad')!.unknown_sender_policy).toBe('request_approval');
+  });
+
+  it('rejects body without unknownSenderPolicy with 400', async () => {
+    seedMg({ id: 'mg_patch_empty' });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_patch_empty',
+      method: 'PATCH',
+      req: makeReq({}),
+      res,
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/unknownSenderPolicy is required/) });
+  });
+
+  it('returns 404 when the mg does not exist', async () => {
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_missing',
+      method: 'PATCH',
+      req: makeReq({ unknownSenderPolicy: 'strict' }),
+      res,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects unsupported methods with 405', async () => {
+    seedMg({ id: 'mg_method' });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_method',
+      method: 'DELETE',
+      req: makeReq(),
+      res,
+    });
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('does not collide with /api/channels/:id (single-segment id) routing', async () => {
+    // Sanity: the handler treats /api/channels/foo as an mga lookup, not an
+    // mg lookup. Without the mg-prefix, it would 404 as a missing wire and
+    // never reach the mg branch.
+    seedMg({ id: 'mg_collision' });
+    expect(getDb().prepare('SELECT id FROM messaging_groups WHERE id = ?').get('mg_collision')).toBeTruthy();
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg_collision',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/channel wire not found/) });
+  });
+});

--- a/src/web/routes/channels.ts
+++ b/src/web/routes/channels.ts
@@ -410,16 +410,14 @@ export async function handleChannelsRoute(ctx: ChannelsRouteContext): Promise<bo
         return true;
       }
       updateMessagingGroup(id, { unknown_sender_policy: validated.input.unknownSenderPolicy });
-      const after = getMessagingGroupDetail(id);
-      if (!after) {
-        error(res, 500, `messaging group ${id} disappeared after update`);
-        return true;
-      }
       log.info('messaging group policy updated via web', {
         id,
         unknownSenderPolicy: validated.input.unknownSenderPolicy,
       });
-      json(res, 200, { messagingGroup: after });
+      // Same connection, same tx, same row — the post-update re-fetch can't
+      // return null without the row being concurrently deleted, which is not
+      // a state this surface needs to guard against.
+      json(res, 200, { messagingGroup: getMessagingGroupDetail(id)! });
       return true;
     }
     error(res, 405, `method not allowed on ${pathname}: ${method}`);

--- a/src/web/routes/channels.ts
+++ b/src/web/routes/channels.ts
@@ -29,14 +29,17 @@ import {
   deleteMessagingGroupAgent,
   getMessagingGroup,
   getMessagingGroupAgent,
+  updateMessagingGroup,
   updateMessagingGroupAgent,
 } from '../../db/messaging-groups.js';
 import { log } from '../../log.js';
 import type {
   EngageMode as DbEngageMode,
   IgnoredMessagePolicy as DbIgnoredMessagePolicy,
+  MessagingGroup,
   SenderScope as DbSenderScope,
   MessagingGroupAgent,
+  UnknownSenderPolicy,
 } from '../../types.js';
 
 type ApiEngageMode = 'mention' | 'pattern' | 'all';
@@ -256,6 +259,113 @@ function validatePatchInput(body: unknown): { ok: true; input: PatchInput } | { 
   return { ok: true, input: out };
 }
 
+// ─── /api/channels/mg/:id — per-MG detail + policy editor ──────────────
+//
+// Path is namespaced under `mg/` so it can't collide with `/api/channels/:mga-id`
+// when an mg-id and an mga-id happen to share a prefix or shape (both are
+// uuids today, but the disambiguation is a contract for future schemas).
+// Each MGA wire row already carries its parent `messagingGroupId`, so the
+// list page links the detail with the value it already has — no extra
+// resolve step.
+
+export interface WiredAgentSummary {
+  /** mga.id — primary key for the per-MGA detail page in PR3. */
+  messagingGroupAgentId: string;
+  agentGroupId: string;
+  agentGroupFolder: string;
+  agentGroupName: string;
+  /** Snapshot of MGA fields useful for the read-only summary on the detail page. */
+  engageMode: ApiEngageMode;
+  engagePattern: string | null;
+  senderScope: ApiSenderScope;
+  ignoredMessagePolicy: ApiIgnoredMessagePolicy;
+  priority: number;
+  createdAt: string;
+}
+
+export interface MessagingGroupDetailView {
+  id: string;
+  channelType: string;
+  platformId: string;
+  /** MG's `name` column — null when the operator hasn't set one. */
+  displayName: string | null;
+  isGroup: boolean;
+  unknownSenderPolicy: UnknownSenderPolicy;
+  /** ISO when the owner explicitly denied this channel; null otherwise. */
+  deniedAt: string | null;
+  createdAt: string;
+  wiredAgents: WiredAgentSummary[];
+}
+
+interface AgentJoinRow extends MessagingGroupAgent {
+  ag_folder: string;
+  ag_name: string;
+}
+
+export function getMessagingGroupDetail(id: string): MessagingGroupDetailView | null {
+  const mg = getMessagingGroup(id);
+  if (!mg) return null;
+  const rows = getDb()
+    .prepare<AgentJoinRow>(
+      `SELECT mga.*, ag.folder AS ag_folder, ag.name AS ag_name
+         FROM messaging_group_agents mga
+         JOIN agent_groups ag ON ag.id = mga.agent_group_id
+        WHERE mga.messaging_group_id = ?
+        ORDER BY mga.priority DESC, mga.created_at ASC`,
+    )
+    .all(id);
+  return mgToDetailView(
+    mg,
+    rows.map((row) => ({
+      messagingGroupAgentId: row.id,
+      agentGroupId: row.agent_group_id,
+      agentGroupFolder: row.ag_folder,
+      agentGroupName: row.ag_name,
+      engageMode: dbToApiEngage(row.engage_mode, row.engage_pattern),
+      engagePattern:
+        row.engage_mode === 'pattern' && row.engage_pattern !== ALL_MESSAGES_PATTERN_SENTINEL
+          ? row.engage_pattern
+          : null,
+      senderScope: dbToApiSenderScope(row.sender_scope),
+      ignoredMessagePolicy: dbToApiIgnoredPolicy(row.ignored_message_policy),
+      priority: row.priority,
+      createdAt: row.created_at,
+    })),
+  );
+}
+
+function mgToDetailView(mg: MessagingGroup, wiredAgents: WiredAgentSummary[]): MessagingGroupDetailView {
+  return {
+    id: mg.id,
+    channelType: mg.channel_type,
+    platformId: mg.platform_id,
+    displayName: mg.name,
+    isGroup: mg.is_group === 1,
+    unknownSenderPolicy: mg.unknown_sender_policy,
+    deniedAt: mg.denied_at ?? null,
+    createdAt: mg.created_at,
+    wiredAgents,
+  };
+}
+
+const VALID_UNKNOWN_SENDER_POLICIES: UnknownSenderPolicy[] = ['strict', 'request_approval', 'public'];
+
+interface MgPatchInput {
+  unknownSenderPolicy: UnknownSenderPolicy;
+}
+
+function validateMgPatchInput(body: unknown): { ok: true; input: MgPatchInput } | { ok: false; reason: string } {
+  if (!body || typeof body !== 'object') return { ok: false, reason: 'body must be an object' };
+  const b = body as Record<string, unknown>;
+  if (!('unknownSenderPolicy' in b)) {
+    return { ok: false, reason: 'unknownSenderPolicy is required' };
+  }
+  if (!VALID_UNKNOWN_SENDER_POLICIES.includes(b.unknownSenderPolicy as UnknownSenderPolicy)) {
+    return { ok: false, reason: `invalid unknownSenderPolicy: ${String(b.unknownSenderPolicy)}` };
+  }
+  return { ok: true, input: { unknownSenderPolicy: b.unknownSenderPolicy as UnknownSenderPolicy } };
+}
+
 export interface ChannelsRouteContext {
   pathname: string;
   method: string;
@@ -268,6 +378,51 @@ export async function handleChannelsRoute(ctx: ChannelsRouteContext): Promise<bo
 
   if (pathname === '/api/channels' && method === 'GET') {
     json(res, 200, { wires: listAllWires() });
+    return true;
+  }
+
+  // /api/channels/mg/:id — GET (detail) or PATCH (policy edit). Must dispatch
+  // ahead of /api/channels/:id so the literal `mg` segment doesn't get
+  // mis-parsed as an mga-id.
+  const mgMatch = pathname.match(/^\/api\/channels\/mg\/([^/]+)$/);
+  if (mgMatch) {
+    const id = decodeURIComponent(mgMatch[1]);
+    const detail = getMessagingGroupDetail(id);
+    if (!detail) {
+      error(res, 404, `messaging group not found: ${id}`);
+      return true;
+    }
+    if (method === 'GET') {
+      json(res, 200, { messagingGroup: detail });
+      return true;
+    }
+    if (method === 'PATCH') {
+      let body: unknown;
+      try {
+        body = await readJsonBody<unknown>(req);
+      } catch {
+        error(res, 400, 'invalid JSON body');
+        return true;
+      }
+      const validated = validateMgPatchInput(body);
+      if (!validated.ok) {
+        error(res, 400, validated.reason);
+        return true;
+      }
+      updateMessagingGroup(id, { unknown_sender_policy: validated.input.unknownSenderPolicy });
+      const after = getMessagingGroupDetail(id);
+      if (!after) {
+        error(res, 500, `messaging group ${id} disappeared after update`);
+        return true;
+      }
+      log.info('messaging group policy updated via web', {
+        id,
+        unknownSenderPolicy: validated.input.unknownSenderPolicy,
+      });
+      json(res, 200, { messagingGroup: after });
+      return true;
+    }
+    error(res, 405, `method not allowed on ${pathname}: ${method}`);
     return true;
   }
 

--- a/web/ui/pnpm-lock.yaml
+++ b/web/ui/pnpm-lock.yaml
@@ -18,6 +18,18 @@ importers:
         specifier: ^7.0.0
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -26,15 +38,30 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.2)
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17))
+      '@vitest/ui':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.2
+        version: 6.4.2(@types/node@22.19.17)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.17)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -107,6 +134,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -118,6 +149,34 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -291,6 +350,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -432,6 +494,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -444,8 +541,17 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -461,6 +567,66 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/ui@4.1.5':
+    resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
+    peerDependencies:
+      vitest: 4.1.5
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   baseline-browser-mapping@2.10.23:
     resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
     engines: {node: '>=6.0.0'}
@@ -471,8 +637,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -481,8 +659,19 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -493,8 +682,52 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -505,6 +738,13 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -514,17 +754,86 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -536,8 +845,38 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -550,6 +889,18 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -561,10 +912,21 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -591,10 +953,27 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -606,18 +985,71 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -665,10 +1097,106 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -759,6 +1287,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -781,6 +1311,26 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -879,6 +1429,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -956,6 +1508,44 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -977,7 +1567,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -987,7 +1588,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -995,9 +1596,77 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@22.19.17)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@6.4.2(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@22.19.17)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/ui@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      fflate: 0.8.2
+      flatted: 3.4.2
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17))
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   baseline-browser-mapping@2.10.23: {}
 
@@ -1009,19 +1678,77 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   caniuse-lite@1.0.30001791: {}
+
+  chai@6.2.2: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.344: {}
+
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1054,30 +1781,164 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.2: {}
+
+  flatted@3.4.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
   js-tokens@4.0.0: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   node-releases@2.0.38: {}
+
+  nwsapi@2.2.23: {}
+
+  obug@2.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -1089,10 +1950,20 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -1111,6 +1982,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   rollup@4.60.2:
     dependencies:
@@ -1143,20 +2019,72 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
   set-cookie-parser@2.7.2: {}
 
+  siginfo@2.0.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  totalist@3.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
   typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -1164,7 +2092,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@6.4.2:
+  vite@6.4.2(@types/node@22.19.17):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1173,6 +2101,64 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 22.19.17
       fsevents: 2.3.3
+
+  vitest@4.1.5(@types/node@22.19.17)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@6.4.2(@types/node@22.19.17)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@6.4.2(@types/node@22.19.17))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,24 +1,25 @@
-import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { Apps } from "./routes/Apps.tsx";
-import { ApprovalsList } from "./routes/ApprovalsList.tsx";
-import { ChannelsList } from "./routes/ChannelsList.tsx";
-import { GroupDetail } from "./routes/GroupDetail.tsx";
-import { GroupList } from "./routes/GroupList.tsx";
-import { NewGroupWizard } from "./routes/NewGroupWizard.tsx";
-import { OAuthCallback } from "./routes/OAuthCallback.tsx";
-import { SecretsList } from "./routes/SecretsList.tsx";
-import { SessionsList } from "./routes/SessionsList.tsx";
-import { SettingsApprovals } from "./routes/SettingsApprovals.tsx";
-import { SetupWizard } from "./routes/SetupWizard.tsx";
-import { VaultDetail } from "./routes/VaultDetail.tsx";
-import { VaultsList } from "./routes/VaultsList.tsx";
-import { WireChannelPage } from "./routes/WireChannelPage.tsx";
+import { Link, Route, Routes, useLocation } from 'react-router-dom';
+import { Apps } from './routes/Apps.tsx';
+import { ApprovalsList } from './routes/ApprovalsList.tsx';
+import { ChannelsList } from './routes/ChannelsList.tsx';
+import { GroupDetail } from './routes/GroupDetail.tsx';
+import { GroupList } from './routes/GroupList.tsx';
+import { MessagingGroupDetail } from './routes/MessagingGroupDetail.tsx';
+import { NewGroupWizard } from './routes/NewGroupWizard.tsx';
+import { OAuthCallback } from './routes/OAuthCallback.tsx';
+import { SecretsList } from './routes/SecretsList.tsx';
+import { SessionsList } from './routes/SessionsList.tsx';
+import { SettingsApprovals } from './routes/SettingsApprovals.tsx';
+import { SetupWizard } from './routes/SetupWizard.tsx';
+import { VaultDetail } from './routes/VaultDetail.tsx';
+import { VaultsList } from './routes/VaultsList.tsx';
+import { WireChannelPage } from './routes/WireChannelPage.tsx';
 
 export function App() {
   // The OAuth callback page is intentionally chrome-free — the user is
   // mid-handoff back from the hub and the nav frame would just be noise.
   const location = useLocation();
-  const isCallback = location.pathname === "/oauth/callback";
+  const isCallback = location.pathname === '/oauth/callback';
 
   if (isCallback) {
     return (
@@ -62,13 +63,21 @@ export function App() {
         <Route path="/vaults/:name" element={<VaultDetail />} />
         <Route path="/channels" element={<ChannelsList />} />
         <Route path="/channels/new" element={<WireChannelPage />} />
+        <Route path="/channels/mg/:id" element={<MessagingGroupDetail />} />
         <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />
         <Route path="/settings/approvals" element={<SettingsApprovals />} />
         <Route path="/setup" element={<SetupWizard />} />
         <Route path="/groups/new" element={<NewGroupWizard />} />
         <Route path="/groups/:folder" element={<GroupDetail />} />
-        <Route path="*" element={<div className="empty">404 — back to <Link to="/">groups</Link>.</div>} />
+        <Route
+          path="*"
+          element={
+            <div className="empty">
+              404 — back to <Link to="/">groups</Link>.
+            </div>
+          }
+        />
       </Routes>
     </div>
   );

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -63,9 +63,9 @@ describe('mintVaultToken — auth gate on 403', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const api = await import('./api.ts');
-    await expect(
-      api.mintVaultToken('work', { label: 'claw-x', scopes: ['vault:read'] }),
-    ).rejects.toThrow(/beginLogin called/);
+    await expect(api.mintVaultToken('work', { label: 'claw-x', scopes: ['vault:read'] })).rejects.toThrow(
+      /beginLogin called/,
+    );
 
     expect(auth.clearTokens).toHaveBeenCalled();
     expect(auth.beginLogin).toHaveBeenCalledWith(['vault:work:admin']);
@@ -114,15 +114,13 @@ describe('detachVault — auth gate on 403', () => {
   });
 
   it('omits scope hint when caller did not supply one', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse(403, { error: 'This endpoint requires the claw:admin scope' }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(403, { error: 'This endpoint requires the claw:admin scope' }));
     vi.stubGlobal('fetch', fetchMock);
 
     const api = await import('./api.ts');
-    await expect(api.detachVault('research', { revokeToken: false })).rejects.toThrow(
-      /beginLogin called/,
-    );
+    await expect(api.detachVault('research', { revokeToken: false })).rejects.toThrow(/beginLogin called/);
 
     expect(auth.beginLogin).toHaveBeenCalledWith(undefined);
   });
@@ -197,9 +195,7 @@ describe('non-scope 403 does NOT trigger re-auth', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const api = await import('./api.ts');
-    await expect(
-      api.mintVaultToken('work', { label: 'x', scopes: ['vault:read'] }),
-    ).rejects.toMatchObject({
+    await expect(api.mintVaultToken('work', { label: 'x', scopes: ['vault:read'] })).rejects.toMatchObject({
       name: 'HttpError',
       status: 403,
     });
@@ -224,6 +220,88 @@ describe('happy path — 200 returns parsed body and skips auth', () => {
 
     expect(result).toEqual(minted);
     expect(auth.beginLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateMessagingGroupPolicy — body shape and method', () => {
+  // Server-side validateMgPatchInput keys on `unknownSenderPolicy` exactly;
+  // pin the wire shape here so a future rename doesn't silently regress.
+  it('PATCHes /channels/mg/:id with unknownSenderPolicy', async () => {
+    const result = {
+      messagingGroup: {
+        id: 'mg_1',
+        channelType: 'telegram',
+        platformId: 'telegram:42:1',
+        displayName: null,
+        isGroup: false,
+        unknownSenderPolicy: 'public',
+        deniedAt: null,
+        createdAt: '2026-04-20T10:00:00Z',
+        wiredAgents: [],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, result));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    const view = await api.updateMessagingGroupPolicy('mg_1', 'public');
+
+    expect(view.unknownSenderPolicy).toBe('public');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/api\/channels\/mg\/mg_1$/);
+    expect((init as RequestInit).method).toBe('PATCH');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ unknownSenderPolicy: 'public' });
+  });
+
+  it('surfaces server 400 as HttpError(400) without re-auth', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(400, { error: 'invalid unknownSenderPolicy: open' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    // Cast through unknown so we can drive the bad-input branch even though
+    // `open` isn't a valid UnknownSenderPolicy at the type level — the
+    // server is what we're pinning here, not the static check.
+    type UnknownSenderPolicy = import('./api.ts').UnknownSenderPolicy;
+    await expect(
+      api.updateMessagingGroupPolicy('mg_1', 'open' as unknown as UnknownSenderPolicy),
+    ).rejects.toMatchObject({ name: 'HttpError', status: 400 });
+    expect(auth.beginLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMessagingGroupDetail — happy path', () => {
+  it('parses { messagingGroup } envelope and returns the view', async () => {
+    const view = {
+      id: 'mg_x',
+      channelType: 'discord',
+      platformId: 'discord:@me:99',
+      displayName: 'Aaron DM',
+      isGroup: false,
+      unknownSenderPolicy: 'request_approval',
+      deniedAt: null,
+      createdAt: '2026-04-20T10:00:00Z',
+      wiredAgents: [
+        {
+          messagingGroupAgentId: 'mga_1',
+          agentGroupId: 'ag_1',
+          agentGroupFolder: 'main',
+          agentGroupName: 'Main',
+          engageMode: 'mention',
+          engagePattern: null,
+          senderScope: 'all',
+          ignoredMessagePolicy: 'drop',
+          priority: 0,
+          createdAt: '2026-04-20T10:00:00Z',
+        },
+      ],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { messagingGroup: view }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    const result = await api.getMessagingGroupDetail('mg_x');
+    expect(result).toEqual(view);
   });
 });
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -287,10 +287,7 @@ export async function getVaultDetail(name: string): Promise<VaultDetail> {
  * 500 would label as `unauthorized` and lie to the operator about why
  * the count is missing.
  */
-export type TokenCountProbe =
-  | { kind: 'count'; value: number }
-  | { kind: 'unauthorized' }
-  | { kind: 'error' };
+export type TokenCountProbe = { kind: 'count'; value: number } | { kind: 'unauthorized' } | { kind: 'error' };
 
 /**
  * Tolerant token-count probe for the index page. Bypasses `request<T>` on
@@ -531,10 +528,7 @@ export interface ListActivityOptions {
   limit?: number;
 }
 
-export async function listGroupActivity(
-  folder: string,
-  options: ListActivityOptions = {},
-): Promise<ActivityEntry[]> {
+export async function listGroupActivity(folder: string, options: ListActivityOptions = {}): Promise<ActivityEntry[]> {
   const params = new URLSearchParams();
   if (options.since) params.set('since', options.since);
   if (options.limit !== undefined) params.set('limit', String(options.limit));
@@ -840,6 +834,67 @@ export async function listOperatorIdentities(): Promise<Record<string, string>> 
   return r.byChannel;
 }
 
+// --- Per-MG (messaging-group) detail page ---
+
+/**
+ * The three policies the router applies to messages from senders the
+ * messaging group hasn't seen / approved before. Mirrors `UnknownSenderPolicy`
+ * in `src/types.ts` exactly. `public` is the value the DB uses; `open` is
+ * NOT a valid value (we surface only the canonical names).
+ *
+ * - `request_approval` — pause the message and DM the operator with an
+ *   approve/reject card. Default for auto-created MGs.
+ * - `strict` — drop silently. Used on MGs the operator has explicitly locked
+ *   down.
+ * - `public` — admit and route normally. The MG behaves as if every sender
+ *   is known.
+ */
+export type UnknownSenderPolicy = 'strict' | 'request_approval' | 'public';
+
+export interface WiredAgentSummary {
+  /** mga.id — primary key for the per-MGA detail page (lands in PR3). */
+  messagingGroupAgentId: string;
+  agentGroupId: string;
+  agentGroupFolder: string;
+  agentGroupName: string;
+  engageMode: EngageMode;
+  engagePattern: string | null;
+  senderScope: SenderScope;
+  ignoredMessagePolicy: IgnoredMessagePolicy;
+  priority: number;
+  createdAt: string;
+}
+
+export interface MessagingGroupDetailView {
+  id: string;
+  channelType: string;
+  platformId: string;
+  /** Operator-assigned name; null when unset (most auto-created DMs are unnamed). */
+  displayName: string | null;
+  isGroup: boolean;
+  unknownSenderPolicy: UnknownSenderPolicy;
+  /** ISO when the owner explicitly denied this channel; null otherwise. */
+  deniedAt: string | null;
+  createdAt: string;
+  wiredAgents: WiredAgentSummary[];
+}
+
+export async function getMessagingGroupDetail(id: string): Promise<MessagingGroupDetailView> {
+  const r = await request<{ messagingGroup: MessagingGroupDetailView }>(`/channels/mg/${encodeURIComponent(id)}`);
+  return r.messagingGroup;
+}
+
+export async function updateMessagingGroupPolicy(
+  id: string,
+  unknownSenderPolicy: UnknownSenderPolicy,
+): Promise<MessagingGroupDetailView> {
+  const r = await request<{ messagingGroup: MessagingGroupDetailView }>(`/channels/mg/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    json: { unknownSenderPolicy },
+  });
+  return r.messagingGroup;
+}
+
 // --- Channel wirings (global view) ---
 
 export type ChannelKind = 'discord' | 'telegram' | 'cli';
@@ -998,10 +1053,7 @@ export interface RegisterChannelBotResult {
  * `botUserId` for Discord (where botId == bot's snowflake), and as the
  * basis of the operator-id for Telegram.
  */
-export async function registerChannelBot(
-  channel: ChannelKind,
-  token: string,
-): Promise<RegisterChannelBotResult> {
+export async function registerChannelBot(channel: ChannelKind, token: string): Promise<RegisterChannelBotResult> {
   return request<RegisterChannelBotResult>(`/channels/${encodeURIComponent(channel)}/register-bot`, {
     method: 'POST',
     json: { token },

--- a/web/ui/src/routes/ChannelsList.tsx
+++ b/web/ui/src/routes/ChannelsList.tsx
@@ -35,9 +35,7 @@ import {
 
 export function ChannelsList() {
   const [state, setState] = useState<
-    | { kind: 'loading' }
-    | { kind: 'ok'; wires: ChannelWireView[] }
-    | { kind: 'error'; message: string }
+    { kind: 'loading' } | { kind: 'ok'; wires: ChannelWireView[] } | { kind: 'error'; message: string }
   >({ kind: 'loading' });
   const [reloadKey, setReloadKey] = useState(0);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -208,7 +206,12 @@ function ChannelRow({
         <div>engage</div>
         <div>
           {wire.engageMode}
-          {wire.engagePattern && <> · pattern <code>{wire.engagePattern}</code></>}
+          {wire.engagePattern && (
+            <>
+              {' '}
+              · pattern <code>{wire.engagePattern}</code>
+            </>
+          )}
         </div>
         <div>senders</div>
         <div>{wire.senderScope}</div>
@@ -219,6 +222,11 @@ function ChannelRow({
         <button className="secondary" onClick={onEdit} disabled={busy}>
           Edit
         </button>
+        <Link to={`/channels/mg/${encodeURIComponent(wire.messagingGroupId)}`}>
+          <button className="secondary" disabled={busy}>
+            Group settings →
+          </button>
+        </Link>
         <button
           className="secondary"
           onClick={onDelete}

--- a/web/ui/src/routes/MessagingGroupDetail.test.tsx
+++ b/web/ui/src/routes/MessagingGroupDetail.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * MessagingGroupDetail tests cover the contracts the design doc names:
+ *   1. The 3-radio renders all policies; the row matching the DB is selected.
+ *   2. Picking a different radio triggers updateMessagingGroupPolicy and
+ *      reflects the new value back in the radio state.
+ *   3. Server 404 surfaces as the "no channel" empty state with a Back CTA
+ *      (no Retry — there's nothing to come back from).
+ *   4. Unknown errors surface as the load-error banner with a Retry button.
+ *   5. Wired-agents block renders one row per MGA and links to the agent
+ *      group's folder.
+ *
+ * The api module is mocked so we don't need a live server.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/api.ts';
+import { MessagingGroupDetail } from './MessagingGroupDetail.tsx';
+
+vi.mock('../lib/api.ts', async () => {
+  const actual = await vi.importActual<typeof api>('../lib/api.ts');
+  return {
+    ...actual,
+    getMessagingGroupDetail: vi.fn(),
+    updateMessagingGroupPolicy: vi.fn(),
+  };
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/channels/mg/:id" element={<MessagingGroupDetail />} />
+        <Route path="/channels" element={<div>channels list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const baseDetail: api.MessagingGroupDetailView = {
+  id: 'mg_1',
+  channelType: 'telegram',
+  platformId: 'telegram:111111:222222',
+  displayName: 'Aaron DM',
+  isGroup: false,
+  unknownSenderPolicy: 'request_approval',
+  deniedAt: null,
+  createdAt: '2026-04-20T10:00:00Z',
+  wiredAgents: [
+    {
+      messagingGroupAgentId: 'mga_1',
+      agentGroupId: 'ag_1',
+      agentGroupFolder: 'main',
+      agentGroupName: 'Main agent',
+      engageMode: 'mention',
+      engagePattern: null,
+      senderScope: 'all',
+      ignoredMessagePolicy: 'drop',
+      priority: 0,
+      createdAt: '2026-04-20T10:00:00Z',
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.mocked(api.getMessagingGroupDetail).mockResolvedValue(baseDetail);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MessagingGroupDetail — render', () => {
+  it('renders the 3-radio policy editor with the DB value selected', async () => {
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Unknown-sender policy')).toBeInTheDocument();
+    });
+
+    const requestRadio = screen.getByRole('radio', { name: /Request approval/ });
+    const strictRadio = screen.getByRole('radio', { name: /Strict/ });
+    const publicRadio = screen.getByRole('radio', { name: /Public/ });
+
+    expect(requestRadio).toBeChecked();
+    expect(strictRadio).not.toBeChecked();
+    expect(publicRadio).not.toBeChecked();
+  });
+
+  it('renders MG metadata block', async () => {
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Group details')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('telegram:111111:222222')).toBeInTheDocument();
+    expect(screen.getByText('direct message')).toBeInTheDocument();
+    expect(screen.getByText('Aaron DM')).toBeInTheDocument();
+  });
+
+  it('renders wired-agents section with link to agent group folder', async () => {
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Wired agents (1)')).toBeInTheDocument();
+    });
+
+    const link = screen.getByRole('link', { name: 'Main agent' });
+    expect(link).toHaveAttribute('href', '/groups/main');
+  });
+
+  it('renders empty wired-agents state when none exist', async () => {
+    vi.mocked(api.getMessagingGroupDetail).mockResolvedValue({
+      ...baseDetail,
+      wiredAgents: [],
+    });
+
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Wired agents (0)')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No agents wired to this group yet/)).toBeInTheDocument();
+  });
+
+  it('shows the denied-at banner when set', async () => {
+    vi.mocked(api.getMessagingGroupDetail).mockResolvedValue({
+      ...baseDetail,
+      deniedAt: '2026-04-25T00:00:00Z',
+    });
+
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Denied channel\./)).toBeInTheDocument();
+    });
+    expect(screen.getByText('2026-04-25T00:00:00Z')).toBeInTheDocument();
+  });
+});
+
+describe('MessagingGroupDetail — policy edit', () => {
+  it('calls updateMessagingGroupPolicy and updates the radio when the operator picks a new value', async () => {
+    vi.mocked(api.updateMessagingGroupPolicy).mockResolvedValue({
+      ...baseDetail,
+      unknownSenderPolicy: 'public',
+    });
+
+    const user = userEvent.setup();
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Request approval/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Public/ }));
+
+    await waitFor(() => {
+      expect(api.updateMessagingGroupPolicy).toHaveBeenCalledWith('mg_1', 'public');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Public/ })).toBeChecked();
+    });
+    expect(screen.getByRole('radio', { name: /Request approval/ })).not.toBeChecked();
+  });
+
+  it('does not call the API when the operator clicks the already-selected policy', async () => {
+    const user = userEvent.setup();
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Request approval/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Request approval/ }));
+
+    // Give any async work a tick to fire — none should.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(api.updateMessagingGroupPolicy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error banner when the PATCH fails', async () => {
+    vi.mocked(api.updateMessagingGroupPolicy).mockRejectedValue(
+      new api.HttpError(400, 'invalid unknownSenderPolicy: open'),
+    );
+
+    const user = userEvent.setup();
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Request approval/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Strict/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't save:/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/invalid unknownSenderPolicy: open/)).toBeInTheDocument();
+    // The radio should still reflect the DB value, not the rejected pick.
+    expect(screen.getByRole('radio', { name: /Request approval/ })).toBeChecked();
+  });
+});
+
+describe('MessagingGroupDetail — error states', () => {
+  it('renders 404 empty state with Back CTA only', async () => {
+    vi.mocked(api.getMessagingGroupDetail).mockRejectedValue(
+      new api.HttpError(404, 'messaging group not found: mg_missing'),
+    );
+
+    renderAt('/channels/mg/mg_missing');
+
+    await waitFor(() => {
+      expect(screen.getByText(/No channel with id/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Back to channels' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
+  it('renders generic load error with Retry button on non-404', async () => {
+    vi.mocked(api.getMessagingGroupDetail).mockRejectedValue(new api.HttpError(500, 'internal'));
+
+    renderAt('/channels/mg/mg_1');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load this channel/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/MessagingGroupDetail.tsx
+++ b/web/ui/src/routes/MessagingGroupDetail.tsx
@@ -1,0 +1,300 @@
+/**
+ * /channels/mg/:id — per-messaging-group detail + policy editor.
+ *
+ * What's here:
+ *   - read-only metadata (channel type, platform id, denial flag, created)
+ *   - the `unknownSenderPolicy` editor as a 3-radio toggle
+ *   - a read-only summary of wired agents (links to per-MGA detail land in PR3)
+ *
+ * The MG-id is a UUID generated server-side; the disambiguation prefix
+ * `mg/` keeps the route clean against future per-MGA routes (`mga/`)
+ * without needing a discriminator query param.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  getMessagingGroupDetail,
+  HttpError,
+  updateMessagingGroupPolicy,
+  type MessagingGroupDetailView,
+  type UnknownSenderPolicy,
+} from '../lib/api.ts';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; mg: MessagingGroupDetailView }
+  | { kind: 'error'; status: number | null; message: string };
+
+interface PolicyChoice {
+  value: UnknownSenderPolicy;
+  label: string;
+  blurb: string;
+}
+
+const POLICY_CHOICES: PolicyChoice[] = [
+  {
+    value: 'request_approval',
+    label: 'Request approval',
+    blurb: 'Pause the message and DM you an approve / reject card. Default for newly auto-created channels.',
+  },
+  {
+    value: 'strict',
+    label: 'Strict',
+    blurb: 'Drop messages from unknown senders silently. Use when the channel should only see vetted traffic.',
+  },
+  {
+    value: 'public',
+    label: 'Public',
+    blurb:
+      'Admit every sender and route normally. Use for channels you trust by ambient context (private servers, allowlisted chats).',
+  },
+];
+
+export function MessagingGroupDetail() {
+  const { id: rawId } = useParams<{ id: string }>();
+  const id = rawId ?? '';
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [reloadKey, setReloadKey] = useState(0);
+  const [savingPolicy, setSavingPolicy] = useState<UnknownSenderPolicy | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (!id) {
+      setState({ kind: 'error', status: null, message: 'no messaging group id in URL' });
+      return;
+    }
+    let cancelled = false;
+    getMessagingGroupDetail(id)
+      .then((mg) => !cancelled && setState({ kind: 'ok', mg }))
+      .catch((err) => {
+        if (cancelled) return;
+        const status = err instanceof HttpError ? err.status : null;
+        setState({
+          kind: 'error',
+          status,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, reloadKey]);
+
+  const onPick = async (next: UnknownSenderPolicy) => {
+    if (state.kind !== 'ok') return;
+    if (next === state.mg.unknownSenderPolicy) return;
+    setSavingPolicy(next);
+    setSaveError(null);
+    try {
+      const updated = await updateMessagingGroupPolicy(id, next);
+      setState({ kind: 'ok', mg: updated });
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSavingPolicy(null);
+    }
+  };
+
+  if (state.kind === 'loading') {
+    return (
+      <div>
+        <h2>Channel</h2>
+        <ul className="skeleton-list" aria-busy="true">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div>
+        <h2>Channel</h2>
+        <div className="error-banner">
+          {state.status === 404 ? (
+            <>
+              No channel with id <code>{id}</code> — it may have been removed.
+            </>
+          ) : (
+            <>
+              Couldn't load this channel: <code>{state.message}</code>
+            </>
+          )}
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
+          <Link to="/channels">
+            <button className="secondary">Back to channels</button>
+          </Link>
+          {state.status !== 404 && <button onClick={reload}>Retry</button>}
+        </div>
+      </div>
+    );
+  }
+
+  const { mg } = state;
+  return (
+    <div>
+      <div className="list-header">
+        <h2 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Link to="/channels" className="muted" style={{ textDecoration: 'none' }}>
+            Channels
+          </Link>
+          <span className="dim">/</span>
+          <span style={{ textTransform: 'capitalize' }}>{mg.channelType}</span>
+          {mg.displayName && <span className="dim">· {mg.displayName}</span>}
+        </h2>
+      </div>
+
+      {mg.deniedAt && (
+        <div
+          className="banner"
+          style={{
+            background: 'var(--warn-bg, #fff7e0)',
+            border: '1px solid var(--warn, #c08a00)',
+            borderRadius: '8px',
+            padding: '0.75rem 1rem',
+            marginBottom: '1rem',
+          }}
+        >
+          <strong>Denied channel.</strong> The owner explicitly blocked this messaging group at{' '}
+          <code>{mg.deniedAt}</code>. Wire an agent to unblock; until then the router drops messages here before the
+          policy below applies.
+        </div>
+      )}
+
+      <section
+        style={{
+          background: 'white',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '1rem 1.25rem',
+          marginBottom: '1rem',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Group details</h3>
+        <div className="kv">
+          <div>id</div>
+          <div>
+            <code>{mg.id}</code>
+          </div>
+          <div>channel</div>
+          <div style={{ textTransform: 'capitalize' }}>{mg.channelType}</div>
+          <div>platform id</div>
+          <div>
+            <code>{mg.platformId}</code>
+          </div>
+          <div>kind</div>
+          <div>{mg.isGroup ? 'group / channel' : 'direct message'}</div>
+          <div>name</div>
+          <div>{mg.displayName ?? <span className="dim">(unset)</span>}</div>
+          <div>created</div>
+          <div>
+            <code>{mg.createdAt}</code>
+          </div>
+        </div>
+      </section>
+
+      <section
+        style={{
+          background: 'white',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '1rem 1.25rem',
+          marginBottom: '1rem',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Unknown-sender policy</h3>
+        <p className="muted">
+          What should happen when a sender the messaging group hasn't seen before posts a message?
+        </p>
+        <div role="radiogroup" aria-label="Unknown-sender policy">
+          {POLICY_CHOICES.map((choice) => {
+            const selected = mg.unknownSenderPolicy === choice.value;
+            const saving = savingPolicy === choice.value;
+            return (
+              <label
+                key={choice.value}
+                style={{
+                  display: 'block',
+                  padding: '0.6rem 0.75rem',
+                  borderRadius: '6px',
+                  background: selected ? 'var(--accent-bg, #eef4ff)' : 'transparent',
+                  border: selected ? '1px solid var(--accent, #5076ff)' : '1px solid transparent',
+                  cursor: savingPolicy === null ? 'pointer' : 'progress',
+                  marginBottom: '0.4rem',
+                }}
+              >
+                <input
+                  type="radio"
+                  name="unknownSenderPolicy"
+                  value={choice.value}
+                  checked={selected}
+                  disabled={savingPolicy !== null}
+                  onChange={() => onPick(choice.value)}
+                />{' '}
+                <strong>{choice.label}</strong>
+                {saving && <span className="dim"> · saving…</span>}
+                <p className="muted" style={{ margin: '0.25rem 0 0 1.6rem' }}>
+                  {choice.blurb}
+                </p>
+              </label>
+            );
+          })}
+        </div>
+        {saveError && (
+          <div className="error-banner" style={{ marginTop: '0.5rem' }}>
+            Couldn't save: <code>{saveError}</code>
+          </div>
+        )}
+      </section>
+
+      <section
+        style={{
+          background: 'white',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '1rem 1.25rem',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Wired agents ({mg.wiredAgents.length})</h3>
+        {mg.wiredAgents.length === 0 ? (
+          <p className="muted" style={{ margin: 0 }}>
+            No agents wired to this group yet. Wire one from <Link to="/channels/new">Channels → New</Link>.
+          </p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {mg.wiredAgents.map((wa) => (
+              <li
+                key={wa.messagingGroupAgentId}
+                style={{
+                  borderTop: '1px solid var(--border)',
+                  padding: '0.6rem 0',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Link to={`/groups/${encodeURIComponent(wa.agentGroupFolder)}`}>{wa.agentGroupName}</Link>
+                <span className="tag muted">priority {wa.priority}</span>
+                <span className="dim">
+                  engage <code>{wa.engageMode}</code>
+                  {wa.engagePattern && (
+                    <>
+                      {' '}
+                      · pattern <code>{wa.engagePattern}</code>
+                    </>
+                  )}{' '}
+                  · senders <code>{wa.senderScope}</code> · ignored <code>{wa.ignoredMessagePolicy}</code>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/ui/src/routes/MessagingGroupDetail.tsx
+++ b/web/ui/src/routes/MessagingGroupDetail.tsx
@@ -160,8 +160,8 @@ export function MessagingGroupDetail() {
           }}
         >
           <strong>Denied channel.</strong> The owner explicitly blocked this messaging group at{' '}
-          <code>{mg.deniedAt}</code>. Wire an agent to unblock; until then the router drops messages here before the
-          policy below applies.
+          <code>{mg.deniedAt}</code>. The router drops messages here before any wiring or policy below applies — undeny
+          from the central admin surface to restore routing.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

PR2 of the 4-step paraclaw#67 channel-wiring rework. Adds the per-MG detail page operators reach via the new "Group settings →" button on `/channels` rows.

**4-step phase plan** (from design doc PR #75):

| Step | Status | Scope |
|---|---|---|
| PR1 — bot-aware approval routing + settings UI | ✅ merged (#76) | per-bot sender-approval picks + `/settings/approvals` UI |
| **PR2 — per-MG detail page + policy editor** | **this PR** | `/channels/mg/:id` route + GET/PATCH backing endpoint |
| PR3 — per-MGA detail page (engage rules editor) | next | per-wiring routing-rule editor |
| PR4 — 3-button approval card | follow | new approval-card variant for unknown senders |

Design doc: PR #75 (`docs/2026-04-channel-policy-and-approval-routing.md`).

## What's new

**Server** (`src/web/routes/channels.ts`):
- `GET   /api/channels/mg/:id` → `MessagingGroupDetailView` (metadata + wired-agents join)
- `PATCH /api/channels/mg/:id` with `{ unknownSenderPolicy: 'strict' | 'request_approval' | 'public' }`
- Method-not-allowed 405 for everything else
- The `/mg/:id` matcher dispatches ahead of the single-segment `/:id` so the more specific path wins; the existing `/api/channels/*` scope gate continues to enforce `claw:read` on GET and `claw:admin` on PATCH — no `server.ts` changes.

**API client** (`web/ui/src/lib/api.ts`):
- `UnknownSenderPolicy`, `WiredAgentSummary`, `MessagingGroupDetailView` types
- `getMessagingGroupDetail(id)` / `updateMessagingGroupPolicy(id, policy)` helpers

**UI** (`web/ui/src/routes/MessagingGroupDetail.tsx`):
- Header breadcrumb back to `/channels`
- Denied-at banner when set
- `Group details` metadata card (id, channel, platform id, kind, name, created)
- `Unknown-sender policy` 3-radio editor (saves on click, snaps back on PATCH failure)
- `Wired agents (N)` read-only summary linking each row to `/groups/<folder>`
- 404 → "No channel with id…" + Back-only CTA (no Retry — nothing to come back from)
- Other errors → load-error banner + Retry

**Navigation** (`web/ui/src/routes/ChannelsList.tsx`):
- New "Group settings →" button on each wire row → `/channels/mg/<id>`

## Routing rationale

Disambiguated against future `/channels/mga/:id` (per-MGA detail, PR3) by prefixing the MG route with `mg/`. Avoids needing a discriminator query param and keeps the URL self-describing.

## Gates

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — **442 passing** (was 430 → +12 new in `channels-mg-detail.test.ts`)
- `web/ui` typecheck — clean
- `web/ui` tests — **31 passing** (3 files: `api.test.ts` +3, `MessagingGroupDetail.test.tsx` +10)
- `web/ui` build — clean (385.38 kB / 110.83 kB gzipped)
- Prettier — clean

**Total new tests in this PR: 25** (12 server + 3 api-client + 10 component).

## Versioning

Bump `0.0.14-rc.29` → `0.0.14-rc.30` per governance.

## Commit breakdown

1. `feat(server): GET/PATCH /api/channels/mg/:id for per-MG detail` — server route + 12-test suite + RC bump
2. `feat(ui-api): getMessagingGroupDetail + updateMessagingGroupPolicy` — typed client + 3-test pin (incl. lockfile sync for testing-library deps PR1 added but didn't lock)
3. `feat(ui): /channels/mg/:id detail page + 3-radio policy editor` — route component + 10-test suite + nav button on `/channels` rows

## Test plan

- [ ] Open `/channels`, click "Group settings →" on a wire — lands on `/channels/mg/<id>`
- [ ] All three radios render with the DB value selected
- [ ] Picking a different radio fires PATCH and reflects new state; clicking the already-selected radio is a no-op
- [ ] Bad payload (e.g. unknown policy enum) → inline error banner, radio snaps back
- [ ] Direct-load with bad id → 404 empty state with Back-only
- [ ] Direct-load with server failure → load error + Retry
- [ ] Wired-agents row links to `/groups/<folder>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)