### PR TITLE
fix: idempotent messages_in inserts on duplicate dispatch (paraclaw#92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.36",
+  "version": "0.0.14-rc.37",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/db/session-db.test.ts
+++ b/src/db/session-db.test.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { migrateMessagesInTable } from './session-db.js';
+import { ensureSchema, insertMessage, migrateMessagesInTable } from './session-db.js';
 
 const TEST_DIR = '/tmp/paraclaw-session-db-test';
 const DB_PATH = path.join(TEST_DIR, 'inbound.db');
@@ -53,6 +53,41 @@ describe('migrateMessagesInTable', () => {
       series_id: string;
     };
     expect(row.series_id).toBe('legacy-1');
+    db.close();
+  });
+});
+
+describe('insertMessage', () => {
+  it('returns inserted=true on first write, inserted=false on duplicate id (paraclaw#92)', () => {
+    if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+
+    ensureSchema(DB_PATH, 'inbound');
+    const db = openDb(DB_PATH);
+
+    const args = {
+      id: 'msg-dup-1:ag-1',
+      kind: 'chat' as const,
+      timestamp: new Date().toISOString(),
+      platformId: 'telegram:bot:chat',
+      channelType: 'telegram',
+      threadId: null,
+      content: '{"text":"hi"}',
+      processAfter: null,
+      recurrence: null,
+    };
+
+    const first = insertMessage(db, args);
+    expect(first.inserted).toBe(true);
+
+    // Duplicate dispatch — same id arrives again (sender-approval replay
+    // racing with re-emitted chat-sdk event, or platform getUpdates retry).
+    const second = insertMessage(db, args);
+    expect(second.inserted).toBe(false);
+
+    const count = (db.prepare('SELECT COUNT(*) AS n FROM messages_in WHERE id = ?').get(args.id) as { n: number }).n;
+    expect(count).toBe(1);
+
     db.close();
   });
 });

--- a/src/db/session-db.ts
+++ b/src/db/session-db.ts
@@ -100,15 +100,25 @@ export function insertMessage(
      */
     trigger?: 0 | 1;
   },
-): void {
-  db.prepare(
-    `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
-     VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger)`,
-  ).run({
-    ...message,
-    trigger: message.trigger ?? 1,
-    seq: nextEvenSeq(db),
-  });
+): { inserted: boolean } {
+  // ON CONFLICT(id) DO NOTHING: the same `event.message.id` can legitimately
+  // arrive twice for one (session, agent) pair — sender-approval replay
+  // racing with a re-dispatched chat-sdk event, or a Telegram getUpdates
+  // retry. The id is canonical, so a duplicate is the SAME message; treat
+  // it as idempotent rather than crashing the inbound path. Targeted to
+  // (id) so an unrelated UNIQUE(seq) collision still surfaces.
+  const info = db
+    .prepare(
+      `INSERT INTO messages_in (id, seq, kind, timestamp, status, platform_id, channel_type, thread_id, content, process_after, recurrence, series_id, trigger)
+       VALUES (@id, @seq, @kind, @timestamp, 'pending', @platformId, @channelType, @threadId, @content, @processAfter, @recurrence, @id, @trigger)
+       ON CONFLICT(id) DO NOTHING`,
+    )
+    .run({
+      ...message,
+      trigger: message.trigger ?? 1,
+      seq: nextEvenSeq(db),
+    });
+  return { inserted: info.changes > 0 };
 }
 
 export function countDueMessages(db: Database): number {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -234,8 +234,9 @@ export function writeSessionMessage(
   const content = extractAttachmentFiles(agentGroupId, sessionId, message.id, message.content);
 
   const db = openInboundDb(agentGroupId, sessionId);
+  let inserted: boolean;
   try {
-    insertMessage(db, {
+    ({ inserted } = insertMessage(db, {
       id: message.id,
       kind: message.kind,
       timestamp: message.timestamp,
@@ -246,9 +247,18 @@ export function writeSessionMessage(
       processAfter: message.processAfter ?? null,
       recurrence: message.recurrence ?? null,
       trigger: message.trigger ?? 1,
-    });
+    }));
   } finally {
     db.close();
+  }
+
+  if (!inserted) {
+    log.debug('messages_in id already present — duplicate dispatch, skipping', {
+      agentGroupId,
+      sessionId,
+      messageId: message.id,
+    });
+    return;
   }
 
   updateSession(sessionId, { last_active: new Date().toISOString() });


### PR DESCRIPTION
## Summary
- The same `event.message.id` can legitimately arrive twice for one (session, agent) pair — sender-approval replay racing with re-dispatched chat-sdk events, or platform getUpdates retries. The id is canonical, so a duplicate IS the same message.
- Switch `insertMessage` to `INSERT … ON CONFLICT(id) DO NOTHING` and return `{ inserted }`. `writeSessionMessage` skips the `last_active` bump on duplicates and emits a debug log so drops are observable.
- Targeted to `(id)` — `UNIQUE(seq)` collisions still surface as bugs.

## Why this shape
- Idempotent re-arrival is benign by design once we accept that the id is canonical: the FIRST insert's downstream effects (route log, typing indicator, container wake) already ran when the original message landed. The duplicate has nothing new to contribute.
- Pre-fix, the throw at `messages_in.id` UNIQUE-violation crashed the whole inbound path — second attempt ate the first message's wake side effect AND surfaced as a user-visible error. Aaron observed this twice on his install today (sender-approval replay 14:21:50 PT + direct inbound 15:15:14 / 15:15:33 PT).

## Closes
- Closes #92

## Test plan
- [x] New regression test `insertMessage › returns inserted=true on first write, inserted=false on duplicate id` — verifies single row remains, second `inserted` is false.
- [x] Full host suite green: 486/486 (was 485 pre-fix; +1 regression).
- [x] `pnpm exec tsc --noEmit` clean.
- [x] No new lint errors on changed files (`session-manager.ts:22 'findSession'` pre-exists on main; my diff adds zero errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)