### PR TITLE
feat: three-button approval card — Approve & always allow (paraclaw#67 PR4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.31",
+  "version": "0.0.14-rc.32",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -16,7 +16,12 @@
  * access gate is not registered and core defaults to allow-all.
  */
 import { recordDroppedMessage } from '../../db/dropped-messages.js';
-import { createMessagingGroupAgent, setMessagingGroupDeniedAt } from '../../db/messaging-groups.js';
+import {
+  createMessagingGroupAgent,
+  getMessagingGroup,
+  setMessagingGroupDeniedAt,
+  updateMessagingGroup,
+} from '../../db/messaging-groups.js';
 import {
   routeInbound,
   setAccessGate,
@@ -217,7 +222,8 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
     return true; // claim the response so it's not unclaimed-logged, but do nothing
   }
   const approverId = clickerId;
-  const approved = payload.value === 'approve';
+  const alsoAllow = payload.value === 'approve_and_allow';
+  const approved = payload.value === 'approve' || alsoAllow;
 
   if (approved) {
     addMember({
@@ -232,6 +238,26 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
       agentGroupId: row.agent_group_id,
       approverId,
     });
+
+    if (alsoAllow) {
+      // Snapshot the prior policy for the audit line — read before the
+      // update so the "fromPolicy" field reflects pre-flip state even if
+      // a concurrent click had already flipped it.
+      const mg = getMessagingGroup(row.messaging_group_id);
+      const fromPolicy = mg?.unknown_sender_policy ?? null;
+      if (fromPolicy !== 'public') {
+        updateMessagingGroup(row.messaging_group_id, { unknown_sender_policy: 'public' });
+      }
+      log.info('Unknown-sender policy flipped to public via approval card', {
+        audit: 'sender_approval_policy_flip',
+        approvalId: row.id,
+        messagingGroupId: row.messaging_group_id,
+        agentGroupId: row.agent_group_id,
+        approverId,
+        fromPolicy,
+        toPolicy: 'public',
+      });
+    }
 
     // Clear the pending row BEFORE re-routing so the gate check on the
     // second attempt doesn't see the in-flight row and short-circuit.

--- a/src/modules/permissions/index.ts
+++ b/src/modules/permissions/index.ts
@@ -242,7 +242,9 @@ async function handleSenderApprovalResponse(payload: ResponsePayload): Promise<b
     if (alsoAllow) {
       // Snapshot the prior policy for the audit line — read before the
       // update so the "fromPolicy" field reflects pre-flip state even if
-      // a concurrent click had already flipped it.
+      // a concurrent click had already flipped it. fromPolicy=null means
+      // the MG row was deleted between approval-creation and click; the
+      // updateMessagingGroup call below silently no-ops on a missing row.
       const mg = getMessagingGroup(row.messaging_group_id);
       const fromPolicy = mg?.unknown_sender_policy ?? null;
       if (fromPolicy !== 'public') {

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -325,6 +325,65 @@ describe('unknown-sender request_approval flow', () => {
     infoSpy.mockRestore();
   });
 
+  it('approve_and_allow → idempotent on already-public MG, audit still fires with fromPolicy=public', async () => {
+    // Pre-flip the MG to public to simulate a second click after a prior
+    // always-allow has already happened. The button is shown unconditionally
+    // (Aaron's call) so this branch can fire even when policy is already
+    // public.
+    const { updateMessagingGroup, getMessagingGroup } = await import('../../db/messaging-groups.js');
+    updateMessagingGroup('mg-chat', { unknown_sender_policy: 'public' });
+
+    // With public policy, the access gate skips the unknown-sender flow —
+    // so we can't trigger the approval via routeInbound. Seed the pending
+    // row directly to exercise just the click handler. Upsert the sender
+    // user first so addMember's FK to users(id) holds.
+    upsertUser({ id: 'tg:later-stranger', kind: 'telegram', display_name: 'Later', created_at: now() });
+    const { createPendingSenderApproval } = await import('./db/pending-sender-approvals.js');
+    const approvalId = 'nsa-test-idempotent';
+    createPendingSenderApproval({
+      id: approvalId,
+      messaging_group_id: 'mg-chat',
+      agent_group_id: 'ag-1',
+      sender_identity: 'tg:later-stranger',
+      sender_name: 'Later',
+      original_message: JSON.stringify(stranger('hello again')),
+      approver_user_id: 'telegram:owner',
+      created_at: now(),
+      title: 'New sender',
+      options_json: '[]',
+    });
+
+    const { log } = await import('../../log.js');
+    const infoSpy = vi.spyOn(log, 'info');
+
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: approvalId,
+        value: 'approve_and_allow',
+        userId: 'owner',
+        channelType: 'telegram',
+        platformId: 'dm-owner',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    // Policy stays public (no regression).
+    expect(getMessagingGroup('mg-chat')?.unknown_sender_policy).toBe('public');
+
+    // Audit log fires with fromPolicy='public' so the click is traceable
+    // even when the DB write was a no-op.
+    const auditCalls = infoSpy.mock.calls.filter(([, data]) => {
+      return typeof data === 'object' && data !== null && (data as { audit?: string }).audit === 'sender_approval_policy_flip';
+    });
+    expect(auditCalls).toHaveLength(1);
+    const [, auditFields] = auditCalls[0] as [string, Record<string, unknown>];
+    expect(auditFields).toMatchObject({ fromPolicy: 'public', toPolicy: 'public' });
+
+    infoSpy.mockRestore();
+  });
+
   it('rejects clicks from an unauthorized user (prevents self-admit via forwarded card)', async () => {
     // Stranger triggers the approval flow; card goes to the owner.
     const { routeInbound } = await import('../../router.js');

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -262,6 +262,69 @@ describe('unknown-sender request_approval flow', () => {
     expect(member).toBeUndefined();
   });
 
+  it('approve_and_allow → admits the sender, flips MG policy to public, and emits an audit log', async () => {
+    const { routeInbound } = await import('../../router.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+    const { getMessagingGroup } = await import('../../db/messaging-groups.js');
+    const { log } = await import('../../log.js');
+
+    const infoSpy = vi.spyOn(log, 'info');
+
+    await routeInbound(stranger('let everyone in'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const { getDb } = await import('../../db/connection.js');
+    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    expect(pending).toBeDefined();
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: pending.id,
+        value: 'approve_and_allow',
+        userId: 'owner',
+        channelType: 'telegram',
+        platformId: 'dm-owner',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    // Sender admitted (same as 'approve' branch).
+    const member = getDb()
+      .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
+      .get('tg:stranger', 'ag-1');
+    expect(member).toBeDefined();
+
+    // MG flipped to public so future strangers skip the gate.
+    const mg = getMessagingGroup('mg-chat');
+    expect(mg?.unknown_sender_policy).toBe('public');
+
+    // Audit log entry includes operator + MG + before-state for traceability.
+    const auditCalls = infoSpy.mock.calls.filter(([, data]) => {
+      return (
+        typeof data === 'object' &&
+        data !== null &&
+        (data as { audit?: string }).audit === 'sender_approval_policy_flip'
+      );
+    });
+    expect(auditCalls).toHaveLength(1);
+    const [, auditFields] = auditCalls[0] as [string, Record<string, unknown>];
+    expect(auditFields).toMatchObject({
+      messagingGroupId: 'mg-chat',
+      agentGroupId: 'ag-1',
+      approverId: 'telegram:owner',
+      fromPolicy: 'request_approval',
+      toPolicy: 'public',
+    });
+
+    // Pending row cleared.
+    const stillPending = (getDb().prepare('SELECT COUNT(*) AS c FROM pending_sender_approvals').get() as { c: number })
+      .c;
+    expect(stillPending).toBe(0);
+
+    infoSpy.mockRestore();
+  });
+
   it('rejects clicks from an unauthorized user (prevents self-admit via forwarded card)', async () => {
     // Stranger triggers the approval flow; card goes to the owner.
     const { routeInbound } = await import('../../router.js');

--- a/src/modules/permissions/sender-approval.ts
+++ b/src/modules/permissions/sender-approval.ts
@@ -35,8 +35,15 @@ import type { InboundEvent } from '../../channels/adapter.js';
 import { appendFallbackNotice, pickApprovalDelivery, pickApprover } from '../approvals/primitive.js';
 import { createPendingSenderApproval, hasInFlightSenderApproval } from './db/pending-sender-approvals.js';
 
+// Three-button card per design doc PR #75 phase 4. The "always allow" branch
+// flips the messaging group's unknown_sender_policy to 'public' so future
+// strangers walk through with no gate. Shown unconditionally — even on
+// 'strict' MGs that wouldn't normally render this card — so the operator can
+// recover from a too-restrictive default with one click. The handler short-
+// circuits if the policy is already 'public', so the click is idempotent.
 const APPROVAL_OPTIONS: RawOption[] = [
   { label: 'Allow', selectedLabel: '✅ Allowed', value: 'approve' },
+  { label: 'Allow & open channel', selectedLabel: '✅ Channel opened', value: 'approve_and_allow' },
   { label: 'Deny', selectedLabel: '❌ Denied', value: 'reject' },
 ];
 
@@ -154,4 +161,5 @@ export async function requestSenderApproval(input: RequestSenderApprovalInput): 
  * response handler so the two sides can't drift.
  */
 export const APPROVE_VALUE = 'approve';
+export const APPROVE_AND_ALLOW_VALUE = 'approve_and_allow';
 export const REJECT_VALUE = 'reject';


### PR DESCRIPTION
## Summary

Final PR in the channel-policy phase plan ([design doc PR #75](https://github.com/ParachuteComputer/paraclaw/pull/75)). Adds a third button to the unknown-sender approval card so the operator can admit one stranger AND open the channel for everyone in a single click.

- New option **Allow & open channel** on the sender-approval card (between Allow and Deny)
- Click handler: `addMember` (existing approve invariant) + flip `messaging_groups.unknown_sender_policy = 'public'` (new) + replay event
- Audit log line tagged `audit: 'sender_approval_policy_flip'` carrying operator + MG + agent group + before-state policy
- Idempotent: already-public MGs skip the write
- Aaron's call: button is **always** rendered, regardless of MG's current policy — gives the operator a one-click recovery from a too-restrictive default

## Cross-PR shape

- PR1 [#76](https://github.com/ParachuteComputer/paraclaw/pull/76) — DB migration + view shapes (merged)
- PR2 [#79](https://github.com/ParachuteComputer/paraclaw/pull/79) — `/channels/mg/:id` policy editor + `updateMessagingGroup` helper (merged)
- PR3 [#82](https://github.com/ParachuteComputer/paraclaw/pull/82) — `/channels/mga/:id` per-wire detail (merged)
- **PR4 (this)** — three-button approval card

PR4 reuses PR2's `updateMessagingGroup` helper. The web seam (`channels.ts mg/:id PATCH`) wraps it with auth + validation; calling it from inside an authorized response handler is the same trust boundary, no auth-seam baggage.

## Why log.info instead of a new audit table

Paraclaw doesn't have an audit-log table yet. The lightest viable surface is structured `log.info` with an `audit` discriminator field — same shape as existing audit-style entries (sender admit, channel denial). The field is greppable should we ever materialize a table.

## Files

- `src/modules/permissions/sender-approval.ts` — option array + `APPROVE_AND_ALLOW_VALUE` export
- `src/modules/permissions/index.ts` — handler branch (member + replay + policy flip + audit log)
- `src/modules/permissions/sender-approval.test.ts` — happy-path test asserting member + flip + audit + pending cleared

## Gates

- `pnpm test` — 458 passed (51 files); +1 net vs. main (`approve_and_allow` test)
- `pnpm exec tsc --noEmit` — clean
- `pnpm run build` — clean
- `pnpm exec prettier --check src/**/*.ts` — clean

## Test plan

- [ ] Reviewer: confirm the audit-log field set covers the operator + MG + before-state ask
- [ ] Reviewer: confirm reusing `updateMessagingGroup` (not adding a wrapping `setUnknownSenderPolicy`) is the right call
- [ ] Reviewer: any additional test? deny path is unchanged but I didn't add a regression test for "deny still works alongside the new option"

🤖 Generated with [Claude Code](https://claude.com/claude-code)