### PR TITLE
chore: cleanup batch — cross-ref types (#80) + prettier baseline (#88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.35",
+  "version": "0.0.14-rc.36",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -375,7 +375,11 @@ describe('unknown-sender request_approval flow', () => {
     // Audit log fires with fromPolicy='public' so the click is traceable
     // even when the DB write was a no-op.
     const auditCalls = infoSpy.mock.calls.filter(([, data]) => {
-      return typeof data === 'object' && data !== null && (data as { audit?: string }).audit === 'sender_approval_policy_flip';
+      return (
+        typeof data === 'object' &&
+        data !== null &&
+        (data as { audit?: string }).audit === 'sender_approval_policy_flip'
+      );
     });
     expect(auditCalls).toHaveLength(1);
     const [, auditFields] = auditCalls[0] as [string, Record<string, unknown>];

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,11 @@ export interface AgentGroup {
   created_at: string;
 }
 
+/**
+ * Exact wire mirror — `UnknownSenderPolicy` in `web/ui/src/lib/api.ts` MUST
+ * stay in lock-step with this union. No translator; the values cross the
+ * wire as-is. If you add or rename a value here, update the client too.
+ */
 export type UnknownSenderPolicy = 'strict' | 'request_approval' | 'public';
 
 export interface MessagingGroup {
@@ -95,6 +100,14 @@ export interface UserDm {
   resolved_at: string;
 }
 
+/**
+ * DB-side vocabulary. The wire/API uses a different (post-rebuild) shape —
+ * see `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` in
+ * `web/ui/src/lib/api.ts`. Translation between the two lives in
+ * `src/web/routes/channels.ts` (`dbToApi*` + the patch-input mapper). If
+ * you add or rename a value here, update the translator AND the wire
+ * union — they are NOT meant to drift independently.
+ */
 export type EngageMode = 'pattern' | 'mention' | 'mention-sticky';
 export type SenderScope = 'all' | 'known';
 export type IgnoredMessagePolicy = 'drop' | 'accumulate';

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,16 +100,11 @@ export interface UserDm {
   resolved_at: string;
 }
 
-/**
- * DB-side vocabulary. The wire/API uses a different (post-rebuild) shape —
- * see `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` in
- * `web/ui/src/lib/api.ts`. Translation between the two lives in
- * `src/web/routes/channels.ts` (`dbToApi*` + the patch-input mapper). If
- * you add or rename a value here, update the translator AND the wire
- * union — they are NOT meant to drift independently.
- */
+// DB vocabulary. See dbToApi* in src/web/routes/channels.ts for wire equivalents in web/ui/src/lib/api.ts.
 export type EngageMode = 'pattern' | 'mention' | 'mention-sticky';
+// DB vocabulary. See dbToApi* in src/web/routes/channels.ts for wire equivalents in web/ui/src/lib/api.ts.
 export type SenderScope = 'all' | 'known';
+// DB vocabulary. See dbToApi* in src/web/routes/channels.ts for wire equivalents in web/ui/src/lib/api.ts.
 export type IgnoredMessagePolicy = 'drop' | 'accumulate';
 
 export interface MessagingGroupAgent {

--- a/src/web/routes/channels.ts
+++ b/src/web/routes/channels.ts
@@ -242,7 +242,8 @@ function validatePatchInput(body: unknown): { ok: true; input: PatchInput } | { 
     if (b.engagePattern === ALL_MESSAGES_PATTERN_SENTINEL) {
       return {
         ok: false,
-        reason: "engagePattern '.' is reserved as the 'all' sentinel — use '\\\\.' (escaped) to match a literal dot, or set engageMode to 'all'",
+        reason:
+          "engagePattern '.' is reserved as the 'all' sentinel — use '\\\\.' (escaped) to match a literal dot, or set engageMode to 'all'",
       };
     }
     out.engagePattern = b.engagePattern as string | null;

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -965,16 +965,11 @@ export async function updateMessagingGroupPolicy(
 
 export type ChannelKind = 'discord' | 'telegram' | 'cli';
 
-/**
- * Wire/API vocabulary. The DB uses a different (pre-rebuild) shape — see
- * `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` in `src/types.ts`.
- * Translation between the two lives in `src/web/routes/channels.ts`
- * (`dbToApi*` + the patch-input mapper). If you add or rename a value
- * here, update the translator AND the server union — they are NOT meant
- * to drift independently.
- */
+// Wire vocabulary. See dbToApi* in src/web/routes/channels.ts for DB equivalents in src/types.ts.
 export type EngageMode = 'mention' | 'pattern' | 'all';
+// Wire vocabulary. See dbToApi* in src/web/routes/channels.ts for DB equivalents in src/types.ts.
 export type SenderScope = 'allowlist' | 'all';
+// Wire vocabulary. See dbToApi* in src/web/routes/channels.ts for DB equivalents in src/types.ts.
 export type IgnoredMessagePolicy = 'drop' | 'silent';
 
 export interface ChannelWireView {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -902,9 +902,11 @@ export async function listOperatorIdentities(): Promise<Record<string, string>> 
 
 /**
  * The three policies the router applies to messages from senders the
- * messaging group hasn't seen / approved before. Mirrors `UnknownSenderPolicy`
- * in `src/types.ts` exactly. `public` is the value the DB uses; `open` is
- * NOT a valid value (we surface only the canonical names).
+ * messaging group hasn't seen / approved before. Exact wire mirror of
+ * `UnknownSenderPolicy` in `src/types.ts` — no translator; values cross
+ * the wire as-is. Keep this union in lock-step with the server side.
+ * `public` is the value the DB uses; `open` is NOT a valid value (we
+ * surface only the canonical names).
  *
  * - `request_approval` — pause the message and DM the operator with an
  *   approve/reject card. Default for auto-created MGs.
@@ -963,6 +965,14 @@ export async function updateMessagingGroupPolicy(
 
 export type ChannelKind = 'discord' | 'telegram' | 'cli';
 
+/**
+ * Wire/API vocabulary. The DB uses a different (pre-rebuild) shape — see
+ * `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` in `src/types.ts`.
+ * Translation between the two lives in `src/web/routes/channels.ts`
+ * (`dbToApi*` + the patch-input mapper). If you add or rename a value
+ * here, update the translator AND the server union — they are NOT meant
+ * to drift independently.
+ */
 export type EngageMode = 'mention' | 'pattern' | 'all';
 export type SenderScope = 'allowlist' | 'all';
 export type IgnoredMessagePolicy = 'drop' | 'silent';


### PR DESCRIPTION
Bundles two cosmetic-only cleanups per `feedback_bundle_cohesive_prs`. Per-issue commits.

## Closes

- #80 — Cross-ref `UnknownSenderPolicy` / `EngageMode` / `SenderScope` / `IgnoredMessagePolicy` between `src/types.ts` and `web/ui/src/lib/api.ts`.
- #88 — Prettier baseline-fix on `src/modules/permissions/sender-approval.test.ts` + `src/web/routes/channels.ts` (note: actual paths differ from issue body — `permissions/` not `sender-approval/`, `web/routes/` not `modules/messaging/`).

## Commits

1. `806ef43` — `chore: prettier baseline-fix on sender-approval.test.ts + channels.ts` (#88). Pure formatting, no behavior change. Stops the husky `pre-commit` reformat fight that was tripping every PR touching these files.
2. `27e2315` — `docs: cross-ref UnknownSenderPolicy/EngageMode/SenderScope/IgnoredMessagePolicy between server and client` (#80). JSDoc-only — no code change.
3. `702e5d6` — `chore: bump version to 0.0.14-rc.36` (governance: every code/content PR bumps).

## Reading the code surfaced an unstated invariant

The #80 issue framed all four enums as "stay in lock-step" cross-refs. **Only `UnknownSenderPolicy` actually is.** The other three diverge intentionally:

- Server (`src/types.ts`): pre-rebuild DB vocabulary — `mention-sticky`, `known`, `accumulate`
- Client (`web/ui/src/lib/api.ts`): post-rebuild API vocabulary — `all`, `allowlist`, `silent`
- Translation lives in `src/web/routes/channels.ts` (`dbToApi*` + the patch-input mapper)

Comments in this PR reflect that real shape — `UnknownSenderPolicy` is "exact wire mirror"; the other three are "DB ↔ wire vocabularies, see translator." Both directions point at the translator so a future contributor adding a fourth value knows where to look.

## Gates

- `pnpm run typecheck` — pass (no output)
- `pnpm test` — pass (485/485 in 53 files)
- `pnpm run build:spa` — pass (399.65 kB built)
- `pnpm run lint` — same 9 errors / 153 warnings as `main`. None of them are in files this PR touches; verified with `git diff main..HEAD --stat`.

## Patterns check

- `feedback_bundle_cohesive_prs` — both issues are cosmetic / type-doc, same touch surface, no cascade-conflict risk. Bundled with per-issue commits as recommended.
- `feedback_governance_rules` — RC bump (rc.36). No `@latest` promotion — this stays on the rc tag until a release-cut.
- Both commits clean through husky's `format:fix` `pre-commit` hook (the prettier-baseline commit was specifically designed to silence that hook for these files going forward).

## Test plan

- [ ] Reviewer confirms cross-ref accuracy (server-vs-wire vocabulary distinction matches reality)
- [ ] Reviewer confirms prettier diff is pure-formatting (no semantic change in either file)
- [ ] CI green (typecheck + test + build:spa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)