### PR TITLE
feat: wire web/ui SPA build into pnpm install chain (paraclaw#85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,10 @@ const cb       = `${window.location.origin}${import.meta.env.BASE_URL}oauth/call
 
 The server-side mirror lives in `web/server/src/server.ts`: `MOUNT` (from `PARACLAW_WEB_MOUNT`) is stripped uniformly before dispatch so `/api/*` and static-serve both see paths without the prefix.
 
+### SPA build is wired into install
+
+`web/ui/dist/` is gitignored. The root `package.json` runs `build:spa` from a `postinstall` hook so a fresh `pnpm install` produces a working `/claw/*` without a manual rebuild step. If `static-serve` 503s with "UI bundle not found", the install most likely fired with `--ignore-scripts` (which suppresses `postinstall` lifecycle hooks) — fall back to `pnpm run build:spa` to rebuild manually.
+
 ## CJK font support
 
 Agent containers ship without CJK fonts by default (~200MB saved). If you notice signals the user works with Chinese/Japanese/Korean content — conversing in CJK, CJK timezone (e.g., `Asia/Tokyo`, `Asia/Shanghai`, `Asia/Seoul`, `Asia/Taipei`, `Asia/Hong_Kong`), system locale hint, or mentions of needing to render CJK in screenshots/PDFs/scraped pages — offer to enable it:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,12 @@ Test your contribution on a fresh clone before submitting. For skills, run the s
 
 ### web/ui test harness
 
-The frontend bundle in `web/ui/` is intentionally outside the pnpm workspace (the `web:build` script uses `--ignore-workspace`), so a root-level `pnpm install` does **not** populate `web/ui/node_modules`. If you're running web/ui tests, install its deps first:
+The frontend bundle in `web/ui/` is intentionally outside the pnpm workspace (the `build:spa` script uses `--ignore-workspace`). A root-level `pnpm install` populates `web/ui/node_modules` and builds `web/ui/dist/` automatically via the `postinstall` hook — usually no extra step is needed.
+
+If you ran `pnpm install --ignore-scripts` (the postinstall is suppressed), or you want to run web/ui tests on their own, install its deps and run the test runner directly:
 
 ```bash
-cd web/ui && pnpm install --ignore-workspace && pnpm test
+cd web/ui && pnpm install --frozen-lockfile --ignore-workspace && pnpm test
 ```
 
 Otherwise the test runner exits with a missing-dependency error (the exact symptom — module-not-found on `@vitejs/plugin-react`, missing test framework, etc. — depends on which entry point your package manager hits first).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.33",
+  "version": "0.0.14-rc.34",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
@@ -15,7 +15,8 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "prepare": "husky",
     "parachute": "bun scripts/parachute.ts",
-    "web:build": "cd web/ui && pnpm install --ignore-workspace && pnpm build",
+    "build:spa": "cd web/ui && pnpm install --frozen-lockfile --ignore-workspace && pnpm build",
+    "postinstall": "if [ -d web/ui ]; then pnpm run build:spa; fi",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Closes #85. Mirrors hub PR #163 (commit 93096f5): wire a `postinstall` hook that runs the SPA build so a fresh `pnpm install` at the repo root produces a working `/claw/*` UI without the manual `pnpm web:build` step Aaron hit during the paraclaw#78 live test.

- `build:spa`: `cd web/ui && pnpm install --frozen-lockfile --ignore-workspace && pnpm build` (renamed from `web:build`; only one in-tree reference, both in `package.json`)
- `postinstall`: `if [ -d web/ui ]; then pnpm run build:spa; fi` — the existence check lets stripped checkouts (CI-only `src/` worktrees) install without failing
- `CLAUDE.md` `Web UI` section: brief paragraph noting that `--ignore-scripts` is the most likely cause when `static-serve` 503s with "UI bundle not found" + manual fallback

No `prepack` / `files` array — paraclaw is a clone-and-run repo, not an npm package, so the publish lifecycle isn't relevant.

## Differences from hub#163

| | hub | paraclaw |
|---|---|---|
| pkg manager | bun | pnpm |
| published to npm | yes (`@openparachute/hub`) | no (clone + `pnpm install`) |
| `prepack` | yes | omitted |
| `files` array | yes (adds `web/ui/dist`) | omitted |
| frozen-lockfile | `bun install --frozen-lockfile` | `pnpm install --frozen-lockfile --ignore-workspace` (web/ui isn't a workspace member) |

## Verification

Two fresh-clone tests against the branch:

1. **`pnpm install` (default)** — postinstall fires automatically, builds run, `web/ui/dist/{index.html,assets/}` exist after install completes. Output snippet:
   ```
   . postinstall: vite v6.4.2 building for production...
   . postinstall: ✓ 76 modules transformed.
   . postinstall: dist/index.html                   0.50 kB
   . postinstall: dist/assets/index-DUvm8py6.js   395.82 kB
   . postinstall: verify-base: ✓ dist/index.html references /claw/-prefixed assets.
   ```
2. **`pnpm install --ignore-scripts`** — postinstall correctly skipped, `web/ui/dist` not created. Manual fallback `pnpm run build:spa` then succeeds.

No infinite loop: `web/ui/package.json` has no `postinstall` of its own, and `--frozen-lockfile` keeps the inner pnpm from re-resolving.

## Gates

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 476/476 (host vitest)
- [x] `pnpm format:check` — clean for diff (2 pre-existing warnings on `sender-approval.test.ts` + `channels.ts` are unrelated branch drift)

## Patterns check

This PR is the install-side mirror of [parachute-patterns/patterns/spa-build-into-install-chain.md] — the canonical name `build:spa`, the existence-checked `postinstall`, the gitignored `dist/` rebuilt at install time. Follows the pattern hub already adopted; doesn't change it.

## Test plan

- [ ] After merge: pull main on Aaron's live install, confirm `pnpm install` (no extra steps) leaves `web/ui/dist/` populated, restart paraclaw, confirm `/claw/` loads in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)