### PR TITLE
fix: SERVICE_VERSION reads from package.json (closes #101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.38",
+  "version": "0.0.14-rc.39",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/web/server-version.test.ts
+++ b/src/web/server-version.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Regression test for paraclaw#101 — SERVICE_VERSION must read from
+ * package.json, not be hardcoded. Without this dynamism, every rc bump
+ * silently lies about the running version.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { SERVICE_VERSION } from './server.js';
+import pkg from '../../package.json' with { type: 'json' };
+
+describe('SERVICE_VERSION', () => {
+  test('matches package.json version (no hardcoded drift)', () => {
+    expect(SERVICE_VERSION).toBe(pkg.version);
+    expect(SERVICE_VERSION).toMatch(/^\d+\.\d+\.\d+(-[a-z]+\.\d+)?$/);
+  });
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -23,6 +23,12 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 
+// Sourced from package.json so `/api/health` and the hub-registered
+// manifest reflect the actual built version. Pre-paraclaw#101 this was a
+// hardcoded string that drifted across rc bumps; vault uses the same
+// pattern (see parachute-vault src/routing.ts).
+import pkg from '../../package.json' with { type: 'json' };
+
 import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR } from '../config.js';
 import { openDb, type Database } from '../db/connection.js';
 import {
@@ -87,7 +93,8 @@ const HOST = process.env.PARACLAW_WEB_BIND ?? '127.0.0.1';
 // hub#83) sets this from `module.json` `paths[0]` automatically. Empty
 // string = serve at the origin root (default).
 const MOUNT = normalizeMount(process.env.PARACLAW_WEB_MOUNT ?? '');
-const SERVICE_VERSION = '0.0.14-rc.7';
+/** Exported for tests; serves as the value reported by `/api/health` and registered with hub. */
+export const SERVICE_VERSION: string = pkg.version;
 
 interface AgentGroupRow {
   id: string;


### PR DESCRIPTION
Closes paraclaw#101.

## Problem

`src/web/server.ts:90` hardcoded `SERVICE_VERSION = '0.0.14-rc.7'` — a string that hadn't been bumped across ~30 rc releases. Result: `/api/health` and the hub-registered services-manifest both reported `rc.7` regardless of the actual running binary. `parachute status` showed wildly wrong versions for paraclaw.

## Fix

Source `SERVICE_VERSION` from `package.json` at module load:

```ts
import pkg from '../../package.json' with { type: 'json' };
export const SERVICE_VERSION: string = pkg.version;
```

Mirrors the pattern vault uses (see `parachute-vault src/routing.ts` and `src/cli.ts`). Constant is now automatically in sync with the built release.

## Regression test

`src/web/server-version.test.ts` asserts `SERVICE_VERSION === pkg.version` and that the value matches the SemVer-with-rc shape. A future regression-to-hardcode would fail this test.

## Gates

- `pnpm test` — **492/492** (was 491; +1 new)
- `pnpm exec tsc --noEmit` — clean

## Bump

0.0.14-rc.38 → 0.0.14-rc.39

🤖 Generated with [Claude Code](https://claude.com/claude-code)