### PR TITLE
feat: per-agent-group provider override (paraclaw#86)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.34",
+  "version": "0.0.14-rc.35",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -118,8 +118,8 @@ async function spawnContainer(session: Session): Promise<void> {
   const { provider, contribution } = resolveProviderContribution(session, agentGroup, containerConfig);
 
   // Resolve the chosen agent-provider credential source for this spawn
-  // (paraclaw#78). Phase 1 reads only the install-default scope; Phase 2
-  // will check the agent_group_id row first. Side effects (host file
+  // (paraclaw#78). Two-tier lookup (paraclaw#86): per-agent-group row
+  // wins over the install-wide default sentinel. Side effects (host file
   // re-read, fallback warnings) happen here once per spawn.
   const credentialsEnvelope = getProviderCredentialsForSpawn(agentGroup.id);
 

--- a/src/modules/provider-credentials/db.ts
+++ b/src/modules/provider-credentials/db.ts
@@ -62,7 +62,10 @@ export function readProviderCredentials(scopeId: string = DEFAULT_SCOPE_ID): Pro
 }
 
 export interface PutProviderCredentialsInput {
-  scopeId?: string;
+  // Required so a future caller can't silently overwrite the install-wide
+  // row by forgetting the scope. Pass `DEFAULT_SCOPE_ID` explicitly when
+  // you mean the install-wide credential.
+  scopeId: string;
   source: ProviderSource;
   apiKey?: string | null;
   serverUrl?: string | null;
@@ -74,7 +77,7 @@ export interface PutProviderCredentialsInput {
  * unchanged (caller-side merge — we read-modify-write).
  */
 export function putProviderCredentials(input: PutProviderCredentialsInput): void {
-  const scopeId = input.scopeId ?? DEFAULT_SCOPE_ID;
+  const { scopeId } = input;
   const existing = getProviderCredentialsRow(scopeId);
   const k = key();
   const api_key_encrypted =

--- a/src/modules/provider-credentials/spawn.test.ts
+++ b/src/modules/provider-credentials/spawn.test.ts
@@ -92,6 +92,68 @@ describe('getProviderCredentialsForSpawn', () => {
     expect(env.source).toBe('external_server');
     expect(env.env).toEqual({});
   });
+
+  it('per-group override wins over default (paraclaw#86)', async () => {
+    const { putProviderCredentials } = await import('./db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    putProviderCredentials({
+      scopeId: 'ag-special',
+      source: 'external_server',
+      apiKey: 'override-key',
+      serverUrl: 'https://override.test',
+    });
+
+    const { getProviderCredentialsForSpawn } = await import('./spawn.js');
+    const env = getProviderCredentialsForSpawn('ag-special');
+    expect(env.source).toBe('external_server');
+    expect(env.resolvedScope).toBe('group');
+    expect(env.env).toEqual({
+      ANTHROPIC_API_KEY: 'override-key',
+      ANTHROPIC_BASE_URL: 'https://override.test',
+    });
+  });
+
+  it('falls back to default when no per-group override exists (paraclaw#86)', async () => {
+    const { putProviderCredentials } = await import('./db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+
+    const { getProviderCredentialsForSpawn } = await import('./spawn.js');
+    const env = getProviderCredentialsForSpawn('ag-no-override');
+    expect(env.source).toBe('anthropic_api_key');
+    expect(env.resolvedScope).toBe('default');
+    expect(env.env).toEqual({ ANTHROPIC_API_KEY: 'install-default-key' });
+  });
+
+  it("one group's override does not leak into another group (paraclaw#86)", async () => {
+    const { putProviderCredentials } = await import('./db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    putProviderCredentials({
+      scopeId: 'ag-private',
+      source: 'claude_setup_token',
+      apiKey: 'sk-ant-oat01-private',
+    });
+
+    const { getProviderCredentialsForSpawn } = await import('./spawn.js');
+    const privateEnv = getProviderCredentialsForSpawn('ag-private');
+    expect(privateEnv.resolvedScope).toBe('group');
+    expect(privateEnv.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-private' });
+
+    const otherEnv = getProviderCredentialsForSpawn('ag-other');
+    expect(otherEnv.resolvedScope).toBe('default');
+    expect(otherEnv.env).toEqual({ ANTHROPIC_API_KEY: 'install-default-key' });
+  });
+
+  it('group override with empty secret slot still wins (paraclaw#86)', async () => {
+    const { putProviderCredentials } = await import('./db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    putProviderCredentials({ scopeId: 'ag-broken', source: 'claude_setup_token', apiKey: null });
+
+    const { getProviderCredentialsForSpawn } = await import('./spawn.js');
+    const env = getProviderCredentialsForSpawn('ag-broken');
+    expect(env.source).toBe('claude_setup_token');
+    expect(env.resolvedScope).toBe('group');
+    expect(env.env).toEqual({});
+  });
 });
 
 describe('provider_credentials db round-trip', () => {

--- a/src/modules/provider-credentials/spawn.test.ts
+++ b/src/modules/provider-credentials/spawn.test.ts
@@ -32,8 +32,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('claude_setup_token → injects CLAUDE_CODE_OAUTH_TOKEN env, suppresses ANTHROPIC_API_KEY + ANTHROPIC_AUTH_TOKEN', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'claude_setup_token', apiKey: 'sk-ant-oat01-paste' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'claude_setup_token', apiKey: 'sk-ant-oat01-paste' });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
     const env = getProviderCredentialsForSpawn('ag-1');
@@ -45,8 +45,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('claude_setup_token → empty env when token missing', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'claude_setup_token', apiKey: null });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'claude_setup_token', apiKey: null });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
     const env = getProviderCredentialsForSpawn('ag-1');
@@ -55,8 +55,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('anthropic_api_key → injects ANTHROPIC_API_KEY env, no files, no suppress', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'sk-ant-api03-test' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'sk-ant-api03-test' });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
     const env = getProviderCredentialsForSpawn('ag-1');
@@ -67,8 +67,9 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('external_server → injects ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL', async () => {
-    const { putProviderCredentials } = await import('./db.js');
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
     putProviderCredentials({
+      scopeId: DEFAULT_SCOPE_ID,
       source: 'external_server',
       apiKey: 'or-key',
       serverUrl: 'https://openrouter.ai/api/v1',
@@ -84,8 +85,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('external_server → empty env when key or url missing', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'external_server', apiKey: 'or-key', serverUrl: null });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'external_server', apiKey: 'or-key', serverUrl: null });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
     const env = getProviderCredentialsForSpawn('ag-1');
@@ -94,8 +95,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('per-group override wins over default (paraclaw#86)', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
     putProviderCredentials({
       scopeId: 'ag-special',
       source: 'external_server',
@@ -114,8 +115,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('falls back to default when no per-group override exists (paraclaw#86)', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
     const env = getProviderCredentialsForSpawn('ag-no-override');
@@ -125,8 +126,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it("one group's override does not leak into another group (paraclaw#86)", async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
     putProviderCredentials({
       scopeId: 'ag-private',
       source: 'claude_setup_token',
@@ -144,8 +145,8 @@ describe('getProviderCredentialsForSpawn', () => {
   });
 
   it('group override with empty secret slot still wins (paraclaw#86)', async () => {
-    const { putProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
     putProviderCredentials({ scopeId: 'ag-broken', source: 'claude_setup_token', apiKey: null });
 
     const { getProviderCredentialsForSpawn } = await import('./spawn.js');
@@ -167,8 +168,10 @@ describe('provider_credentials db round-trip', () => {
   });
 
   it('encrypts api_key at rest, decrypts on read', async () => {
-    const { putProviderCredentials, readProviderCredentials, getProviderCredentialsRow } = await import('./db.js');
+    const { putProviderCredentials, readProviderCredentials, getProviderCredentialsRow, DEFAULT_SCOPE_ID } =
+      await import('./db.js');
     putProviderCredentials({
+      scopeId: DEFAULT_SCOPE_ID,
       source: 'anthropic_api_key',
       apiKey: 'sk-ant-api03-secret',
     });
@@ -182,15 +185,20 @@ describe('provider_credentials db round-trip', () => {
   });
 
   it('upsert preserves unspecified fields (undefined = no-op, null = clear)', async () => {
-    const { putProviderCredentials, readProviderCredentials } = await import('./db.js');
-    putProviderCredentials({ source: 'external_server', apiKey: 'k1', serverUrl: 'https://a.test' });
-    putProviderCredentials({ source: 'external_server', serverUrl: 'https://b.test' });
+    const { putProviderCredentials, readProviderCredentials, DEFAULT_SCOPE_ID } = await import('./db.js');
+    putProviderCredentials({
+      scopeId: DEFAULT_SCOPE_ID,
+      source: 'external_server',
+      apiKey: 'k1',
+      serverUrl: 'https://a.test',
+    });
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'external_server', serverUrl: 'https://b.test' });
 
     const plain = readProviderCredentials();
     expect(plain?.apiKey).toBe('k1');
     expect(plain?.serverUrl).toBe('https://b.test');
 
-    putProviderCredentials({ source: 'external_server', apiKey: null });
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'external_server', apiKey: null });
     const cleared = readProviderCredentials();
     expect(cleared?.apiKey).toBeNull();
     expect(cleared?.serverUrl).toBe('https://b.test');

--- a/src/modules/provider-credentials/spawn.ts
+++ b/src/modules/provider-credentials/spawn.ts
@@ -20,8 +20,11 @@
  *   - anthropic_api_key: env `ANTHROPIC_API_KEY=<plaintext>`.
  *   - external_server: env `ANTHROPIC_API_KEY=<plaintext>` + `ANTHROPIC_BASE_URL=<server_url>`.
  *
- * Phase 1 only consults the install-default scope (`__default__`). Phase 2
- * will check the agent_group_id row first and fall back to default.
+ * Two-tier resolution (paraclaw#86): if a row keyed by the spawn's
+ * `agentGroupId` exists, it wins; otherwise the install-wide default
+ * (`__default__`) row is used. A group row with the secret slot empty
+ * still wins — clear-the-override is a deliberate UI action that
+ * deletes the row, not one that blanks out the secret.
  */
 import { log } from '../../log.js';
 import { DEFAULT_SCOPE_ID, readProviderCredentials, type ProviderSource } from './db.js';
@@ -29,6 +32,8 @@ import { DEFAULT_SCOPE_ID, readProviderCredentials, type ProviderSource } from '
 export interface ProviderSpawnEnvelope {
   /** Source we resolved. `null` means no row + no auto-fallback — caller emits a warning. */
   source: ProviderSource | null;
+  /** Which scope the resolved row came from — `'group'` if the per-group override won, `'default'` if it fell back. */
+  resolvedScope: 'group' | 'default' | null;
   env: Record<string, string>;
   /** Filename → contents. Filenames are joined under the per-group `.claude-shared/` dir. */
   files: Record<string, string>;
@@ -37,30 +42,34 @@ export interface ProviderSpawnEnvelope {
 }
 
 /**
- * Resolve the spawn envelope for an agent group. `agentGroupId` is the
- * recipient — Phase 1 ignores it and reads the default scope. Pure of
+ * Resolve the spawn envelope for an agent group. Reads the per-group
+ * override first, then falls back to the install-wide default. Pure of
  * filesystem writes; the container-runner is the one that lays down
  * `files` on disk and threads `env` into spawn args.
  */
-export function getProviderCredentialsForSpawn(_agentGroupId: string): ProviderSpawnEnvelope {
+export function getProviderCredentialsForSpawn(agentGroupId: string): ProviderSpawnEnvelope {
   const empty: ProviderSpawnEnvelope = {
     source: null,
+    resolvedScope: null,
     env: {},
     files: {},
     suppressSecretEnvKeys: new Set(),
   };
 
-  const row = readProviderCredentials(DEFAULT_SCOPE_ID);
+  const groupRow = agentGroupId !== DEFAULT_SCOPE_ID ? readProviderCredentials(agentGroupId) : undefined;
+  const row = groupRow ?? readProviderCredentials(DEFAULT_SCOPE_ID);
+  const resolvedScope: 'group' | 'default' | null = groupRow ? 'group' : row ? 'default' : null;
   if (!row) return empty;
 
   switch (row.source) {
     case 'claude_setup_token': {
       if (!row.apiKey) {
-        log.warn('claude_setup_token selected but no token stored', { agentGroupId: _agentGroupId });
-        return { ...empty, source: 'claude_setup_token' };
+        log.warn('claude_setup_token selected but no token stored', { agentGroupId, resolvedScope });
+        return { ...empty, source: 'claude_setup_token', resolvedScope };
       }
       return {
         source: 'claude_setup_token',
+        resolvedScope,
         env: { CLAUDE_CODE_OAUTH_TOKEN: row.apiKey },
         files: {},
         // Claude Code's auth precedence: ANTHROPIC_AUTH_TOKEN and
@@ -72,11 +81,12 @@ export function getProviderCredentialsForSpawn(_agentGroupId: string): ProviderS
     }
     case 'anthropic_api_key': {
       if (!row.apiKey) {
-        log.warn('anthropic_api_key selected but no key stored', { agentGroupId: _agentGroupId });
-        return { ...empty, source: 'anthropic_api_key' };
+        log.warn('anthropic_api_key selected but no key stored', { agentGroupId, resolvedScope });
+        return { ...empty, source: 'anthropic_api_key', resolvedScope };
       }
       return {
         source: 'anthropic_api_key',
+        resolvedScope,
         env: { ANTHROPIC_API_KEY: row.apiKey },
         files: {},
         suppressSecretEnvKeys: new Set(),
@@ -85,14 +95,16 @@ export function getProviderCredentialsForSpawn(_agentGroupId: string): ProviderS
     case 'external_server': {
       if (!row.apiKey || !row.serverUrl) {
         log.warn('external_server selected but key or url missing', {
-          agentGroupId: _agentGroupId,
+          agentGroupId,
+          resolvedScope,
           hasKey: row.apiKey != null,
           hasUrl: row.serverUrl != null,
         });
-        return { ...empty, source: 'external_server' };
+        return { ...empty, source: 'external_server', resolvedScope };
       }
       return {
         source: 'external_server',
+        resolvedScope,
         env: { ANTHROPIC_API_KEY: row.apiKey, ANTHROPIC_BASE_URL: row.serverUrl },
         files: {},
         suppressSecretEnvKeys: new Set(),

--- a/src/web/routes/agent-provider.test.ts
+++ b/src/web/routes/agent-provider.test.ts
@@ -39,8 +39,9 @@ describe('readAgentProviderView', () => {
   });
 
   it('exposes only booleans for stored secrets — never the plaintext', async () => {
-    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('../../modules/provider-credentials/db.js');
     putProviderCredentials({
+      scopeId: DEFAULT_SCOPE_ID,
       source: 'anthropic_api_key',
       apiKey: 'sk-ant-api03-secret-do-not-leak',
     });
@@ -53,8 +54,8 @@ describe('readAgentProviderView', () => {
   });
 
   it('exposes setup-token presence as hasApiKey: true (single secret slot)', async () => {
-    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
-    putProviderCredentials({ source: 'claude_setup_token', apiKey: 'sk-ant-oat01-secret' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('../../modules/provider-credentials/db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'claude_setup_token', apiKey: 'sk-ant-oat01-secret' });
 
     const { readAgentProviderView } = await import('./agent-provider.js');
     const view = readAgentProviderView();
@@ -178,8 +179,8 @@ describe('setAgentProvider', () => {
 
 describe('per-group agent provider (paraclaw#86)', () => {
   it('readGroupAgentProviderView reports unoverridden + effective from default', async () => {
-    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('../../modules/provider-credentials/db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
 
     const { readGroupAgentProviderView } = await import('./agent-provider.js');
     const view = readGroupAgentProviderView('ag-no-override');
@@ -238,8 +239,8 @@ describe('per-group agent provider (paraclaw#86)', () => {
   });
 
   it('clearGroupAgentProvider deletes the override row + emits override_cleared audit', async () => {
-    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
-    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    const { putProviderCredentials, DEFAULT_SCOPE_ID } = await import('../../modules/provider-credentials/db.js');
+    putProviderCredentials({ scopeId: DEFAULT_SCOPE_ID, source: 'anthropic_api_key', apiKey: 'install-default-key' });
     putProviderCredentials({ scopeId: 'ag-x', source: 'claude_setup_token', apiKey: 'sk-ant-oat01-x' });
 
     const { log } = await import('../../log.js');

--- a/src/web/routes/agent-provider.test.ts
+++ b/src/web/routes/agent-provider.test.ts
@@ -175,3 +175,107 @@ describe('setAgentProvider', () => {
     expect(row?.serverUrl).toBeNull();
   });
 });
+
+describe('per-group agent provider (paraclaw#86)', () => {
+  it('readGroupAgentProviderView reports unoverridden + effective from default', async () => {
+    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+
+    const { readGroupAgentProviderView } = await import('./agent-provider.js');
+    const view = readGroupAgentProviderView('ag-no-override');
+    expect(view.overridden).toBe(false);
+    expect(view.override.source).toBeNull();
+    expect(view.override.hasApiKey).toBe(false);
+    expect(view.effective.source).toBe('anthropic_api_key');
+    expect(view.effective.hasApiKey).toBe(true);
+  });
+
+  it('setGroupAgentProvider stores under the group id, not the default sentinel', async () => {
+    const { setGroupAgentProvider } = await import('./agent-provider.js');
+    const result = setGroupAgentProvider(
+      { source: 'claude_setup_token', apiKey: '  sk-ant-oat01-group  ' },
+      'ag-special',
+      'telegram:7',
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.view.overridden).toBe(true);
+    expect(result.view.override.source).toBe('claude_setup_token');
+    expect(result.view.override.hasApiKey).toBe(true);
+    expect(result.view.effective.source).toBe('claude_setup_token');
+
+    const { readProviderCredentials } = await import('../../modules/provider-credentials/db.js');
+    const groupRow = readProviderCredentials('ag-special');
+    expect(groupRow?.apiKey).toBe('sk-ant-oat01-group');
+    const defaultRow = readProviderCredentials();
+    expect(defaultRow).toBeUndefined();
+  });
+
+  it('per-group audit emits agentGroupId and never the secret', async () => {
+    const { log } = await import('../../log.js');
+    const infoSpy = vi.spyOn(log, 'info').mockImplementation(() => {});
+
+    const { setGroupAgentProvider } = await import('./agent-provider.js');
+    const ok = setGroupAgentProvider(
+      { source: 'external_server', apiKey: 'or-key', serverUrl: 'https://openrouter.ai/api/v1' },
+      'ag-9',
+      'telegram:9',
+    );
+    expect(ok.ok).toBe(true);
+
+    const auditCalls = infoSpy.mock.calls.filter(
+      (c) => (c[1] as { audit?: string } | undefined)?.audit === 'agent_provider_source_changed',
+    );
+    expect(auditCalls).toHaveLength(1);
+    const [, payload] = auditCalls[0]!;
+    expect(payload).toMatchObject({
+      audit: 'agent_provider_source_changed',
+      agentGroupId: 'ag-9',
+      toSource: 'external_server',
+      actor: 'telegram:9',
+    });
+    expect(JSON.stringify(payload)).not.toContain('or-key');
+  });
+
+  it('clearGroupAgentProvider deletes the override row + emits override_cleared audit', async () => {
+    const { putProviderCredentials } = await import('../../modules/provider-credentials/db.js');
+    putProviderCredentials({ source: 'anthropic_api_key', apiKey: 'install-default-key' });
+    putProviderCredentials({ scopeId: 'ag-x', source: 'claude_setup_token', apiKey: 'sk-ant-oat01-x' });
+
+    const { log } = await import('../../log.js');
+    const infoSpy = vi.spyOn(log, 'info').mockImplementation(() => {});
+
+    const { clearGroupAgentProvider } = await import('./agent-provider.js');
+    const result = clearGroupAgentProvider('ag-x', 'telegram:1');
+    expect(result.cleared).toBe(true);
+    expect(result.view.overridden).toBe(false);
+    expect(result.view.effective.source).toBe('anthropic_api_key');
+
+    const { readProviderCredentials } = await import('../../modules/provider-credentials/db.js');
+    expect(readProviderCredentials('ag-x')).toBeUndefined();
+
+    const auditCalls = infoSpy.mock.calls.filter(
+      (c) => (c[1] as { audit?: string } | undefined)?.audit === 'agent_provider_override_cleared',
+    );
+    expect(auditCalls).toHaveLength(1);
+    expect(auditCalls[0]![1]).toMatchObject({
+      audit: 'agent_provider_override_cleared',
+      agentGroupId: 'ag-x',
+      fromSource: 'claude_setup_token',
+      actor: 'telegram:1',
+    });
+  });
+
+  it('clearGroupAgentProvider on unset row is idempotent — no audit, cleared:false', async () => {
+    const { log } = await import('../../log.js');
+    const infoSpy = vi.spyOn(log, 'info').mockImplementation(() => {});
+
+    const { clearGroupAgentProvider } = await import('./agent-provider.js');
+    const result = clearGroupAgentProvider('ag-nope', 'telegram:1');
+    expect(result.cleared).toBe(false);
+    const auditCalls = infoSpy.mock.calls.filter(
+      (c) => (c[1] as { audit?: string } | undefined)?.audit === 'agent_provider_override_cleared',
+    );
+    expect(auditCalls).toHaveLength(0);
+  });
+});

--- a/src/web/routes/agent-provider.ts
+++ b/src/web/routes/agent-provider.ts
@@ -1,7 +1,9 @@
 /**
  * `/api/settings/agent-provider` — read + write the install-wide
- * agent-provider credential source (paraclaw#78). Backs the
- * `/claw/settings/agent-provider` page.
+ * agent-provider credential source (paraclaw#78).
+ * `/api/groups/:folder/agent-provider` — per-agent-group override
+ * (paraclaw#86); same shape, scoped to the group's id. Both back the
+ * `/claw/settings/agent-provider` and `/claw/groups/<folder>` UIs.
  *
  * Three sources, all paste-only:
  *   - `claude_setup_token` — operator runs `claude setup-token` on a host
@@ -19,12 +21,15 @@
  *
  * Audit log: source changes emit `audit: 'agent_provider_source_changed'`
  * via structured `log.info`, mirroring the PR4 sender-approval pattern.
+ * Per-group changes carry an `agentGroupId` field; per-group clear emits
+ * `audit: 'agent_provider_override_cleared'`.
  */
 import http from 'node:http';
 
 import { log } from '../../log.js';
 import {
   DEFAULT_SCOPE_ID,
+  deleteProviderCredentials,
   putProviderCredentials,
   readProviderCredentials,
   type ProviderSource,
@@ -35,6 +40,21 @@ interface AgentProviderView {
   hasApiKey: boolean;
   serverUrl: string | null;
   updatedAt: string | null;
+}
+
+/**
+ * Per-group response shape: same fields as the install-wide view, plus
+ * `overridden` (true iff a row exists for this agent_group_id) and an
+ * `effective` snapshot of what spawn would actually use right now —
+ * either the override or the inherited default. The UI uses
+ * `overridden` to decide between "Override default" and "Clear
+ * override" affordances.
+ */
+export interface GroupAgentProviderView {
+  agentGroupId: string;
+  overridden: boolean;
+  override: AgentProviderView;
+  effective: AgentProviderView;
 }
 
 const json = (res: http.ServerResponse, status: number, body: unknown): void => {
@@ -51,13 +71,29 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
   return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
 }
 
-export function readAgentProviderView(): AgentProviderView {
-  const row = readProviderCredentials(DEFAULT_SCOPE_ID);
+function viewForScope(scopeId: string): AgentProviderView {
+  const row = readProviderCredentials(scopeId);
   return {
     source: row?.source ?? null,
     hasApiKey: !!row?.apiKey,
     serverUrl: row?.serverUrl ?? null,
     updatedAt: row?.updatedAt ?? null,
+  };
+}
+
+export function readAgentProviderView(): AgentProviderView {
+  return viewForScope(DEFAULT_SCOPE_ID);
+}
+
+export function readGroupAgentProviderView(agentGroupId: string): GroupAgentProviderView {
+  const overrideRow = readProviderCredentials(agentGroupId);
+  const override = viewForScope(agentGroupId);
+  const effective = overrideRow ? override : viewForScope(DEFAULT_SCOPE_ID);
+  return {
+    agentGroupId,
+    overridden: overrideRow != null,
+    override,
+    effective,
   };
 }
 
@@ -84,12 +120,58 @@ export function setAgentProvider(
   body: SetAgentProviderBody,
   actor: string | null,
 ): SetAgentProviderResult | SetAgentProviderError {
+  const result = applySetForScope(body, DEFAULT_SCOPE_ID, actor, null);
+  if (!result.ok) return result;
+  return { ok: true, view: readAgentProviderView() };
+}
+
+export interface SetGroupAgentProviderResult {
+  ok: true;
+  view: GroupAgentProviderView;
+}
+
+export function setGroupAgentProvider(
+  body: SetAgentProviderBody,
+  agentGroupId: string,
+  actor: string | null,
+): SetGroupAgentProviderResult | SetAgentProviderError {
+  const result = applySetForScope(body, agentGroupId, actor, agentGroupId);
+  if (!result.ok) return result;
+  return { ok: true, view: readGroupAgentProviderView(agentGroupId) };
+}
+
+export interface ClearGroupAgentProviderResult {
+  ok: true;
+  view: GroupAgentProviderView;
+  cleared: boolean;
+}
+
+export function clearGroupAgentProvider(agentGroupId: string, actor: string | null): ClearGroupAgentProviderResult {
+  const previous = readProviderCredentials(agentGroupId);
+  const cleared = deleteProviderCredentials(agentGroupId);
+  if (cleared) {
+    log.info('Agent-provider override cleared', {
+      audit: 'agent_provider_override_cleared',
+      agentGroupId,
+      fromSource: previous?.source ?? null,
+      actor,
+    });
+  }
+  return { ok: true, view: readGroupAgentProviderView(agentGroupId), cleared };
+}
+
+function applySetForScope(
+  body: SetAgentProviderBody,
+  scopeId: string,
+  actor: string | null,
+  agentGroupId: string | null,
+): { ok: true } | SetAgentProviderError {
   const { source, apiKey, serverUrl } = body;
   if (!source || !VALID_SOURCES.includes(source)) {
     return { ok: false, status: 400, message: `source must be one of ${VALID_SOURCES.join(', ')}` };
   }
 
-  const previous = readProviderCredentials(DEFAULT_SCOPE_ID);
+  const previous = readProviderCredentials(scopeId);
   const previousSource = previous?.source ?? null;
 
   switch (source) {
@@ -97,14 +179,14 @@ export function setAgentProvider(
       if (!apiKey || !apiKey.trim()) {
         return { ok: false, status: 400, message: 'apiKey is required for claude_setup_token' };
       }
-      putProviderCredentials({ source, apiKey: apiKey.trim(), serverUrl: null });
+      putProviderCredentials({ scopeId, source, apiKey: apiKey.trim(), serverUrl: null });
       break;
     }
     case 'anthropic_api_key': {
       if (!apiKey || !apiKey.trim()) {
         return { ok: false, status: 400, message: 'apiKey is required for anthropic_api_key' };
       }
-      putProviderCredentials({ source, apiKey: apiKey.trim(), serverUrl: null });
+      putProviderCredentials({ scopeId, source, apiKey: apiKey.trim(), serverUrl: null });
       break;
     }
     case 'external_server': {
@@ -120,6 +202,7 @@ export function setAgentProvider(
         return { ok: false, status: 400, message: 'serverUrl must be a valid URL' };
       }
       putProviderCredentials({
+        scopeId,
         source,
         apiKey: apiKey.trim(),
         serverUrl: serverUrl.trim(),
@@ -133,11 +216,12 @@ export function setAgentProvider(
     fromSource: previousSource,
     toSource: source,
     actor,
+    agentGroupId,
     // Don't log apiKey — that's the secret.
     hasServerUrl: source === 'external_server' && !!serverUrl,
   });
 
-  return { ok: true, view: readAgentProviderView() };
+  return { ok: true };
 }
 
 export interface AgentProviderRouteContext {
@@ -175,4 +259,51 @@ export async function handleAgentProviderRoute(ctx: AgentProviderRouteContext): 
   }
   error(res, 405, `${method} not allowed`);
   return true;
+}
+
+export interface GroupAgentProviderRouteContext {
+  method: string;
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  agentGroupId: string;
+  actorSubject: string | null;
+}
+
+/**
+ * Per-group agent-provider sub-route. Mounted under
+ * `/api/groups/:folder/agent-provider`; the caller has already resolved
+ * folder → agentGroupId and gated on the right `claw:*` scope.
+ *
+ *   - GET    → `GroupAgentProviderView` (override + effective + flag)
+ *   - POST   → set / replace the override
+ *   - DELETE → clear the override (idempotent — 200 either way)
+ */
+export async function handleGroupAgentProviderRoute(ctx: GroupAgentProviderRouteContext): Promise<void> {
+  const { method, req, res, agentGroupId, actorSubject } = ctx;
+  if (method === 'GET') {
+    json(res, 200, readGroupAgentProviderView(agentGroupId));
+    return;
+  }
+  if (method === 'POST') {
+    let body: SetAgentProviderBody;
+    try {
+      body = await readJsonBody<SetAgentProviderBody>(req);
+    } catch {
+      error(res, 400, 'invalid JSON body');
+      return;
+    }
+    const result = setGroupAgentProvider(body, agentGroupId, actorSubject);
+    if (!result.ok) {
+      error(res, result.status, result.message);
+      return;
+    }
+    json(res, 200, result.view);
+    return;
+  }
+  if (method === 'DELETE') {
+    const result = clearGroupAgentProvider(agentGroupId, actorSubject);
+    json(res, 200, result.view);
+    return;
+  }
+  error(res, 405, `${method} not allowed`);
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -60,7 +60,7 @@ import { handleOauthProvidersRoute } from './routes/oauth-providers.js';
 import { handleSecretsRoute } from './routes/secrets.js';
 import { handleSessionsRoute } from './routes/sessions.js';
 import { handleSettingsRoute } from './routes/settings.js';
-import { handleAgentProviderRoute } from './routes/agent-provider.js';
+import { handleAgentProviderRoute, handleGroupAgentProviderRoute } from './routes/agent-provider.js';
 import { handleSetupStatusRoute } from './routes/setup-status.js';
 import { handleVaultsRoute } from './routes/vaults.js';
 import { forwardToVault, mintVaultTokenHttp } from './vault-proxy.js';
@@ -589,7 +589,16 @@ async function handleApi(
     const folder = decodeURIComponent(groupRoute[1]);
     const sub = groupRoute[2] ?? '';
 
-    const requiredScope: ClawScope = sub === '' && method === 'GET' ? SCOPE_CLAW_READ : SCOPE_CLAW_WRITE;
+    // Reads at the group root + the agent-provider subroute go through
+    // claw:read; writes default to claw:write; agent-provider writes
+    // (paraclaw#86) bump to claw:admin since they store API keys.
+    const isAgentProviderSub = sub === '/agent-provider';
+    const requiredScope: ClawScope =
+      method === 'GET' && (sub === '' || isAgentProviderSub)
+        ? SCOPE_CLAW_READ
+        : isAgentProviderSub
+          ? SCOPE_CLAW_ADMIN
+          : SCOPE_CLAW_WRITE;
     if (!(await gate(req, res, requiredScope))) return;
 
     const group = getAgentGroup(folder);
@@ -828,6 +837,23 @@ async function handleApi(
         detachVaultFromGroup(folder, mcpName);
         const updated = getAgentGroup(folder);
         json(res, 200, { group: updated, revokedTokenId, revokeError });
+      } catch (err) {
+        error(res, 500, err instanceof Error ? err.message : String(err));
+      }
+      return;
+    }
+
+    if (sub === '/agent-provider') {
+      const auth = await authenticate(req.headers.authorization, requiredScope);
+      const actorSubject = auth.ok ? (auth.claims.sub ?? null) : null;
+      try {
+        await handleGroupAgentProviderRoute({
+          method,
+          req,
+          res,
+          agentGroupId: group.id,
+          actorSubject,
+        });
       } catch (err) {
         error(res, 500, err instanceof Error ? err.message : String(err));
       }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -599,7 +599,14 @@ async function handleApi(
         : isAgentProviderSub
           ? SCOPE_CLAW_ADMIN
           : SCOPE_CLAW_WRITE;
-    if (!(await gate(req, res, requiredScope))) return;
+    // Authenticate once; capture sub so the agent-provider sub-route's
+    // audit log doesn't have to re-decode the JWT.
+    const auth = await authenticate(req.headers.authorization, requiredScope);
+    if (!auth.ok) {
+      send401or403(res, auth);
+      return;
+    }
+    const actorSubject = auth.claims.sub ?? null;
 
     const group = getAgentGroup(folder);
     if (!group) {
@@ -844,8 +851,10 @@ async function handleApi(
     }
 
     if (sub === '/agent-provider') {
-      const auth = await authenticate(req.headers.authorization, requiredScope);
-      const actorSubject = auth.ok ? (auth.claims.sub ?? null) : null;
+      // Group existence (folder → agent_group) was validated by `getAgentGroup`
+      // upstream — by the time we get here `group` is non-null, so the
+      // sub-route handler can assume the agent group id is real and 404
+      // semantics for unknown folders are already handled.
       try {
         await handleGroupAgentProviderRoute({
           method,

--- a/web/ui/src/components/AgentProviderCards.tsx
+++ b/web/ui/src/components/AgentProviderCards.tsx
@@ -1,0 +1,220 @@
+/**
+ * Three paste-only agent-provider cards reused at install-wide
+ * (`/settings/agent-provider`) and per-group (`/groups/<folder>`)
+ * scopes. Each card consumes the same `AgentProviderView` shape and
+ * fires `onSubmit` with the matching `SetAgentProviderInput` slice.
+ *
+ * The card never displays the secret — it accepts a paste and
+ * forwards it to the caller, which writes through the encrypted
+ * provider-credentials store. `view.hasApiKey` is a boolean only.
+ */
+import { useState } from 'react';
+
+import type { AgentProviderSource, AgentProviderView } from '../lib/api.ts';
+
+interface CardProps {
+  active: boolean;
+  title: string;
+  children: React.ReactNode;
+}
+
+function Card({ active, title, children }: CardProps) {
+  return (
+    <div
+      style={{
+        background: 'white',
+        border: active ? '2px solid var(--accent, #2563eb)' : '1px solid var(--border)',
+        borderRadius: '8px',
+        padding: '1rem 1.25rem',
+        marginBottom: '0.75rem',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <strong>{title}</strong>
+        {active && <span className="tag">active</span>}
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>{children}</div>
+    </div>
+  );
+}
+
+interface SubmitInput {
+  source: AgentProviderSource;
+  apiKey?: string;
+  serverUrl?: string;
+}
+
+interface AgentProviderCardsProps {
+  view: AgentProviderView;
+  busy: boolean;
+  onSubmit: (input: SubmitInput) => void;
+}
+
+export function AgentProviderCards({ view, busy, onSubmit }: AgentProviderCardsProps) {
+  return (
+    <>
+      <ClaudeSetupTokenCard
+        view={view}
+        busy={busy}
+        onSubmit={(apiKey) => onSubmit({ source: 'claude_setup_token', apiKey })}
+      />
+      <ApiKeyCard view={view} busy={busy} onSubmit={(apiKey) => onSubmit({ source: 'anthropic_api_key', apiKey })} />
+      <ExternalServerCard
+        view={view}
+        busy={busy}
+        onSubmit={(apiKey, serverUrl) => onSubmit({ source: 'external_server', apiKey, serverUrl })}
+      />
+    </>
+  );
+}
+
+function ClaudeSetupTokenCard({
+  view,
+  busy,
+  onSubmit,
+}: {
+  view: AgentProviderView;
+  busy: boolean;
+  onSubmit: (apiKey: string) => void;
+}) {
+  const active = view.source === 'claude_setup_token';
+  const [token, setToken] = useState('');
+  return (
+    <Card active={active} title="Claude setup token (recommended)">
+      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
+        Generate a Claude setup token with <code>claude setup-token</code> on a host where you've authenticated to your
+        Pro / Max / Team / Enterprise subscription. The command walks you through OAuth and prints a one-year token (
+        <code>sk-ant-oat01-…</code>). Inference-only — paste it here.
+        {active && view.hasApiKey && ' A token is currently stored.'}
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (token.trim()) {
+            onSubmit(token.trim());
+            setToken('');
+          }
+        }}
+        style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}
+      >
+        <input
+          type="password"
+          autoComplete="off"
+          placeholder="sk-ant-oat01-…"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          disabled={busy}
+          style={{ flex: '1 1 24rem', minWidth: '16rem' }}
+        />
+        <button type="submit" disabled={busy || !token.trim()}>
+          {active ? 'Replace token' : 'Use setup token'}
+        </button>
+      </form>
+    </Card>
+  );
+}
+
+function ApiKeyCard({
+  view,
+  busy,
+  onSubmit,
+}: {
+  view: AgentProviderView;
+  busy: boolean;
+  onSubmit: (apiKey: string) => void;
+}) {
+  const active = view.source === 'anthropic_api_key';
+  const [apiKey, setApiKey] = useState('');
+  return (
+    <Card active={active} title="Anthropic API key">
+      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
+        Paste an API key from console.anthropic.com. Per-token billing.
+        {active && view.hasApiKey && ' A key is currently stored.'}
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (apiKey.trim()) {
+            onSubmit(apiKey.trim());
+            setApiKey('');
+          }
+        }}
+        style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}
+      >
+        <input
+          type="password"
+          autoComplete="off"
+          placeholder="sk-ant-api03-…"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          disabled={busy}
+          style={{ flex: '1 1 24rem', minWidth: '16rem' }}
+        />
+        <button type="submit" disabled={busy || !apiKey.trim()}>
+          {active ? 'Replace key' : 'Use API key'}
+        </button>
+      </form>
+    </Card>
+  );
+}
+
+function ExternalServerCard({
+  view,
+  busy,
+  onSubmit,
+}: {
+  view: AgentProviderView;
+  busy: boolean;
+  onSubmit: (apiKey: string, serverUrl: string) => void;
+}) {
+  const active = view.source === 'external_server';
+  const [serverUrl, setServerUrl] = useState(active ? (view.serverUrl ?? '') : '');
+  const [apiKey, setApiKey] = useState('');
+  const ready = serverUrl.trim() && apiKey.trim();
+  return (
+    <Card active={active} title="External provider server">
+      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
+        A self-hosted Claude proxy or a vendor that speaks the Anthropic API (e.g. OpenRouter). Sets{' '}
+        <code>ANTHROPIC_BASE_URL</code> + API key inside the container.
+        {active && view.serverUrl && (
+          <>
+            {' '}
+            Pointed at <code>{view.serverUrl}</code>.
+          </>
+        )}
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (ready) {
+            onSubmit(apiKey.trim(), serverUrl.trim());
+            setApiKey('');
+            setServerUrl('');
+          }
+        }}
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+      >
+        <input
+          type="url"
+          placeholder="https://openrouter.ai/api/v1"
+          value={serverUrl}
+          onChange={(e) => setServerUrl(e.target.value)}
+          disabled={busy}
+        />
+        <input
+          type="password"
+          autoComplete="off"
+          placeholder="API key"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          disabled={busy}
+        />
+        <div>
+          <button type="submit" disabled={busy || !ready}>
+            {active ? 'Replace' : 'Use external server'}
+          </button>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -851,6 +851,42 @@ export async function setAgentProvider(input: SetAgentProviderInput): Promise<Ag
   });
 }
 
+// --- Settings: per-agent-group agent provider override (paraclaw#86) ---
+
+/**
+ * Per-group view: `override` is the row keyed on this agent_group_id (all
+ * fields null when no override exists). `effective` is what the next
+ * spawn would actually use — the override when present, otherwise the
+ * install-wide default. `overridden` is the trigger for the UI's
+ * inherit/override branching.
+ */
+export interface GroupAgentProviderView {
+  agentGroupId: string;
+  overridden: boolean;
+  override: AgentProviderView;
+  effective: AgentProviderView;
+}
+
+export async function getGroupAgentProvider(folder: string): Promise<GroupAgentProviderView> {
+  return request<GroupAgentProviderView>(`/groups/${encodeURIComponent(folder)}/agent-provider`);
+}
+
+export async function setGroupAgentProvider(
+  folder: string,
+  input: SetAgentProviderInput,
+): Promise<GroupAgentProviderView> {
+  return request<GroupAgentProviderView>(`/groups/${encodeURIComponent(folder)}/agent-provider`, {
+    method: 'POST',
+    json: input,
+  });
+}
+
+export async function clearGroupAgentProvider(folder: string): Promise<GroupAgentProviderView> {
+  return request<GroupAgentProviderView>(`/groups/${encodeURIComponent(folder)}/agent-provider`, {
+    method: 'DELETE',
+  });
+}
+
 /**
  * Per-channel native id of the install's primary operator (oldest global
  * owner). Used to pre-fill the "bot admin user" field on /channels/new so

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -1,15 +1,21 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { ActivityFeed } from '../components/ActivityFeed.tsx';
+import { AgentProviderCards } from '../components/AgentProviderCards.tsx';
 import { ScopeGrants, SCOPE_OPTIONS } from '../components/ScopeGrants.tsx';
 import { StatusDot, formatRelative } from '../components/StatusDot.tsx';
 import { VaultPicker } from '../components/VaultPicker.tsx';
 import {
   attachVault,
+  clearGroupAgentProvider,
   detachVault,
   getGroup,
+  getGroupAgentProvider,
+  setGroupAgentProvider,
   spawnSession,
   type AgentGroupView,
+  type AgentProviderSource,
+  type GroupAgentProviderView,
   type GroupStatus,
   type VaultScope,
 } from '../lib/api.ts';
@@ -255,160 +261,309 @@ export function GroupDetail() {
       {tab === 'activity' && folder && <ActivityFeed folder={folder} />}
 
       {tab === 'overview' && (
-      <>
-      <div className="section">
-        <h3>Agent group</h3>
-        <div className="kv">
-          <div>name</div>
-          <div>{group.name}</div>
-          <div>folder</div>
-          <div>
-            <code>{group.folder}</code>
+        <>
+          <div className="section">
+            <h3>Agent group</h3>
+            <div className="kv">
+              <div>name</div>
+              <div>{group.name}</div>
+              <div>folder</div>
+              <div>
+                <code>{group.folder}</code>
+              </div>
+              <div>id</div>
+              <div>
+                <code>{group.id}</code>
+              </div>
+              <div>provider</div>
+              <div>{group.agent_provider ?? <em className="dim">default</em>}</div>
+              <div>created</div>
+              <div>{new Date(group.created_at).toLocaleString()}</div>
+            </div>
           </div>
-          <div>id</div>
-          <div>
-            <code>{group.id}</code>
-          </div>
-          <div>provider</div>
-          <div>{group.agent_provider ?? <em className="dim">default</em>}</div>
-          <div>created</div>
-          <div>{new Date(group.created_at).toLocaleString()}</div>
-        </div>
-      </div>
 
-      {group.status && (
-        <StatusSection status={group.status} onSpawn={onSpawn} spawning={spawning} />
-      )}
+          {group.status && <StatusSection status={group.status} onSpawn={onSpawn} spawning={spawning} />}
 
-      {group.vault ? (
-        <div className="section">
-          <h3>Vault attachment</h3>
-          <div className="kv">
-            <div>vault url</div>
-            <div>
-              <code>{group.vault.vaultBaseUrl}</code>
-            </div>
-            <div>scope</div>
-            <div>
-              <span className="tag">{group.vault.scope}</span>
-            </div>
-            <div>token label</div>
-            <div>
-              <code>{group.vault.tokenLabel}</code>
-            </div>
-            <div>attached</div>
-            <div>{new Date(group.vault.attachedAt).toLocaleString()}</div>
-          </div>
-          <hr className="sep" />
-          <div className="dim" style={{ marginBottom: '0.75rem' }}>
-            The agent's container.json has a <code>parachute-vault</code> MCP entry pointing at this URL with a Bearer
-            token. Detach removes the entry; the token stays valid until you revoke it via{' '}
-            <code>parachute vault tokens revoke {group.vault.tokenLabel}</code>.
-          </div>
-          <button className="danger" onClick={onDetach} disabled={submitting}>
-            {submitting ? 'Working…' : 'Detach vault'}
-          </button>
-        </div>
-      ) : (
-        <div className="section">
-          <h3>Attach {pickedVaultName ? <code>{pickedVaultName}</code> : null} vault</h3>
-          <form onSubmit={onAttach}>
-            <div className="row">
-              <label htmlFor="vaultBaseUrl">Vault</label>
-              <VaultPicker
-                inputId="vaultBaseUrl"
-                value={vaultBaseUrl}
-                onChange={setVaultBaseUrl}
-                onPickedName={setPickedVaultName}
-                disabled={submitting}
-              />
-            </div>
+          {folder && <AgentProviderSection folder={folder} />}
 
-            <div className="row">
-              <label htmlFor="scope">Scope</label>
-              <select
-                id="scope"
-                value={scope}
-                onChange={(e) => setScope(e.target.value as VaultScope)}
-                disabled={submitting}
-              >
-                {SCOPE_OPTIONS.map((s) => (
-                  <option key={s.value} value={s.value}>
-                    {s.label}
-                  </option>
-                ))}
-              </select>
-              <p className="dim">
-                Token capability — the agent literally cannot exceed this. Default <code>vault:read</code>.
-              </p>
-              <ScopeGrants scope={scope} />
-            </div>
-
-            <div className="row">
-              <label htmlFor="tokenLabel">Token label</label>
-              <input
-                id="tokenLabel"
-                type="text"
-                value={tokenLabel}
-                onChange={(e) => setTokenLabel(e.target.value)}
-                disabled={submitting}
-                placeholder={`claw-${folder}`}
-              />
-              <p className="dim">
-                Used for revocation. Default: <code>claw-{folder}</code>.
-              </p>
-            </div>
-
-            <div className="row">
-              <label htmlFor="pasteToken">Paste an existing token (optional)</label>
-              <input
-                id="pasteToken"
-                type="text"
-                value={pasteToken}
-                onChange={(e) => setPasteToken(e.target.value)}
-                disabled={submitting}
-                placeholder="pvt_…  (leave blank to mint a fresh one via the parachute CLI)"
-              />
-              <p className="dim">
-                When blank: the server runs{' '}
-                <code>
-                  parachute vault tokens create --scope {scope} --label {tokenLabel || `claw-${folder}`}
-                </code>{' '}
-                for you. (Until vault OAuth is wired in Phase B; then you'll never see <code>pvt_…</code> tokens at
-                all.)
-              </p>
-            </div>
-
-            <div className="actions">
-              <button type="submit" disabled={submitting}>
-                {submitting ? 'Attaching…' : 'Attach vault'}
+          {group.vault ? (
+            <div className="section">
+              <h3>Vault attachment</h3>
+              <div className="kv">
+                <div>vault url</div>
+                <div>
+                  <code>{group.vault.vaultBaseUrl}</code>
+                </div>
+                <div>scope</div>
+                <div>
+                  <span className="tag">{group.vault.scope}</span>
+                </div>
+                <div>token label</div>
+                <div>
+                  <code>{group.vault.tokenLabel}</code>
+                </div>
+                <div>attached</div>
+                <div>{new Date(group.vault.attachedAt).toLocaleString()}</div>
+              </div>
+              <hr className="sep" />
+              <div className="dim" style={{ marginBottom: '0.75rem' }}>
+                The agent's container.json has a <code>parachute-vault</code> MCP entry pointing at this URL with a
+                Bearer token. Detach removes the entry; the token stays valid until you revoke it via{' '}
+                <code>parachute vault tokens revoke {group.vault.tokenLabel}</code>.
+              </div>
+              <button className="danger" onClick={onDetach} disabled={submitting}>
+                {submitting ? 'Working…' : 'Detach vault'}
               </button>
             </div>
-          </form>
+          ) : (
+            <div className="section">
+              <h3>Attach {pickedVaultName ? <code>{pickedVaultName}</code> : null} vault</h3>
+              <form onSubmit={onAttach}>
+                <div className="row">
+                  <label htmlFor="vaultBaseUrl">Vault</label>
+                  <VaultPicker
+                    inputId="vaultBaseUrl"
+                    value={vaultBaseUrl}
+                    onChange={setVaultBaseUrl}
+                    onPickedName={setPickedVaultName}
+                    disabled={submitting}
+                  />
+                </div>
+
+                <div className="row">
+                  <label htmlFor="scope">Scope</label>
+                  <select
+                    id="scope"
+                    value={scope}
+                    onChange={(e) => setScope(e.target.value as VaultScope)}
+                    disabled={submitting}
+                  >
+                    {SCOPE_OPTIONS.map((s) => (
+                      <option key={s.value} value={s.value}>
+                        {s.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="dim">
+                    Token capability — the agent literally cannot exceed this. Default <code>vault:read</code>.
+                  </p>
+                  <ScopeGrants scope={scope} />
+                </div>
+
+                <div className="row">
+                  <label htmlFor="tokenLabel">Token label</label>
+                  <input
+                    id="tokenLabel"
+                    type="text"
+                    value={tokenLabel}
+                    onChange={(e) => setTokenLabel(e.target.value)}
+                    disabled={submitting}
+                    placeholder={`claw-${folder}`}
+                  />
+                  <p className="dim">
+                    Used for revocation. Default: <code>claw-{folder}</code>.
+                  </p>
+                </div>
+
+                <div className="row">
+                  <label htmlFor="pasteToken">Paste an existing token (optional)</label>
+                  <input
+                    id="pasteToken"
+                    type="text"
+                    value={pasteToken}
+                    onChange={(e) => setPasteToken(e.target.value)}
+                    disabled={submitting}
+                    placeholder="pvt_…  (leave blank to mint a fresh one via the parachute CLI)"
+                  />
+                  <p className="dim">
+                    When blank: the server runs{' '}
+                    <code>
+                      parachute vault tokens create --scope {scope} --label {tokenLabel || `claw-${folder}`}
+                    </code>{' '}
+                    for you. (Until vault OAuth is wired in Phase B; then you'll never see <code>pvt_…</code> tokens at
+                    all.)
+                  </p>
+                </div>
+
+                <div className="actions">
+                  <button type="submit" disabled={submitting}>
+                    {submitting ? 'Attaching…' : 'Attach vault'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          <div className="section">
+            <h3>What the agent gets</h3>
+            <p className="muted">
+              When attached, the agent's container has a <code>parachute-vault</code> MCP server available with the nine
+              vault tools: <code>query-notes</code>, <code>create-note</code>, <code>update-note</code>,{' '}
+              <code>delete-note</code>, <code>list-tags</code>, <code>update-tag</code>, <code>delete-tag</code>,{' '}
+              <code>find-path</code>, <code>vault-info</code>. Constrained by the scope you chose.
+            </p>
+            <p className="muted">
+              Paraclaw doesn't impose a vault-note layout on the agent — the claw decides how to use vault access. (See{' '}
+              <a
+                href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
+                target="_blank"
+                rel="noreferrer"
+              >
+                docs/parachute-integration.md
+              </a>
+              .)
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function describeSource(source: AgentProviderSource | null, serverUrl: string | null): string {
+  switch (source) {
+    case 'claude_setup_token':
+      return 'Claude setup token';
+    case 'anthropic_api_key':
+      return 'Anthropic API key';
+    case 'external_server':
+      return serverUrl ? `External server (${serverUrl})` : 'External server';
+    case null:
+      return 'not configured';
+  }
+}
+
+function AgentProviderSection({ folder }: { folder: string }) {
+  const [state, setState] = useState<
+    { kind: 'loading' } | { kind: 'ok'; view: GroupAgentProviderView } | { kind: 'error'; message: string }
+  >({ kind: 'loading' });
+  const [busy, setBusy] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      setState({ kind: 'loading' });
+      const view = await getGroupAgentProvider(folder);
+      setState({ kind: 'ok', view });
+    } catch (err) {
+      setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  }, [folder]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const submit = async (input: { source: AgentProviderSource; apiKey?: string; serverUrl?: string }) => {
+    setBusy(true);
+    setFlash(null);
+    try {
+      const view = await setGroupAgentProvider(folder, input);
+      setState({ kind: 'ok', view });
+      setShowForm(false);
+      setFlash({ kind: 'ok', text: 'Override saved — takes effect on the next session spawn.' });
+    } catch (err) {
+      setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onClear = async () => {
+    if (!window.confirm("Clear this group's override and inherit the install-wide default?")) return;
+    setBusy(true);
+    setFlash(null);
+    try {
+      const view = await clearGroupAgentProvider(folder);
+      setState({ kind: 'ok', view });
+      setShowForm(false);
+      setFlash({
+        kind: 'ok',
+        text: 'Override cleared. Group will inherit the install-wide default on the next spawn.',
+      });
+    } catch (err) {
+      setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="section">
+        <h3>Agent provider</h3>
+        <div className="skeleton skeleton-line" style={{ width: '60%' }} />
+      </div>
+    );
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="section">
+        <h3>Agent provider</h3>
+        <div className="error-banner">
+          Couldn't load: <code>{state.message}</code>
+        </div>
+        <div className="actions" style={{ marginTop: '0.75rem' }}>
+          <button onClick={reload}>Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  const { view } = state;
+  const effectiveSummary = describeSource(view.effective.source, view.effective.serverUrl);
+  const overrideSummary = describeSource(view.override.source, view.override.serverUrl);
+
+  return (
+    <div className="section">
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+        <h3 style={{ margin: 0 }}>Agent provider</h3>
+        {view.overridden ? <span className="tag">override</span> : <span className="tag muted">inheriting</span>}
+      </div>
+      <p className="muted" style={{ marginTop: '0.75rem' }}>
+        {view.overridden ? (
+          <>
+            This group uses its own credential source: <strong>{overrideSummary}</strong>. Clear the override to inherit
+            the install-wide default again.
+          </>
+        ) : (
+          <>
+            This group inherits the install-wide default — currently <strong>{effectiveSummary}</strong>. Set an
+            override below to give this group its own credentials. Change at{' '}
+            <Link to="/settings/agent-provider">Settings · Agent provider</Link> for the install-wide default.
+          </>
+        )}
+      </p>
+
+      {flash && (
+        <div className={flash.kind === 'ok' ? 'status-banner' : 'error-banner'} style={{ marginBottom: '0.75rem' }}>
+          {flash.text}
         </div>
       )}
 
-      <div className="section">
-        <h3>What the agent gets</h3>
-        <p className="muted">
-          When attached, the agent's container has a <code>parachute-vault</code> MCP server available with the nine
-          vault tools: <code>query-notes</code>, <code>create-note</code>, <code>update-note</code>,{' '}
-          <code>delete-note</code>, <code>list-tags</code>, <code>update-tag</code>, <code>delete-tag</code>,{' '}
-          <code>find-path</code>, <code>vault-info</code>. Constrained by the scope you chose.
-        </p>
-        <p className="muted">
-          Paraclaw doesn't impose a vault-note layout on the agent — the claw decides how to use vault access. (See{' '}
-          <a
-            href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
-            target="_blank"
-            rel="noreferrer"
-          >
-            docs/parachute-integration.md
-          </a>
-          .)
-        </p>
-      </div>
-      </>
+      {!view.overridden && !showForm && (
+        <div className="actions">
+          <button onClick={() => setShowForm(true)}>Override default</button>
+        </div>
+      )}
+
+      {(view.overridden || showForm) && (
+        <>
+          <AgentProviderCards view={view.override} busy={busy} onSubmit={submit} />
+          <div className="actions" style={{ display: 'flex', gap: '0.5rem' }}>
+            {view.overridden && (
+              <button className="danger" onClick={onClear} disabled={busy}>
+                {busy ? 'Working…' : 'Clear override'}
+              </button>
+            )}
+            {!view.overridden && showForm && (
+              <button className="secondary" onClick={() => setShowForm(false)} disabled={busy}>
+                Cancel
+              </button>
+            )}
+          </div>
+        </>
       )}
     </div>
   );
@@ -431,15 +586,7 @@ function DetailTabs({ tab, onChange }: { tab: DetailTab; onChange: (next: Detail
   );
 }
 
-function StatusSection({
-  status,
-  onSpawn,
-  spawning,
-}: {
-  status: GroupStatus;
-  onSpawn: () => void;
-  spawning: boolean;
-}) {
+function StatusSection({ status, onSpawn, spawning }: { status: GroupStatus; onSpawn: () => void; spawning: boolean }) {
   return (
     <div className="section">
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>

--- a/web/ui/src/routes/SettingsAgentProvider.tsx
+++ b/web/ui/src/routes/SettingsAgentProvider.tsx
@@ -8,10 +8,12 @@
  *     Anthropic API).
  *
  * The page never displays plaintext secrets — the API returns a `hasApiKey`
- * boolean only.
+ * boolean only. Per-agent-group overrides live on each group's detail page
+ * (paraclaw#86).
  */
 import { useCallback, useEffect, useState } from 'react';
 
+import { AgentProviderCards } from '../components/AgentProviderCards.tsx';
 import { getAgentProvider, setAgentProvider, type AgentProviderSource, type AgentProviderView } from '../lib/api.ts';
 
 type SaveState = { kind: 'idle' } | { kind: 'saving' } | { kind: 'error'; message: string };
@@ -91,8 +93,8 @@ export function SettingsAgentProvider() {
         <a href="agent-provider">Agent provider</a>
       </nav>
       <p className="muted">
-        Where the agent gets its Claude credentials. One source per install — applies to every agent group. Changing the
-        source takes effect on the next session spawn.
+        Where the agent gets its Claude credentials. One source per install — applies to every agent group unless a
+        specific group sets an override on its detail page. Changing the source takes effect on the next session spawn.
       </p>
 
       {save.kind === 'error' && (
@@ -101,192 +103,7 @@ export function SettingsAgentProvider() {
         </div>
       )}
 
-      <ClaudeSetupTokenCard
-        view={view}
-        busy={save.kind === 'saving'}
-        onSubmit={(apiKey) => submit({ source: 'claude_setup_token', apiKey })}
-      />
-      <ApiKeyCard
-        view={view}
-        busy={save.kind === 'saving'}
-        onSubmit={(apiKey) => submit({ source: 'anthropic_api_key', apiKey })}
-      />
-      <ExternalServerCard
-        view={view}
-        busy={save.kind === 'saving'}
-        onSubmit={(apiKey, serverUrl) => submit({ source: 'external_server', apiKey, serverUrl })}
-      />
+      <AgentProviderCards view={view} busy={save.kind === 'saving'} onSubmit={submit} />
     </div>
-  );
-}
-
-function Card({ active, title, children }: { active: boolean; title: string; children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        background: 'white',
-        border: active ? '2px solid var(--accent, #2563eb)' : '1px solid var(--border)',
-        borderRadius: '8px',
-        padding: '1rem 1.25rem',
-        marginBottom: '0.75rem',
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
-        <strong>{title}</strong>
-        {active && <span className="tag">active</span>}
-      </div>
-      <div style={{ marginTop: '0.5rem' }}>{children}</div>
-    </div>
-  );
-}
-
-function ClaudeSetupTokenCard({
-  view,
-  busy,
-  onSubmit,
-}: {
-  view: AgentProviderView;
-  busy: boolean;
-  onSubmit: (apiKey: string) => void;
-}) {
-  const active = view.source === 'claude_setup_token';
-  const [token, setToken] = useState('');
-  return (
-    <Card active={active} title="Claude setup token (recommended)">
-      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
-        Generate a Claude setup token with <code>claude setup-token</code> on a host where you've authenticated to your
-        Pro / Max / Team / Enterprise subscription. The command walks you through OAuth and prints a one-year token (
-        <code>sk-ant-oat01-…</code>). Inference-only — paste it here.
-        {active && view.hasApiKey && ' A token is currently stored.'}
-      </p>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (token.trim()) {
-            onSubmit(token.trim());
-            setToken('');
-          }
-        }}
-        style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}
-      >
-        <input
-          type="password"
-          autoComplete="off"
-          placeholder="sk-ant-oat01-…"
-          value={token}
-          onChange={(e) => setToken(e.target.value)}
-          disabled={busy}
-          style={{ flex: '1 1 24rem', minWidth: '16rem' }}
-        />
-        <button type="submit" disabled={busy || !token.trim()}>
-          {active ? 'Replace token' : 'Use setup token'}
-        </button>
-      </form>
-    </Card>
-  );
-}
-
-function ApiKeyCard({
-  view,
-  busy,
-  onSubmit,
-}: {
-  view: AgentProviderView;
-  busy: boolean;
-  onSubmit: (apiKey: string) => void;
-}) {
-  const active = view.source === 'anthropic_api_key';
-  const [apiKey, setApiKey] = useState('');
-  return (
-    <Card active={active} title="Anthropic API key">
-      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
-        Paste an API key from console.anthropic.com. Per-token billing.
-        {active && view.hasApiKey && ' A key is currently stored.'}
-      </p>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (apiKey.trim()) {
-            onSubmit(apiKey.trim());
-            setApiKey('');
-          }
-        }}
-        style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}
-      >
-        <input
-          type="password"
-          autoComplete="off"
-          placeholder="sk-ant-api03-…"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          disabled={busy}
-          style={{ flex: '1 1 24rem', minWidth: '16rem' }}
-        />
-        <button type="submit" disabled={busy || !apiKey.trim()}>
-          {active ? 'Replace key' : 'Use API key'}
-        </button>
-      </form>
-    </Card>
-  );
-}
-
-function ExternalServerCard({
-  view,
-  busy,
-  onSubmit,
-}: {
-  view: AgentProviderView;
-  busy: boolean;
-  onSubmit: (apiKey: string, serverUrl: string) => void;
-}) {
-  const active = view.source === 'external_server';
-  const [serverUrl, setServerUrl] = useState(active ? (view.serverUrl ?? '') : '');
-  const [apiKey, setApiKey] = useState('');
-  const ready = serverUrl.trim() && apiKey.trim();
-  return (
-    <Card active={active} title="External provider server">
-      <p className="muted" style={{ margin: '0 0 0.5rem' }}>
-        A self-hosted Claude proxy or a vendor that speaks the Anthropic API (e.g. OpenRouter). Sets{' '}
-        <code>ANTHROPIC_BASE_URL</code> + API key inside the container.
-        {active && view.serverUrl && (
-          <>
-            {' '}
-            Pointed at <code>{view.serverUrl}</code>.
-          </>
-        )}
-      </p>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (ready) {
-            onSubmit(apiKey.trim(), serverUrl.trim());
-            setApiKey('');
-            setServerUrl('');
-          }
-        }}
-        style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-      >
-        <input
-          type="url"
-          placeholder="https://openrouter.ai/api/v1"
-          value={serverUrl}
-          onChange={(e) => setServerUrl(e.target.value)}
-          disabled={busy}
-        />
-        <input
-          type="password"
-          autoComplete="off"
-          placeholder="API key"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          disabled={busy}
-        />
-        <div>
-          <button type="submit" disabled={busy || !ready}>
-            {active ? 'Replace' : 'Use external server'}
-          </button>
-        </div>
-      </form>
-    </Card>
   );
 }


### PR DESCRIPTION
## Summary

Phase 2 of paraclaw#78. Each agent group can override the install-wide agent-provider source on its detail page; spawn lookup prefers the group-specific row over the `__default__` sentinel, falling back to the default if no override exists.

- **Spawn lookup** (`src/modules/provider-credentials/spawn.ts`): two-tier resolution — per-group row wins, default fallback otherwise. Envelope carries `resolvedScope: 'group' | 'default' | null` so logs/UI can attribute which tier was used.
- **HTTP** (`src/web/routes/agent-provider.ts`, `src/web/server.ts`): `/api/groups/:folder/agent-provider` GET / POST / DELETE.
  - GET → `GroupAgentProviderView` — `{ agentGroupId, overridden, override, effective }`.
  - POST → set/replace the override (same body shape as install-wide).
  - DELETE → clear the override (idempotent).
  - Scope tiers: `claw:read` for GET, `claw:admin` for POST/DELETE (secret-bearing). Server dispatch branches scope on `isAgentProviderSub`.
  - Audit log: source changes carry `agentGroupId` on the existing `agent_provider_source_changed` event; clear emits new `agent_provider_override_cleared`.
- **Web UI**:
  - New `AgentProviderSection` on the agent-group detail page (`web/ui/src/routes/GroupDetail.tsx`) — inherited-summary when no override, override-summary + "Clear override" when active, "Override default" reveals form.
  - Extracted shared `AgentProviderCards` component (`web/ui/src/components/AgentProviderCards.tsx`) so install-wide and per-group surfaces stay in sync.
  - API client additions: `getGroupAgentProvider`, `setGroupAgentProvider`, `clearGroupAgentProvider`.
- **Tests**: +5 spawn (per-group wins, default fallback, empty-slot override still wins, etc.), +5 route (GET/POST/DELETE override semantics, audit fields, scope branching).

Bump: `0.0.14-rc.34` → `0.0.14-rc.35`.

Closes #86

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 485/485 pass
- [x] `cd web/ui && pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec prettier --check` — clean for touched files (pre-existing drift on `sender-approval.test.ts` + `channels.ts` covered by paraclaw#88)
- [ ] Manual browser check on agent-group detail page (override + clear flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)