### PR TITLE
feat: per-MGA detail page + routing-rules editor (paraclaw#67 PR3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.30",
+  "version": "0.0.14-rc.31",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/web/routes/channels-mg-detail.test.ts
+++ b/src/web/routes/channels-mg-detail.test.ts
@@ -305,21 +305,20 @@ describe('handleChannelsRoute — PATCH /api/channels/mg/:id', () => {
     expect(res.statusCode).toBe(405);
   });
 
-  it('does not collide with /api/channels/:id (single-segment id) routing', async () => {
-    // Sanity: the handler treats /api/channels/foo as an mga lookup, not an
-    // mg lookup. Without the mg-prefix, it would 404 as a missing wire and
-    // never reach the mg branch.
+  it('returns false (no match) for single-segment id routing', async () => {
+    // After PR3, neither mg nor mga is reachable as a single-segment id —
+    // the handler returns false so the outer dispatcher 404s the unknown
+    // route. Asserts the handler doesn't accidentally write a response.
     seedMg({ id: 'mg_collision' });
-    expect(getDb().prepare('SELECT id FROM messaging_groups WHERE id = ?').get('mg_collision')).toBeTruthy();
 
     const res = makeRes();
-    await handleChannelsRoute({
+    const matched = await handleChannelsRoute({
       pathname: '/api/channels/mg_collision',
       method: 'GET',
       req: makeReq(),
       res,
     });
-    expect(res.statusCode).toBe(404);
-    expect(res.json()).toMatchObject({ error: expect.stringMatching(/channel wire not found/) });
+    expect(matched).toBe(false);
+    expect(res.statusCode).toBe(0);
   });
 });

--- a/src/web/routes/channels-mga-detail.test.ts
+++ b/src/web/routes/channels-mga-detail.test.ts
@@ -301,6 +301,51 @@ describe('handleChannelsRoute — PATCH /api/channels/mga/:id', () => {
     expect(res.json()).toMatchObject({ error: expect.stringMatching(/invalid engageMode: wave-hands/) });
   });
 
+  it("rejects engagePattern '.' with 400 — bare dot is the 'all' sentinel", async () => {
+    // Without this guard the server silently rewrites '.' as the
+    // engageMode='all' wire-format sentinel, which round-trips back as
+    // 'all' on the next read and silently swallows the user's intent.
+    // Force them to pick: \\. for a literal dot, or engageMode='all'.
+    seedFullWire();
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({ engageMode: 'pattern', engagePattern: '.' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: expect.stringMatching(/engagePattern '\.' is reserved as the 'all' sentinel/),
+    });
+
+    // Row was not modified — still 'mention' / null from the seed.
+    const persisted = getMessagingGroupAgent('mga_routing')!;
+    expect(persisted.engage_mode).toBe('mention');
+    expect(persisted.engage_pattern).toBeNull();
+  });
+
+  it("rejects engagePattern '.' even without engageMode in the body", async () => {
+    // Same swallow risk via the mode-unchanged branch in apiToDbPatch —
+    // pin the validation catches both shapes.
+    seedFullWire({ engage: { engage_mode: 'pattern', engage_pattern: '^/ask\\b' } });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({ engagePattern: '.' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: expect.stringMatching(/engagePattern '\.' is reserved as the 'all' sentinel/),
+    });
+  });
+
   it('returns 404 when the wire does not exist', async () => {
     const res = makeRes();
     await handleChannelsRoute({

--- a/src/web/routes/channels-mga-detail.test.ts
+++ b/src/web/routes/channels-mga-detail.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for the per-MGA detail block of `handleChannelsRoute`. Covers
+ * GET (detail fetch), PATCH (routing-rules update with translation
+ * round-tripping), DELETE (unwire), and 404/405 status shapes.
+ *
+ * Fixture pattern mirrors channels-mg-detail.test.ts — direct route
+ * handler invocation against an in-memory DB, no HTTP layer.
+ */
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { createAgentGroup } from '../../db/agent-groups.js';
+import { createMessagingGroup, createMessagingGroupAgent, getMessagingGroupAgent } from '../../db/messaging-groups.js';
+import type { AgentGroup, MessagingGroup, MessagingGroupAgent } from '../../types.js';
+import { handleChannelsRoute } from './channels.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+const now = (): string => new Date().toISOString();
+
+function seedAgentGroup(over: Partial<AgentGroup> = {}): AgentGroup {
+  const ag: AgentGroup = {
+    id: over.id ?? 'ag_test',
+    name: over.name ?? 'Test agents',
+    folder: over.folder ?? 'test-agents',
+    agent_provider: over.agent_provider ?? null,
+    secret_mode: over.secret_mode ?? 'all',
+    created_at: over.created_at ?? now(),
+  };
+  createAgentGroup(ag);
+  return ag;
+}
+
+function seedMg(over: Partial<MessagingGroup> = {}): MessagingGroup {
+  const mg: MessagingGroup = {
+    id: over.id ?? 'mg_test',
+    channel_type: over.channel_type ?? 'telegram',
+    platform_id: over.platform_id ?? 'telegram:111111:222222',
+    name: over.name ?? null,
+    is_group: over.is_group ?? 0,
+    unknown_sender_policy: over.unknown_sender_policy ?? 'request_approval',
+    created_at: over.created_at ?? now(),
+  };
+  createMessagingGroup(mg);
+  return mg;
+}
+
+function seedMga(mgaOver: Partial<MessagingGroupAgent> = {}): MessagingGroupAgent {
+  const mga: MessagingGroupAgent = {
+    id: mgaOver.id ?? 'mga_test',
+    messaging_group_id: mgaOver.messaging_group_id ?? 'mg_test',
+    agent_group_id: mgaOver.agent_group_id ?? 'ag_test',
+    engage_mode: mgaOver.engage_mode ?? 'mention',
+    engage_pattern: mgaOver.engage_pattern ?? null,
+    sender_scope: mgaOver.sender_scope ?? 'all',
+    ignored_message_policy: mgaOver.ignored_message_policy ?? 'drop',
+    session_mode: mgaOver.session_mode ?? 'shared',
+    priority: mgaOver.priority ?? 0,
+    created_at: mgaOver.created_at ?? now(),
+  };
+  createMessagingGroupAgent(mga);
+  return mga;
+}
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  json(): unknown;
+}
+
+function makeReq(body?: unknown): http.IncomingMessage {
+  const stream = body === undefined ? Readable.from([]) : Readable.from([Buffer.from(JSON.stringify(body))]);
+  return stream as unknown as http.IncomingMessage;
+}
+
+function makeRes(): MockRes & http.ServerResponse {
+  const captured: { status: number; headers: Record<string, string>; chunks: string[] } = {
+    status: 0,
+    headers: {},
+    chunks: [],
+  };
+  const res = {
+    writeHead(status: number, headers?: Record<string, string>) {
+      captured.status = status;
+      if (headers) Object.assign(captured.headers, headers);
+      return this;
+    },
+    end(chunk?: string) {
+      if (chunk) captured.chunks.push(chunk);
+    },
+    get statusCode() {
+      return captured.status;
+    },
+    get headers() {
+      return captured.headers;
+    },
+    get body() {
+      return captured.chunks.join('');
+    },
+    json() {
+      return JSON.parse(captured.chunks.join(''));
+    },
+  } as unknown as MockRes & http.ServerResponse;
+  return res;
+}
+
+function seedFullWire(
+  override: { mgaId?: string; engage?: Partial<Pick<MessagingGroupAgent, 'engage_mode' | 'engage_pattern'>> } = {},
+): { mga: MessagingGroupAgent } {
+  const ag = seedAgentGroup({ id: 'ag_routing', folder: 'routing', name: 'Routing agent' });
+  const mg = seedMg({ id: 'mg_routing' });
+  const mga = seedMga({
+    id: override.mgaId ?? 'mga_routing',
+    messaging_group_id: mg.id,
+    agent_group_id: ag.id,
+    engage_mode: override.engage?.engage_mode ?? 'mention',
+    engage_pattern: override.engage?.engage_pattern ?? null,
+  });
+  return { mga };
+}
+
+describe('handleChannelsRoute — GET /api/channels/mga/:id', () => {
+  it('returns 200 with the wire detail on hit', async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    const handled = await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { wire: Record<string, unknown> };
+    expect(body.wire).toMatchObject({
+      id: 'mga_routing',
+      messagingGroupId: 'mg_routing',
+      agentGroupId: 'ag_routing',
+      agentGroupFolder: 'routing',
+      agentGroupName: 'Routing agent',
+      channelType: 'telegram',
+      platformId: 'telegram:111111:222222',
+      engageMode: 'mention',
+      engagePattern: null,
+      senderScope: 'all',
+      ignoredMessagePolicy: 'drop',
+      priority: 0,
+    });
+  });
+
+  it("collapses pattern + '.' sentinel to engageMode 'all' on the API shape", async () => {
+    seedFullWire({
+      engage: { engage_mode: 'pattern', engage_pattern: '.' },
+    });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+
+    const body = res.json() as { wire: { engageMode: string; engagePattern: string | null } };
+    expect(body.wire.engageMode).toBe('all');
+    expect(body.wire.engagePattern).toBeNull();
+  });
+
+  it("renders mention-sticky as plain 'mention' on the API shape (lossy display)", async () => {
+    seedFullWire({
+      engage: { engage_mode: 'mention-sticky', engage_pattern: null },
+    });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+
+    const body = res.json() as { wire: { engageMode: string } };
+    expect(body.wire.engageMode).toBe('mention');
+  });
+
+  it('returns 404 when the wire does not exist', async () => {
+    const res = makeRes();
+    const handled = await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_missing',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/channel wire not found/) });
+  });
+});
+
+describe('handleChannelsRoute — PATCH /api/channels/mga/:id', () => {
+  it('updates routing rules and returns the post-update wire', async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    const handled = await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({
+        engageMode: 'pattern',
+        engagePattern: '^/ask\\b',
+        senderScope: 'allowlist',
+        ignoredMessagePolicy: 'silent',
+        priority: 7,
+      }),
+      res,
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { wire: Record<string, unknown> };
+    expect(body.wire).toMatchObject({
+      id: 'mga_routing',
+      engageMode: 'pattern',
+      engagePattern: '^/ask\\b',
+      senderScope: 'allowlist',
+      ignoredMessagePolicy: 'silent',
+      priority: 7,
+    });
+
+    // Persisted in DB shape (sender_scope='known', ignored_message_policy='accumulate').
+    const persisted = getMessagingGroupAgent('mga_routing')!;
+    expect(persisted.engage_mode).toBe('pattern');
+    expect(persisted.engage_pattern).toBe('^/ask\\b');
+    expect(persisted.sender_scope).toBe('known');
+    expect(persisted.ignored_message_policy).toBe('accumulate');
+    expect(persisted.priority).toBe(7);
+  });
+
+  it("preserves mention-sticky on the row when the PATCH sets engageMode='mention'", async () => {
+    seedFullWire({
+      engage: { engage_mode: 'mention-sticky', engage_pattern: null },
+    });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({ engageMode: 'mention' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The DB row keeps mention-sticky — UI doesn't expose the distinction,
+    // so a no-op-feeling PATCH shouldn't silently downgrade router behavior.
+    const persisted = getMessagingGroupAgent('mga_routing')!;
+    expect(persisted.engage_mode).toBe('mention-sticky');
+  });
+
+  it("encodes engageMode='all' as DB pattern + '.' sentinel", async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({ engageMode: 'all' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const persisted = getMessagingGroupAgent('mga_routing')!;
+    expect(persisted.engage_mode).toBe('pattern');
+    expect(persisted.engage_pattern).toBe('.');
+  });
+
+  it('rejects an invalid engageMode with 400 + value echo', async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'PATCH',
+      req: makeReq({ engageMode: 'wave-hands' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: expect.stringMatching(/invalid engageMode: wave-hands/) });
+  });
+
+  it('returns 404 when the wire does not exist', async () => {
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_missing',
+      method: 'PATCH',
+      req: makeReq({ priority: 9 }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('handleChannelsRoute — DELETE /api/channels/mga/:id', () => {
+  it('hard-deletes the wire row and returns 200', async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    const handled = await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'DELETE',
+      req: makeReq(),
+      res,
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id: 'mga_routing', deleted: true });
+    expect(getMessagingGroupAgent('mga_routing')).toBeUndefined();
+  });
+
+  it('returns 404 when the wire does not exist', async () => {
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_missing',
+      method: 'DELETE',
+      req: makeReq(),
+      res,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('handleChannelsRoute — /api/channels/mga/:id misc', () => {
+  it('rejects unsupported methods with 405', async () => {
+    seedFullWire();
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mga/mga_routing',
+      method: 'POST',
+      req: makeReq({ engageMode: 'mention' }),
+      res,
+    });
+
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('does not collide with /api/channels/mg/:id routing', async () => {
+    // Sanity: the mg/ block dispatches first, mga/ second. A path of
+    // `/api/channels/mg/foo` must NOT be misread as mga lookup.
+    seedMg({ id: 'mg_disambig' });
+
+    const res = makeRes();
+    await handleChannelsRoute({
+      pathname: '/api/channels/mg/mg_disambig',
+      method: 'GET',
+      req: makeReq(),
+      res,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { messagingGroup: { id: string } };
+    expect(body.messagingGroup.id).toBe('mg_disambig');
+  });
+});

--- a/src/web/routes/channels.ts
+++ b/src/web/routes/channels.ts
@@ -109,11 +109,11 @@ function apiToDbPatch(input: PatchInput, current: MessagingGroupAgent): DbPatch 
     } else if (input.engageMode === 'pattern') {
       out.engage_mode = 'pattern';
       // Pattern body comes from input.engagePattern when present; otherwise
-      // preserve what's already on the row. We never write '.' here — that
-      // would silently re-collapse to 'all' on the next read.
+      // preserve what's already on the row. validatePatchInput already
+      // rejects bare '.' here so the next read can't silently collapse to
+      // 'all'.
       if (input.engagePattern !== undefined) {
-        out.engage_pattern =
-          input.engagePattern === ALL_MESSAGES_PATTERN_SENTINEL ? current.engage_pattern : input.engagePattern;
+        out.engage_pattern = input.engagePattern;
       }
     } else if (input.engageMode === 'mention') {
       // Preserve mention-sticky if that's what's currently on the row;
@@ -235,6 +235,15 @@ function validatePatchInput(body: unknown): { ok: true; input: PatchInput } | { 
   if ('engagePattern' in b) {
     if (b.engagePattern !== null && typeof b.engagePattern !== 'string') {
       return { ok: false, reason: 'engagePattern must be string or null' };
+    }
+    // Bare '.' is the wire-format sentinel for engageMode='all' — accepting
+    // it as a literal pattern would silently round-trip back as 'all' on the
+    // next read and lose the user's intent. Force the caller to disambiguate.
+    if (b.engagePattern === ALL_MESSAGES_PATTERN_SENTINEL) {
+      return {
+        ok: false,
+        reason: "engagePattern '.' is reserved as the 'all' sentinel — use '\\\\.' (escaped) to match a literal dot, or set engageMode to 'all'",
+      };
     }
     out.engagePattern = b.engagePattern as string | null;
   }

--- a/src/web/routes/channels.ts
+++ b/src/web/routes/channels.ts
@@ -424,13 +424,21 @@ export async function handleChannelsRoute(ctx: ChannelsRouteContext): Promise<bo
     return true;
   }
 
-  // /api/channels/:id — PATCH or DELETE
-  const idMatch = pathname.match(/^\/api\/channels\/([^/]+)$/);
-  if (idMatch) {
-    const id = decodeURIComponent(idMatch[1]);
+  // /api/channels/mga/:id — GET (wire detail), PATCH (routing rules edit),
+  // or DELETE (unwire). The `mga/` segment matches the `mg/` convention from
+  // the messaging-group detail block above; `mga` = messaging_group_agent =
+  // one wire row.
+  const mgaMatch = pathname.match(/^\/api\/channels\/mga\/([^/]+)$/);
+  if (mgaMatch) {
+    const id = decodeURIComponent(mgaMatch[1]);
     const current = getMessagingGroupAgent(id);
     if (!current) {
       error(res, 404, `channel wire not found: ${id}`);
+      return true;
+    }
+
+    if (method === 'GET') {
+      json(res, 200, { wire: getOneWireView(id)! });
       return true;
     }
 
@@ -449,13 +457,10 @@ export async function handleChannelsRoute(ctx: ChannelsRouteContext): Promise<bo
       }
       const dbPatch = apiToDbPatch(validated.input, current);
       updateMessagingGroupAgent(id, dbPatch);
-      const after = getOneWireView(id);
-      if (!after) {
-        error(res, 500, `channel wire ${id} disappeared after update`);
-        return true;
-      }
       log.info('channel wire updated via web', { id, fields: Object.keys(dbPatch) });
-      json(res, 200, { wire: after });
+      // Same connection, same row — see channels.ts mg/:id PATCH for the
+      // non-null-assertion rationale.
+      json(res, 200, { wire: getOneWireView(id)! });
       return true;
     }
 
@@ -465,6 +470,9 @@ export async function handleChannelsRoute(ctx: ChannelsRouteContext): Promise<bo
       json(res, 200, { id, deleted: true });
       return true;
     }
+
+    error(res, 405, `method not allowed on ${pathname}: ${method}`);
+    return true;
   }
 
   return false;

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { Link, Route, Routes, useLocation } from 'react-router-dom';
 import { Apps } from './routes/Apps.tsx';
 import { ApprovalsList } from './routes/ApprovalsList.tsx';
 import { ChannelsList } from './routes/ChannelsList.tsx';
+import { ChannelWireDetail } from './routes/ChannelWireDetail.tsx';
 import { GroupDetail } from './routes/GroupDetail.tsx';
 import { GroupList } from './routes/GroupList.tsx';
 import { MessagingGroupDetail } from './routes/MessagingGroupDetail.tsx';
@@ -64,6 +65,7 @@ export function App() {
         <Route path="/channels" element={<ChannelsList />} />
         <Route path="/channels/new" element={<WireChannelPage />} />
         <Route path="/channels/mg/:id" element={<MessagingGroupDetail />} />
+        <Route path="/channels/mga/:id" element={<ChannelWireDetail />} />
         <Route path="/apps" element={<Apps />} />
         <Route path="/approvals" element={<ApprovalsList />} />
         <Route path="/settings/approvals" element={<SettingsApprovals />} />

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -341,3 +341,70 @@ describe('wireChannelToGroup — body contract with server', () => {
     expect(body.channel).toBeUndefined();
   });
 });
+
+describe('channel-wire helpers — pinned to /channels/mga/:id', () => {
+  // PR3 disambiguates per-MG and per-MGA detail under prefixed paths. Pin
+  // the helper paths so a future refactor can't silently fall back to the
+  // single-segment `/channels/:id` shape that PR3 deleted.
+  function wireView(over: Partial<import('./api.ts').ChannelWireView> = {}): import('./api.ts').ChannelWireView {
+    return {
+      id: 'mga_1',
+      channelType: 'telegram',
+      messagingGroupId: 'mg_1',
+      platformId: 'telegram:42:1',
+      displayName: null,
+      agentGroupId: 'ag_1',
+      agentGroupFolder: 'main',
+      agentGroupName: 'Main',
+      engageMode: 'mention',
+      engagePattern: null,
+      senderScope: 'all',
+      ignoredMessagePolicy: 'drop',
+      priority: 0,
+      createdAt: '2026-04-20T10:00:00Z',
+      ...over,
+    };
+  }
+
+  it('getChannelWireDetail GETs /channels/mga/:id and unwraps { wire }', async () => {
+    const view = wireView({ id: 'mga_x', engageMode: 'all' });
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { wire: view }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    const result = await api.getChannelWireDetail('mga_x');
+
+    expect(result).toEqual(view);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/api\/channels\/mga\/mga_x$/);
+    expect((init as RequestInit).method ?? 'GET').toBe('GET');
+  });
+
+  it('updateChannelWire PATCHes /channels/mga/:id with the input body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { wire: wireView({ engageMode: 'all' }) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await api.updateChannelWire('mga_1', { engageMode: 'all', priority: 3 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/api\/channels\/mga\/mga_1$/);
+    expect((init as RequestInit).method).toBe('PATCH');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ engageMode: 'all', priority: 3 });
+  });
+
+  it('deleteChannelWire DELETEs /channels/mga/:id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { id: 'mga_1', deleted: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = await import('./api.ts');
+    await api.deleteChannelWire('mga_1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/api\/channels\/mga\/mga_1$/);
+    expect((init as RequestInit).method).toBe('DELETE');
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -928,8 +928,13 @@ export async function listChannelWires(): Promise<ChannelWireView[]> {
   return r.wires;
 }
 
+export async function getChannelWireDetail(id: string): Promise<ChannelWireView> {
+  const r = await request<{ wire: ChannelWireView }>(`/channels/mga/${encodeURIComponent(id)}`);
+  return r.wire;
+}
+
 export async function deleteChannelWire(id: string): Promise<void> {
-  return request<void>(`/channels/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  return request<void>(`/channels/mga/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
 export interface UpdateChannelWireInput {
@@ -941,7 +946,7 @@ export interface UpdateChannelWireInput {
 }
 
 export async function updateChannelWire(id: string, input: UpdateChannelWireInput): Promise<ChannelWireView> {
-  const r = await request<{ wire: ChannelWireView }>(`/channels/${encodeURIComponent(id)}`, {
+  const r = await request<{ wire: ChannelWireView }>(`/channels/mga/${encodeURIComponent(id)}`, {
     method: 'PATCH',
     json: input,
   });

--- a/web/ui/src/routes/ChannelWireDetail.test.tsx
+++ b/web/ui/src/routes/ChannelWireDetail.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * ChannelWireDetail tests cover the contracts the design doc names for
+ * the per-MGA route:
+ *   1. The 3-radio engage-mode editor renders all options; the row matching
+ *      the DB is selected. "Only when mentioned" is the surface for Aaron's
+ *      "respond only to mentions" toggle.
+ *   2. Saving the form calls updateChannelWire with the right input shape
+ *      and reflects the new wire state back in the form.
+ *   3. Server 404 surfaces as the "no wire" empty state with a Back CTA
+ *      (no Retry — there's nothing to come back from).
+ *   4. Unknown errors surface as the load-error banner with a Retry button.
+ *   5. Metadata block links back to the parent /channels/mg/:id route and
+ *      to the /groups/:folder route.
+ *   6. Delete confirms via window.confirm and calls deleteChannelWire.
+ *
+ * The api module is mocked so we don't need a live server.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../lib/api.ts';
+import { ChannelWireDetail } from './ChannelWireDetail.tsx';
+
+vi.mock('../lib/api.ts', async () => {
+  const actual = await vi.importActual<typeof api>('../lib/api.ts');
+  return {
+    ...actual,
+    getChannelWireDetail: vi.fn(),
+    updateChannelWire: vi.fn(),
+    deleteChannelWire: vi.fn(),
+  };
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/channels/mga/:id" element={<ChannelWireDetail />} />
+        <Route path="/channels" element={<div>channels list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const baseWire: api.ChannelWireView = {
+  id: 'mga_1',
+  channelType: 'telegram',
+  messagingGroupId: 'mg_1',
+  platformId: 'telegram:111111:222222',
+  displayName: 'Aaron DM',
+  agentGroupId: 'ag_1',
+  agentGroupFolder: 'main',
+  agentGroupName: 'Main agent',
+  engageMode: 'mention',
+  engagePattern: null,
+  senderScope: 'all',
+  ignoredMessagePolicy: 'drop',
+  priority: 0,
+  createdAt: '2026-04-20T10:00:00Z',
+};
+
+beforeEach(() => {
+  vi.mocked(api.getChannelWireDetail).mockResolvedValue(baseWire);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ChannelWireDetail — render', () => {
+  it('renders the engage-mode radios with the DB value selected', async () => {
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Routing rules')).toBeInTheDocument();
+    });
+
+    const mention = screen.getByRole('radio', { name: /Only when mentioned/ });
+    const all = screen.getByRole('radio', { name: /Every message/ });
+    const pattern = screen.getByRole('radio', { name: /Pattern match/ });
+
+    expect(mention).toBeChecked();
+    expect(all).not.toBeChecked();
+    expect(pattern).not.toBeChecked();
+  });
+
+  it('shows the regex input only when pattern mode is selected', async () => {
+    vi.mocked(api.getChannelWireDetail).mockResolvedValue({
+      ...baseWire,
+      engageMode: 'pattern',
+      engagePattern: '^/ask\\b',
+    });
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Engage pattern/)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/Engage pattern/)).toHaveValue('^/ask\\b');
+  });
+
+  it('renders the metadata block with links back to MG and to the agent group', async () => {
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByText('Wire details')).toBeInTheDocument();
+    });
+
+    const mgLink = screen.getByRole('link', { name: 'mg_1' });
+    expect(mgLink).toHaveAttribute('href', '/channels/mg/mg_1');
+
+    const groupLinks = screen.getAllByRole('link', { name: 'Main agent' });
+    expect(groupLinks[0]).toHaveAttribute('href', '/groups/main');
+  });
+});
+
+describe('ChannelWireDetail — save', () => {
+  it('calls updateChannelWire with the engage-mode change', async () => {
+    vi.mocked(api.updateChannelWire).mockResolvedValue({
+      ...baseWire,
+      engageMode: 'all',
+    });
+
+    const user = userEvent.setup();
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Only when mentioned/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Every message/ }));
+    await user.click(screen.getByRole('button', { name: /Save routing rules/ }));
+
+    await waitFor(() => {
+      expect(api.updateChannelWire).toHaveBeenCalledWith('mga_1', {
+        engageMode: 'all',
+        engagePattern: null,
+        senderScope: 'all',
+        ignoredMessagePolicy: 'drop',
+        priority: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Every message/ })).toBeChecked();
+    });
+  });
+
+  it('surfaces an error banner when the PATCH fails', async () => {
+    vi.mocked(api.updateChannelWire).mockRejectedValue(new api.HttpError(400, 'invalid engageMode: xyz'));
+
+    const user = userEvent.setup();
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Only when mentioned/ })).toBeChecked();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Every message/ }));
+    await user.click(screen.getByRole('button', { name: /Save routing rules/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't save:/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/invalid engageMode: xyz/)).toBeInTheDocument();
+  });
+});
+
+describe('ChannelWireDetail — delete', () => {
+  it('calls deleteChannelWire after confirm', async () => {
+    vi.mocked(api.deleteChannelWire).mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const user = userEvent.setup();
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Remove wire/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Remove wire/ }));
+
+    await waitFor(() => {
+      expect(api.deleteChannelWire).toHaveBeenCalledWith('mga_1');
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('does not call deleteChannelWire when confirm is dismissed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    const user = userEvent.setup();
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Remove wire/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Remove wire/ }));
+
+    expect(api.deleteChannelWire).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+});
+
+describe('ChannelWireDetail — error states', () => {
+  it('renders 404 empty state with Back CTA only', async () => {
+    vi.mocked(api.getChannelWireDetail).mockRejectedValue(
+      new api.HttpError(404, 'channel wire not found: mga_missing'),
+    );
+
+    renderAt('/channels/mga/mga_missing');
+
+    await waitFor(() => {
+      expect(screen.getByText(/No wire with id/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Back to channels' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
+  it('renders generic load error with Retry button on non-404', async () => {
+    vi.mocked(api.getChannelWireDetail).mockRejectedValue(new api.HttpError(500, 'internal'));
+
+    renderAt('/channels/mga/mga_1');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load this wire/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/ChannelWireDetail.tsx
+++ b/web/ui/src/routes/ChannelWireDetail.tsx
@@ -1,0 +1,403 @@
+/**
+ * /channels/mga/:id — per-wire (messaging-group ↔ agent-group) detail +
+ * routing-rules editor.
+ *
+ * What's here:
+ *   - read-only metadata (linked target group, parent messaging group, channel,
+ *     platform id, priority, created)
+ *   - the routing rules editor: engage mode (mention | all | pattern), pattern,
+ *     sender scope, ignored-message policy, priority
+ *   - delete-wire action with native confirm
+ *
+ * The MGA-id is a UUID generated server-side; the disambiguation prefix
+ * `mga/` keeps the route clean against per-MG routes (`mg/`).
+ *
+ * `engageMode = 'mention'` is the surface for "respond only to mentions".
+ * The DB-side enum has a third state `mention-sticky` that the server
+ * collapses to `'mention'` for display and preserves on PATCH so a future
+ * sticky-aware editor doesn't silently downgrade existing wires.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  deleteChannelWire,
+  getChannelWireDetail,
+  HttpError,
+  updateChannelWire,
+  type ChannelWireView,
+  type EngageMode,
+  type IgnoredMessagePolicy,
+  type SenderScope,
+  type UpdateChannelWireInput,
+} from '../lib/api.ts';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; wire: ChannelWireView }
+  | { kind: 'error'; status: number | null; message: string };
+
+export function ChannelWireDetail() {
+  const { id: rawId } = useParams<{ id: string }>();
+  const id = rawId ?? '';
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [reloadKey, setReloadKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  useEffect(() => {
+    if (!id) {
+      setState({ kind: 'error', status: null, message: 'no wire id in URL' });
+      return;
+    }
+    let cancelled = false;
+    getChannelWireDetail(id)
+      .then((wire) => !cancelled && setState({ kind: 'ok', wire }))
+      .catch((err) => {
+        if (cancelled) return;
+        const status = err instanceof HttpError ? err.status : null;
+        setState({
+          kind: 'error',
+          status,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, reloadKey]);
+
+  if (state.kind === 'loading') {
+    return (
+      <div>
+        <h2>Channel wire</h2>
+        <ul className="skeleton-list" aria-busy="true">
+          <li className="skeleton skeleton-row" />
+          <li className="skeleton skeleton-row" />
+        </ul>
+      </div>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div>
+        <h2>Channel wire</h2>
+        <div className="error-banner">
+          {state.status === 404 ? (
+            <>
+              No wire with id <code>{id}</code> — it may have been removed.
+            </>
+          ) : (
+            <>
+              Couldn't load this wire: <code>{state.message}</code>
+            </>
+          )}
+        </div>
+        <div className="actions" style={{ marginTop: '1rem' }}>
+          <Link to="/channels">
+            <button className="secondary">Back to channels</button>
+          </Link>
+          {state.status !== 404 && <button onClick={reload}>Retry</button>}
+        </div>
+      </div>
+    );
+  }
+
+  const { wire } = state;
+
+  const onSave = async (input: UpdateChannelWireInput) => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await updateChannelWire(id, input);
+      setState({ kind: 'ok', wire: updated });
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (
+      !confirm(
+        `Remove ${wire.channelType} wire to ${wire.agentGroupName}? Inbound messages on this thread will fall back to the unwired-channel guard (silently dropped).`,
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    setSaveError(null);
+    try {
+      await deleteChannelWire(id);
+      setState({ kind: 'error', status: 404, message: 'wire deleted' });
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2 style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Link to="/channels" className="muted" style={{ textDecoration: 'none' }}>
+            Channels
+          </Link>
+          <span className="dim">/</span>
+          <span style={{ textTransform: 'capitalize' }}>{wire.channelType}</span>
+          <span className="dim">→</span>
+          <Link to={`/groups/${encodeURIComponent(wire.agentGroupFolder)}`}>{wire.agentGroupName}</Link>
+        </h2>
+      </div>
+
+      <section
+        style={{
+          background: 'white',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '1rem 1.25rem',
+          marginBottom: '1rem',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Wire details</h3>
+        <div className="kv">
+          <div>id</div>
+          <div>
+            <code>{wire.id}</code>
+          </div>
+          <div>channel</div>
+          <div style={{ textTransform: 'capitalize' }}>{wire.channelType}</div>
+          <div>messaging group</div>
+          <div>
+            <Link to={`/channels/mg/${encodeURIComponent(wire.messagingGroupId)}`}>
+              <code>{wire.messagingGroupId}</code>
+            </Link>
+            {wire.displayName && <span className="dim"> · {wire.displayName}</span>}
+          </div>
+          <div>platform id</div>
+          <div>
+            <code>{wire.platformId}</code>
+          </div>
+          <div>agent group</div>
+          <div>
+            <Link to={`/groups/${encodeURIComponent(wire.agentGroupFolder)}`}>{wire.agentGroupName}</Link>
+          </div>
+          <div>created</div>
+          <div>
+            <code>{wire.createdAt}</code>
+          </div>
+        </div>
+      </section>
+
+      <RoutingRulesEditor wire={wire} saving={saving} onSave={onSave} />
+
+      {saveError && (
+        <div className="error-banner" style={{ marginTop: '0.5rem' }}>
+          Couldn't save: <code>{saveError}</code>
+        </div>
+      )}
+
+      <section
+        style={{
+          background: 'white',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '1rem 1.25rem',
+          marginTop: '1rem',
+        }}
+      >
+        <h3 style={{ marginTop: 0 }}>Danger zone</h3>
+        <p className="muted">
+          Removing this wire stops the agent from receiving inbound messages on this thread. The messaging group itself
+          stays — you can re-wire it later from <Link to="/channels/new">Channels → New</Link>.
+        </p>
+        <button
+          className="secondary"
+          onClick={onDelete}
+          disabled={deleting || saving}
+          style={{ borderColor: 'var(--error)', color: 'var(--error)' }}
+        >
+          {deleting ? 'Removing…' : 'Remove wire'}
+        </button>
+      </section>
+    </div>
+  );
+}
+
+interface EngageChoice {
+  value: EngageMode;
+  label: string;
+  blurb: string;
+}
+
+const ENGAGE_CHOICES: EngageChoice[] = [
+  {
+    value: 'mention',
+    label: 'Only when mentioned',
+    blurb: 'The agent responds only when @-tagged. Best for shared channels where the agent is one of many participants.',
+  },
+  {
+    value: 'all',
+    label: 'Every message',
+    blurb: 'The agent responds to every message in this thread. Right for DMs and dedicated channels.',
+  },
+  {
+    value: 'pattern',
+    label: 'Pattern match',
+    blurb: 'The agent responds when the message text matches a regex. Use for command-prefix channels (e.g. ^/ask\\b).',
+  },
+];
+
+function RoutingRulesEditor({
+  wire,
+  saving,
+  onSave,
+}: {
+  wire: ChannelWireView;
+  saving: boolean;
+  onSave: (input: UpdateChannelWireInput) => void;
+}) {
+  const [engageMode, setEngageMode] = useState<EngageMode>(wire.engageMode);
+  const [engagePattern, setEngagePattern] = useState(wire.engagePattern ?? '');
+  const [senderScope, setSenderScope] = useState<SenderScope>(wire.senderScope);
+  const [ignoredMessagePolicy, setIgnoredMessagePolicy] = useState<IgnoredMessagePolicy>(wire.ignoredMessagePolicy);
+  const [priority, setPriority] = useState(String(wire.priority));
+
+  useEffect(() => {
+    setEngageMode(wire.engageMode);
+    setEngagePattern(wire.engagePattern ?? '');
+    setSenderScope(wire.senderScope);
+    setIgnoredMessagePolicy(wire.ignoredMessagePolicy);
+    setPriority(String(wire.priority));
+  }, [wire]);
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsedPriority = Number.parseInt(priority, 10);
+    onSave({
+      engageMode,
+      engagePattern: engageMode === 'pattern' ? engagePattern.trim() || null : null,
+      senderScope,
+      ignoredMessagePolicy,
+      priority: Number.isFinite(parsedPriority) ? parsedPriority : wire.priority,
+    });
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      style={{
+        background: 'white',
+        border: '1px solid var(--border)',
+        borderRadius: '8px',
+        padding: '1rem 1.25rem',
+        marginBottom: '1rem',
+      }}
+    >
+      <h3 style={{ marginTop: 0 }}>Routing rules</h3>
+
+      <div role="radiogroup" aria-label="Engage mode" style={{ marginBottom: '1rem' }}>
+        <label htmlFor="engageMode-mention" className="muted" style={{ display: 'block', marginBottom: '0.4rem' }}>
+          When should this agent engage?
+        </label>
+        {ENGAGE_CHOICES.map((choice) => {
+          const selected = engageMode === choice.value;
+          return (
+            <label
+              key={choice.value}
+              htmlFor={`engageMode-${choice.value}`}
+              style={{
+                display: 'block',
+                padding: '0.6rem 0.75rem',
+                borderRadius: '6px',
+                background: selected ? 'var(--accent-bg, #eef4ff)' : 'transparent',
+                border: selected ? '1px solid var(--accent, #5076ff)' : '1px solid transparent',
+                cursor: saving ? 'progress' : 'pointer',
+                marginBottom: '0.4rem',
+              }}
+            >
+              <input
+                id={`engageMode-${choice.value}`}
+                type="radio"
+                name="engageMode"
+                value={choice.value}
+                checked={selected}
+                disabled={saving}
+                onChange={() => setEngageMode(choice.value)}
+              />{' '}
+              <strong>{choice.label}</strong>
+              <p className="muted" style={{ margin: '0.25rem 0 0 1.6rem' }}>
+                {choice.blurb}
+              </p>
+            </label>
+          );
+        })}
+      </div>
+
+      {engageMode === 'pattern' && (
+        <div className="row">
+          <label htmlFor="engagePattern">Engage pattern (regex)</label>
+          <input
+            id="engagePattern"
+            type="text"
+            value={engagePattern}
+            onChange={(e) => setEngagePattern(e.target.value)}
+            placeholder="^/ask\b"
+            disabled={saving}
+          />
+        </div>
+      )}
+
+      <div className="row">
+        <label htmlFor="senderScope">Who can talk to this agent?</label>
+        <select
+          id="senderScope"
+          value={senderScope}
+          onChange={(e) => setSenderScope(e.target.value as SenderScope)}
+          disabled={saving}
+        >
+          <option value="all">all — anyone in the thread</option>
+          <option value="allowlist">allowlist — only members of the agent group</option>
+        </select>
+      </div>
+
+      <div className="row">
+        <label htmlFor="ignoredMessagePolicy">What about messages the agent ignores?</label>
+        <select
+          id="ignoredMessagePolicy"
+          value={ignoredMessagePolicy}
+          onChange={(e) => setIgnoredMessagePolicy(e.target.value as IgnoredMessagePolicy)}
+          disabled={saving}
+        >
+          <option value="drop">drop — discard, no record</option>
+          <option value="silent">silent — log them in the conversation but don't reply</option>
+        </select>
+      </div>
+
+      <div className="row">
+        <label htmlFor="priority">Priority</label>
+        <input
+          id="priority"
+          type="number"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value)}
+          disabled={saving}
+          style={{ width: '6rem' }}
+        />
+        <p className="dim" style={{ marginTop: '0.25rem', fontSize: '0.8rem' }}>
+          Higher wins when multiple wires could match the same inbound.
+        </p>
+      </div>
+
+      <div className="actions">
+        <button type="submit" disabled={saving}>
+          {saving ? 'Saving…' : 'Save routing rules'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/ui/src/routes/ChannelsList.tsx
+++ b/web/ui/src/routes/ChannelsList.tsx
@@ -10,10 +10,11 @@
  * could match.
  *
  * Per-wire actions:
- *   - Edit  : open an inline editor for the routing fields above.
- *   - Remove: hard-delete the wiring (no confirmation step beyond
- *             native confirm()). The associated messaging_groups +
- *             messaging_group_agents rows are cleaned up server-side.
+ *   - Routing rules → opens /channels/mga/:id, the per-wire detail page
+ *                     (engage mode editor, sender scope, ignored policy,
+ *                     priority, hard-delete).
+ *   - Group settings → opens /channels/mg/:id, the messaging-group page
+ *                      (unknown-sender policy + denied-channel banner).
  *
  * New wirings are created by the setup wizard — there's no "+ new wire"
  * button here, by design. The wizard owns the channel-token-validate +
@@ -22,25 +23,13 @@
  */
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  deleteChannelWire,
-  listChannelWires,
-  updateChannelWire,
-  type ChannelWireView,
-  type EngageMode,
-  type IgnoredMessagePolicy,
-  type SenderScope,
-  type UpdateChannelWireInput,
-} from '../lib/api.ts';
+import { listChannelWires, type ChannelWireView } from '../lib/api.ts';
 
 export function ChannelsList() {
   const [state, setState] = useState<
     { kind: 'loading' } | { kind: 'ok'; wires: ChannelWireView[] } | { kind: 'error'; message: string }
   >({ kind: 'loading' });
   const [reloadKey, setReloadKey] = useState(0);
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
 
   const reload = useCallback(() => setReloadKey((k) => k + 1), []);
 
@@ -60,40 +49,6 @@ export function ChannelsList() {
       cancelled = true;
     };
   }, [reloadKey]);
-
-  const onDelete = async (w: ChannelWireView) => {
-    if (
-      !confirm(
-        `Remove ${w.channelType} wire to ${w.agentGroupName}? Inbound messages on this thread will fall back to the unwired-channel guard (silently dropped).`,
-      )
-    ) {
-      return;
-    }
-    setBusyId(w.id);
-    setActionError(null);
-    try {
-      await deleteChannelWire(w.id);
-      reload();
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  };
-
-  const onSave = async (id: string, input: UpdateChannelWireInput) => {
-    setBusyId(id);
-    setActionError(null);
-    try {
-      await updateChannelWire(id, input);
-      setEditingId(null);
-      reload();
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  };
 
   if (state.kind === 'loading') {
     return (
@@ -136,8 +91,6 @@ export function ChannelsList() {
         platform id captured.
       </p>
 
-      {actionError && <div className="error-banner">{actionError}</div>}
-
       {state.wires.length === 0 && (
         <div className="empty empty-rich" style={{ marginTop: '1rem' }}>
           <p className="empty-headline">No channels wired yet.</p>
@@ -147,40 +100,14 @@ export function ChannelsList() {
         </div>
       )}
 
-      {state.wires.map((w) =>
-        editingId === w.id ? (
-          <ChannelEditor
-            key={w.id}
-            wire={w}
-            saving={busyId === w.id}
-            onCancel={() => setEditingId(null)}
-            onSave={(input) => onSave(w.id, input)}
-          />
-        ) : (
-          <ChannelRow
-            key={w.id}
-            wire={w}
-            busy={busyId === w.id}
-            onEdit={() => setEditingId(w.id)}
-            onDelete={() => onDelete(w)}
-          />
-        ),
-      )}
+      {state.wires.map((w) => (
+        <ChannelRow key={w.id} wire={w} />
+      ))}
     </div>
   );
 }
 
-function ChannelRow({
-  wire,
-  busy,
-  onEdit,
-  onDelete,
-}: {
-  wire: ChannelWireView;
-  busy: boolean;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
+function ChannelRow({ wire }: { wire: ChannelWireView }) {
   return (
     <div
       style={{
@@ -219,149 +146,13 @@ function ChannelRow({
         <div>{wire.ignoredMessagePolicy}</div>
       </div>
       <div className="actions" style={{ marginTop: '0.75rem' }}>
-        <button className="secondary" onClick={onEdit} disabled={busy}>
-          Edit
-        </button>
-        <Link to={`/channels/mg/${encodeURIComponent(wire.messagingGroupId)}`}>
-          <button className="secondary" disabled={busy}>
-            Group settings →
-          </button>
+        <Link to={`/channels/mga/${encodeURIComponent(wire.id)}`}>
+          <button className="secondary">Routing rules →</button>
         </Link>
-        <button
-          className="secondary"
-          onClick={onDelete}
-          disabled={busy}
-          style={{ borderColor: 'var(--error)', color: 'var(--error)' }}
-        >
-          {busy ? 'Removing…' : 'Remove'}
-        </button>
+        <Link to={`/channels/mg/${encodeURIComponent(wire.messagingGroupId)}`}>
+          <button className="secondary">Group settings →</button>
+        </Link>
       </div>
     </div>
-  );
-}
-
-function ChannelEditor({
-  wire,
-  saving,
-  onCancel,
-  onSave,
-}: {
-  wire: ChannelWireView;
-  saving: boolean;
-  onCancel: () => void;
-  onSave: (input: UpdateChannelWireInput) => void;
-}) {
-  const [engageMode, setEngageMode] = useState<EngageMode>(wire.engageMode);
-  const [engagePattern, setEngagePattern] = useState(wire.engagePattern ?? '');
-  const [senderScope, setSenderScope] = useState<SenderScope>(wire.senderScope);
-  const [ignoredMessagePolicy, setIgnoredMessagePolicy] = useState<IgnoredMessagePolicy>(wire.ignoredMessagePolicy);
-  const [priority, setPriority] = useState(String(wire.priority));
-
-  const onSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const parsedPriority = Number.parseInt(priority, 10);
-    onSave({
-      engageMode,
-      engagePattern: engageMode === 'pattern' ? engagePattern.trim() || null : null,
-      senderScope,
-      ignoredMessagePolicy,
-      priority: Number.isFinite(parsedPriority) ? parsedPriority : wire.priority,
-    });
-  };
-
-  return (
-    <form
-      onSubmit={onSubmit}
-      style={{
-        background: 'white',
-        border: '1px solid var(--accent)',
-        borderRadius: '8px',
-        padding: '1rem 1.25rem',
-        marginBottom: '0.75rem',
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
-        <strong style={{ textTransform: 'capitalize' }}>Editing {wire.channelType}</strong>
-        <span className="dim">→ {wire.agentGroupName}</span>
-      </div>
-
-      <div className="row">
-        <label htmlFor="engageMode">Engage mode</label>
-        <select
-          id="engageMode"
-          value={engageMode}
-          onChange={(e) => setEngageMode(e.target.value as EngageMode)}
-          disabled={saving}
-        >
-          <option value="all">all — agent responds to every message</option>
-          <option value="mention">mention — only when @-tagged</option>
-          <option value="pattern">pattern — when text matches a regex</option>
-        </select>
-      </div>
-
-      {engageMode === 'pattern' && (
-        <div className="row">
-          <label htmlFor="engagePattern">Engage pattern (regex)</label>
-          <input
-            id="engagePattern"
-            type="text"
-            value={engagePattern}
-            onChange={(e) => setEngagePattern(e.target.value)}
-            placeholder="^/ask\b"
-            disabled={saving}
-          />
-        </div>
-      )}
-
-      <div className="row">
-        <label htmlFor="senderScope">Sender scope</label>
-        <select
-          id="senderScope"
-          value={senderScope}
-          onChange={(e) => setSenderScope(e.target.value as SenderScope)}
-          disabled={saving}
-        >
-          <option value="all">all — anyone in the thread</option>
-          <option value="allowlist">allowlist — only members of the agent group</option>
-        </select>
-      </div>
-
-      <div className="row">
-        <label htmlFor="ignoredMessagePolicy">Ignored-message policy</label>
-        <select
-          id="ignoredMessagePolicy"
-          value={ignoredMessagePolicy}
-          onChange={(e) => setIgnoredMessagePolicy(e.target.value as IgnoredMessagePolicy)}
-          disabled={saving}
-        >
-          <option value="drop">drop — discard, no record</option>
-          <option value="silent">silent — log but don't reply</option>
-        </select>
-      </div>
-
-      <div className="row">
-        <label htmlFor="priority">Priority</label>
-        <input
-          id="priority"
-          type="number"
-          value={priority}
-          onChange={(e) => setPriority(e.target.value)}
-          disabled={saving}
-          style={{ width: '6rem' }}
-        />
-        <p className="dim" style={{ marginTop: '0.25rem', fontSize: '0.8rem' }}>
-          Higher wins when multiple wires could match the same inbound.
-        </p>
-      </div>
-
-      <div className="actions">
-        <button type="button" className="secondary" onClick={onCancel} disabled={saving}>
-          Cancel
-        </button>
-        <button type="submit" disabled={saving}>
-          {saving ? 'Saving…' : 'Save'}
-        </button>
-      </div>
-    </form>
   );
 }

--- a/web/ui/src/routes/MessagingGroupDetail.tsx
+++ b/web/ui/src/routes/MessagingGroupDetail.tsx
@@ -290,6 +290,12 @@ export function MessagingGroupDetail() {
                   )}{' '}
                   · senders <code>{wa.senderScope}</code> · ignored <code>{wa.ignoredMessagePolicy}</code>
                 </span>
+                <Link
+                  to={`/channels/mga/${encodeURIComponent(wa.messagingGroupAgentId)}`}
+                  style={{ marginLeft: 'auto' }}
+                >
+                  Routing rules →
+                </Link>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

PR3 of the 4-PR phase plan from design doc #75. Lands the per-MGA (messaging-group ↔ agent-group wire) detail page, the home of the routing-rules editor: engage mode, sender scope, ignored-policy, priority, and hard-delete.

PR2 (#79) gave us `/channels/mg/:id` as the per-messaging-group surface. This PR adds the matching `/channels/mga/:id` per-wire surface, completes the disambiguation that lets both URLs coexist without a discriminator query param, and rewires both ChannelsList and MessagingGroupDetail to link into the new route.

## Commit breakdown

1. **`feat(channels): per-MGA route on /api/channels/mga/:id`** — server. Replaces the old single-segment `/api/channels/:id` matcher with `/api/channels/mga/:id`; adds GET; applies the same same-connection re-fetch cleanup pattern PR2 introduced; 405 on unsupported methods; updates the stale collision test in `channels-mg-detail.test.ts` to match the new shape; adds a fresh `channels-mga-detail.test.ts` with full DB-shape round-trip translation.
2. **`feat(web/ui): channel-wire api helpers on /channels/mga/:id`** — api-client. Adds `getChannelWireDetail(id)` and migrates `updateChannelWire` + `deleteChannelWire` to the prefixed path. Pinned with new tests in `api.test.ts`.
3. **`feat(web/ui): per-MGA detail page + nav rewires`** — UI. New `ChannelWireDetail.tsx` route + tests; ChannelsList drops its inline editor in favor of "Routing rules →" + "Group settings →" links; MessagingGroupDetail's wired-agents list links each row to its wire. Bumps to `0.0.14-rc.31`.

## Aaron's "respond only to mentions" ask

The first radio in the engage-mode editor is **"Only when mentioned"**, surfacing `engageMode='mention'` as the canonical UX answer for the request that motivated PR3.

## Spec drift acknowledged

- The actual schema is `engage_mode = 'pattern' | 'mention' | 'mention-sticky'`, not the `'mention_only'` token in the original brief. The server collapses `mention-sticky` to `'mention'` for display and **preserves it on PATCH** so a future sticky-aware editor doesn't silently downgrade existing wires. Tests pin both the lossy display and the preservation invariant.
- The `pattern + '.'` sentinel collapses to `engageMode: 'all'` on the API surface (covered in tests).
- No `last_engaged_at` field on this surface yet — tracked in #81.
- Type duplication of `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` between server and client is tracked in #80.

## Backwards compatibility

Confirmed only `web/ui` calls the channels HTTP endpoints — MCP tools (`src/mcp/tools/channels.ts`) call DB helpers directly via imports from `db/agent-groups.js` and `db/connection.js`, no `fetch`. Clean migration, no shim needed.

## Test plan

- [x] Host typecheck (`pnpm exec tsc --noEmit`) — clean
- [x] Host tests (`pnpm test`) — 455/455
- [x] web/ui typecheck — clean
- [x] web/ui tests (`pnpm test --run`) — 43/43
- [x] web/ui build — green; `verify-base` confirms `/claw/`-prefixed assets
- [x] Prettier `format:check` (auto via husky pre-commit on all three commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)