### PR TITLE
fix: secrets mode UI (Bug A) + per-session Restart + stale-container banner (Bug B) + spawn-time messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Hard fork from NanoClaw v2. Paraclaw is now its own service: single Bun process 
 - **Native secrets.** Master key at `~/.parachute/claw/master.key` (32 bytes, mode 0600), AES-256-GCM with HKDF domain separation per subsystem, redacted error messages. Migration 015 drops the vestigial `host_pattern` column.
 - **Web UI** ships native pages for paraclaw primitives: `/secrets`, `/approvals`, `/sessions`, `/channels`. Wizard's credential-capture step removed (replaced by `/secrets`).
 - **Lifecycle.** Install via `parachute install paraclaw`; start runs `bun src/index.ts`. Module manifest at `.parachute/module.json`.
+- **fix(secrets):** per-secret mode radio for global secrets was a silent UI illusion (paraclaw#9-era migration moved mode to `agent_groups.secret_mode`). Globals now hide the radio with explainer; scoped secrets reframe the radio as `<group> accepts: [all in-scope | only assigned]`, surfacing the per-group nature of the setting.
+- **feat(secrets):** post-save staleness banner detects running containers spawned before the secret update + per-session `[Restart]` + `Restart all N`. Calls existing `closeSession`; next inbound message respawns fresh with new env. New `GET /api/secrets/:id/stale-sessions` (claw:read).
+- **feat(GroupDetail):** per-session `[Restart]` button on the Live status list + inline help on the spawn-time env model — operators can restart any running container without leaving the agent group page, for code/env/agent-provider changes too, not just secrets.
 
 ## [2.0.0] - 2026-04-22 (NanoClaw v2 — paraclaw's ancestor)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.40",
+  "version": "0.0.14-rc.41",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraclaw",
-  "version": "0.0.14-rc.39",
+  "version": "0.0.14-rc.40",
   "description": "Paraclaw — Parachute's per-session containerized AI agent companion.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -332,8 +332,6 @@ export function findStaleSessionsForSecret(secretId: string): StaleSession[] {
 /** Metadata-only single-row read by id. Returns undefined if missing. */
 export function getSecretById(id: string): SecretRow | undefined {
   return db()
-    .prepare<SecretRow>(
-      `SELECT id, name, kind, agent_group_id, created_at, updated_at FROM secrets WHERE id = ?`,
-    )
+    .prepare<SecretRow>(`SELECT id, name, kind, agent_group_id, created_at, updated_at FROM secrets WHERE id = ?`)
     .get(id);
 }

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -259,3 +259,81 @@ export function removeAssignment(secretId: string, agentGroupId: string): boolea
     .run({ secret_id: secretId, agent_group_id: agentGroupId });
   return r.changes > 0;
 }
+
+// ── Staleness detection (Bug B) ──
+
+export interface StaleSession {
+  sessionId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+  agentGroupFolder: string;
+  sessionCreatedAt: string;
+  secretUpdatedAt: string;
+}
+
+/**
+ * Sessions whose container was spawned BEFORE this secret was last updated
+ * AND whose agent group would inject the secret per the same resolution rules
+ * `resolveInjectableSecrets` applies (scoped match, OR global + group
+ * `secret_mode='all'`, OR global + assignment row).
+ *
+ * The host injects env vars at spawn time only — there is no in-process
+ * update path. This helper powers the post-save banner that prompts the
+ * operator to restart the specific sessions that need to see the change.
+ *
+ * Returns empty when the secret doesn't exist (caller handles 404).
+ */
+export function findStaleSessionsForSecret(secretId: string): StaleSession[] {
+  const rows = db()
+    .prepare<{
+      session_id: string;
+      agent_group_id: string;
+      agent_group_name: string;
+      agent_group_folder: string;
+      session_created_at: string;
+      secret_updated_at: string;
+    }>(
+      `SELECT
+          sess.id           AS session_id,
+          g.id              AS agent_group_id,
+          g.name            AS agent_group_name,
+          g.folder          AS agent_group_folder,
+          sess.created_at   AS session_created_at,
+          s.updated_at      AS secret_updated_at
+        FROM secrets s
+        JOIN agent_groups g
+          ON s.agent_group_id = g.id
+          OR s.agent_group_id IS NULL
+        LEFT JOIN secret_assignments a
+          ON a.secret_id = s.id AND a.agent_group_id = g.id
+        JOIN sessions sess
+          ON sess.agent_group_id = g.id
+        WHERE s.id = @secret_id
+          AND sess.container_status = 'running'
+          AND sess.created_at < s.updated_at
+          AND (
+                s.agent_group_id = g.id
+             OR (s.agent_group_id IS NULL
+                 AND (g.secret_mode = 'all' OR a.secret_id IS NOT NULL))
+          )
+        ORDER BY sess.created_at DESC`,
+    )
+    .all({ secret_id: secretId });
+  return rows.map((r) => ({
+    sessionId: r.session_id,
+    agentGroupId: r.agent_group_id,
+    agentGroupName: r.agent_group_name,
+    agentGroupFolder: r.agent_group_folder,
+    sessionCreatedAt: r.session_created_at,
+    secretUpdatedAt: r.secret_updated_at,
+  }));
+}
+
+/** Metadata-only single-row read by id. Returns undefined if missing. */
+export function getSecretById(id: string): SecretRow | undefined {
+  return db()
+    .prepare<SecretRow>(
+      `SELECT id, name, kind, agent_group_id, created_at, updated_at FROM secrets WHERE id = ?`,
+    )
+    .get(id);
+}

--- a/src/secrets/index.ts
+++ b/src/secrets/index.ts
@@ -273,9 +273,21 @@ export interface StaleSession {
 
 /**
  * Sessions whose container was spawned BEFORE this secret was last updated
- * AND whose agent group would inject the secret per the same resolution rules
- * `resolveInjectableSecrets` applies (scoped match, OR global + group
- * `secret_mode='all'`, OR global + assignment row).
+ * AND whose agent group would inject the secret. The injection predicate
+ * mirrors `resolveInjectableSecrets` for the configurations the UI can
+ * actually create:
+ *   - scoped secret  → matches its parent group (`s.agent_group_id = g.id`)
+ *   - global secret  → matches any group with `secret_mode='all'` OR an
+ *                      explicit `secret_assignments` row
+ *
+ * Note on a subtle asymmetry: `resolveInjectableSecrets` additionally gates
+ * scoped secrets through `(secret_mode='all' OR assignment row exists)` on
+ * the recipient group. The SQL here accepts the scoped match unconditionally.
+ * The asymmetry is benign — the only configs where it would diverge (a
+ * scoped secret paired with its parent group in `selective` mode and no
+ * assignment row) are unreachable via the UI, which always seeds an
+ * assignment row when scoping. If a future code path makes that config
+ * reachable, tighten the SQL to add the same gate.
  *
  * The host injects env vars at spawn time only — there is no in-process
  * update path. This helper powers the post-save banner that prompts the

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -225,11 +225,7 @@ describe('findStaleSessionsForSecret', () => {
     ).run(sessionId, agentGroupId, containerStatus, createdAt);
   }
 
-  function bumpSecretUpdatedAt(
-    db: ReturnType<typeof initTestDb>,
-    secretId: string,
-    updatedAt: string,
-  ) {
+  function bumpSecretUpdatedAt(db: ReturnType<typeof initTestDb>, secretId: string, updatedAt: string) {
     db.prepare(`UPDATE secrets SET updated_at = ? WHERE id = ?`).run(updatedAt, secretId);
   }
 

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -7,7 +7,9 @@ import { _setMasterKeyForTest } from './master-key.js';
 import {
   addAssignment,
   deleteSecret,
+  findStaleSessionsForSecret,
   getSecret,
+  getSecretById,
   listAssignments,
   listSecrets,
   putSecret,
@@ -205,5 +207,152 @@ describe('secret assignments (selective mode)', () => {
 
     expect(resolveInjectableSecrets('A').get('TOKEN')).toBe('shared-via-allowlist');
     expect(resolveInjectableSecrets('B').get('TOKEN')).toBe('b-only');
+  });
+});
+
+describe('findStaleSessionsForSecret', () => {
+  function seedSession(
+    db: ReturnType<typeof initTestDb>,
+    sessionId: string,
+    agentGroupId: string,
+    createdAt: string,
+    containerStatus: 'running' | 'idle' | 'stopped' = 'running',
+  ) {
+    db.prepare(
+      `INSERT INTO sessions
+         (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+       VALUES (?, ?, NULL, NULL, NULL, 'active', ?, NULL, ?)`,
+    ).run(sessionId, agentGroupId, containerStatus, createdAt);
+  }
+
+  function bumpSecretUpdatedAt(
+    db: ReturnType<typeof initTestDb>,
+    secretId: string,
+    updatedAt: string,
+  ) {
+    db.prepare(`UPDATE secrets SET updated_at = ? WHERE id = ?`).run(updatedAt, secretId);
+  }
+
+  it('returns sessions spawned before a global secret was updated, when assigned', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'selective');
+
+    // Session created at t=10
+    seedSession(db, 'sess-A', 'A', '2026-01-01T00:00:10.000Z');
+
+    // Global secret with assignment to A; secret updated at t=20 (after spawn)
+    const sid = putSecret('TOKEN', 'v');
+    addAssignment(sid, 'A');
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:20.000Z');
+
+    const stale = findStaleSessionsForSecret(sid);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].sessionId).toBe('sess-A');
+    expect(stale[0].agentGroupId).toBe('A');
+    expect(stale[0].secretUpdatedAt).toBe('2026-01-01T00:00:20.000Z');
+    expect(stale[0].sessionCreatedAt).toBe('2026-01-01T00:00:10.000Z');
+  });
+
+  it('skips sessions spawned AFTER the secret update', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'selective');
+
+    const sid = putSecret('TOKEN', 'v');
+    addAssignment(sid, 'A');
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:10.000Z');
+
+    // Session spawned at t=20 — after the secret update — already has env.
+    seedSession(db, 'sess-A', 'A', '2026-01-01T00:00:20.000Z');
+
+    expect(findStaleSessionsForSecret(sid)).toEqual([]);
+  });
+
+  it('skips non-running sessions (idle and stopped)', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'all');
+
+    const sid = putSecret('TOKEN', 'v');
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:20.000Z');
+
+    seedSession(db, 'sess-running', 'A', '2026-01-01T00:00:10.000Z', 'running');
+    seedSession(db, 'sess-idle', 'A', '2026-01-01T00:00:10.000Z', 'idle');
+    seedSession(db, 'sess-stopped', 'A', '2026-01-01T00:00:10.000Z', 'stopped');
+
+    const stale = findStaleSessionsForSecret(sid);
+    expect(stale.map((s) => s.sessionId)).toEqual(['sess-running']);
+  });
+
+  it('skips groups that would not inject the global (selective + no assignment)', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'selective');
+    seedAgentGroup(db, 'B', 'selective');
+
+    const sid = putSecret('TOKEN', 'v');
+    addAssignment(sid, 'A'); // only A is assigned
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:20.000Z');
+
+    seedSession(db, 'sess-A', 'A', '2026-01-01T00:00:10.000Z');
+    seedSession(db, 'sess-B', 'B', '2026-01-01T00:00:10.000Z');
+
+    const stale = findStaleSessionsForSecret(sid);
+    expect(stale.map((s) => s.sessionId)).toEqual(['sess-A']);
+  });
+
+  it('includes mode=all groups even without an explicit assignment', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'all');
+
+    const sid = putSecret('TOKEN', 'v');
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:20.000Z');
+
+    seedSession(db, 'sess-A', 'A', '2026-01-01T00:00:10.000Z');
+    expect(findStaleSessionsForSecret(sid).map((s) => s.sessionId)).toEqual(['sess-A']);
+  });
+
+  it('scoped secret only marks its own group stale', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'all');
+    seedAgentGroup(db, 'B', 'all');
+
+    const sid = putSecret('TOKEN', 'v', { agent_group_id: 'A' });
+    bumpSecretUpdatedAt(db, sid, '2026-01-01T00:00:20.000Z');
+
+    seedSession(db, 'sess-A', 'A', '2026-01-01T00:00:10.000Z');
+    seedSession(db, 'sess-B', 'B', '2026-01-01T00:00:10.000Z');
+
+    expect(findStaleSessionsForSecret(sid).map((s) => s.sessionId)).toEqual(['sess-A']);
+  });
+
+  it('returns [] for a missing secret id', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    expect(findStaleSessionsForSecret('does-not-exist')).toEqual([]);
+  });
+});
+
+describe('getSecretById', () => {
+  it('returns the metadata row, never the value', () => {
+    const id = putSecret('NAME', 'plaintext');
+    const row = getSecretById(id);
+    expect(row?.id).toBe(id);
+    expect(row?.name).toBe('NAME');
+    expect(row).not.toHaveProperty('value_encrypted');
+  });
+
+  it('returns undefined for a missing id', () => {
+    expect(getSecretById('does-not-exist')).toBeUndefined();
   });
 });

--- a/src/web/routes/secrets.test.ts
+++ b/src/web/routes/secrets.test.ts
@@ -1,0 +1,175 @@
+/**
+ * HTTP-boundary tests for the secrets route — currently focused on the
+ * staleness probe added with paraclaw#103. The mutation surfaces (POST,
+ * DELETE, /assignments) are exercised by `src/secrets/secrets.test.ts` at
+ * the helper level; this file complements that with the route dispatcher.
+ *
+ * Auth gating (`claw:read` for GET, `claw:admin` for mutation) lives in
+ * `src/web/server.ts` upstream of `handleSecretsRoute`, so 401/403 cases
+ * belong to `auth.test.ts` rather than the route layer — the handler is
+ * never reached without a passing scope check. We assert the handler's
+ * own contract here (status, body shape, 404 for missing rows).
+ */
+import http from 'node:http';
+import crypto from 'crypto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getDb } from '../../db/connection.js';
+import { closeDb, initTestDb, runMigrations } from '../../db/index.js';
+import { _setMasterKeyForTest } from '../../secrets/master-key.js';
+import { addAssignment, putSecret } from '../../secrets/index.js';
+import { handleSecretsRoute } from './secrets.js';
+
+beforeEach(() => {
+  const db = initTestDb();
+  runMigrations(db);
+  _setMasterKeyForTest(crypto.randomBytes(32));
+});
+
+afterEach(() => {
+  closeDb();
+});
+
+interface FakeResponse {
+  statusCode: number;
+  body: unknown;
+  res: http.ServerResponse;
+}
+
+function fakeRes(): FakeResponse {
+  const captured: FakeResponse = {
+    statusCode: 0,
+    body: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res: undefined as any,
+  };
+  const res = {
+    writeHead(status: number) {
+      captured.statusCode = status;
+    },
+    end(chunk: string) {
+      try {
+        captured.body = chunk ? JSON.parse(chunk) : undefined;
+      } catch {
+        captured.body = chunk;
+      }
+    },
+  } as unknown as http.ServerResponse;
+  captured.res = res;
+  return captured;
+}
+
+function fakeReq(): http.IncomingMessage {
+  return Object.assign(Object.create(null), {
+    [Symbol.asyncIterator]: async function* () {},
+  }) as http.IncomingMessage;
+}
+
+function seedAgentGroup(id: string, secretMode: 'all' | 'selective' = 'selective') {
+  getDb()
+    .prepare(
+      `INSERT INTO agent_groups (id, folder, name, secret_mode, created_at)
+       VALUES (?, ?, ?, ?, datetime('now'))`,
+    )
+    .run(id, id, id, secretMode);
+}
+
+function seedSession(sessionId: string, agentGroupId: string, createdAt: string) {
+  getDb()
+    .prepare(
+      `INSERT INTO sessions
+         (id, agent_group_id, messaging_group_id, thread_id, agent_provider, status, container_status, last_active, created_at)
+       VALUES (?, ?, NULL, NULL, NULL, 'active', 'running', NULL, ?)`,
+    )
+    .run(sessionId, agentGroupId, createdAt);
+}
+
+function bumpSecretUpdatedAt(secretId: string, updatedAt: string) {
+  getDb().prepare(`UPDATE secrets SET updated_at = ? WHERE id = ?`).run(updatedAt, secretId);
+}
+
+describe('GET /api/secrets/:id/stale-sessions', () => {
+  it('returns 200 with the secret metadata + the stale-session list', async () => {
+    seedAgentGroup('group-a', 'selective');
+    // Session spawned at t=10, secret bumped to t=20 — session is stale.
+    seedSession('sess-1', 'group-a', '2026-01-01T00:00:10.000Z');
+    const sid = putSecret('TOKEN', 'v');
+    addAssignment(sid, 'group-a');
+    bumpSecretUpdatedAt(sid, '2026-01-01T00:00:20.000Z');
+
+    const cap = fakeRes();
+    const handled = await handleSecretsRoute({
+      pathname: `/api/secrets/${sid}/stale-sessions`,
+      method: 'GET',
+      url: new URL(`https://x/api/secrets/${sid}/stale-sessions`),
+      req: fakeReq(),
+      res: cap.res,
+    });
+
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(200);
+    expect(cap.body).toMatchObject({
+      secretId: sid,
+      secretUpdatedAt: '2026-01-01T00:00:20.000Z',
+      staleSessions: [
+        {
+          sessionId: 'sess-1',
+          agentGroupId: 'group-a',
+          agentGroupName: 'group-a',
+          agentGroupFolder: 'group-a',
+          sessionCreatedAt: '2026-01-01T00:00:10.000Z',
+          secretUpdatedAt: '2026-01-01T00:00:20.000Z',
+        },
+      ],
+    });
+  });
+
+  it('returns 200 with an empty staleSessions array when nothing is stale', async () => {
+    seedAgentGroup('group-a', 'selective');
+    // Session spawned AFTER the secret update — not stale.
+    const sid = putSecret('TOKEN', 'v');
+    addAssignment(sid, 'group-a');
+    bumpSecretUpdatedAt(sid, '2026-01-01T00:00:10.000Z');
+    seedSession('sess-fresh', 'group-a', '2026-01-01T00:00:20.000Z');
+
+    const cap = fakeRes();
+    await handleSecretsRoute({
+      pathname: `/api/secrets/${sid}/stale-sessions`,
+      method: 'GET',
+      url: new URL(`https://x/api/secrets/${sid}/stale-sessions`),
+      req: fakeReq(),
+      res: cap.res,
+    });
+
+    expect(cap.statusCode).toBe(200);
+    expect(cap.body).toMatchObject({ secretId: sid, staleSessions: [] });
+  });
+
+  it('returns 404 for an unknown secret id', async () => {
+    const cap = fakeRes();
+    const handled = await handleSecretsRoute({
+      pathname: '/api/secrets/does-not-exist/stale-sessions',
+      method: 'GET',
+      url: new URL('https://x/api/secrets/does-not-exist/stale-sessions'),
+      req: fakeReq(),
+      res: cap.res,
+    });
+
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(404);
+    expect(cap.body).toMatchObject({ error: expect.stringContaining('does-not-exist') });
+  });
+
+  it('falls through (returns false) on non-GET methods so the dispatcher can keep looking', async () => {
+    const cap = fakeRes();
+    const handled = await handleSecretsRoute({
+      pathname: '/api/secrets/anything/stale-sessions',
+      method: 'POST',
+      url: new URL('https://x/api/secrets/anything/stale-sessions'),
+      req: fakeReq(),
+      res: cap.res,
+    });
+    expect(handled).toBe(false);
+  });
+});

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -1,11 +1,13 @@
 /**
  * /api/secrets — CRUD over paraclaw's local AES-256-GCM secret store.
  *
- * Every endpoint requires `claw:write` for mutation, `claw:read` for the
- * list-metadata view. Plaintext values are accepted on PUT and never
- * returned by any GET — listSecrets() is metadata-only by design. There is
- * no "show value" endpoint; if a human needs the value they should re-mint
- * (or back it out via the original platform's UI).
+ * Auth: `claw:admin` for mutation (POST/PUT/DELETE), `claw:read` for GET.
+ * The mutation gate is admin-not-write because a write-only token would
+ * otherwise be enough to swap any vault credential and silently MITM
+ * downstream API calls. Plaintext values are accepted on POST and never
+ * returned by any GET — `listSecrets()` is metadata-only by design. There
+ * is no "show value" endpoint; if a human needs the value they should
+ * re-mint (or back it out via the original platform's UI).
  */
 import http from 'node:http';
 

--- a/src/web/routes/secrets.ts
+++ b/src/web/routes/secrets.ts
@@ -16,6 +16,8 @@ import {
   type SecretRow,
   addAssignment,
   deleteSecret,
+  findStaleSessionsForSecret,
+  getSecretById,
   listAssignments,
   listSecrets,
   putSecret,
@@ -171,6 +173,26 @@ export async function handleSecretsRoute(ctx: SecretsRouteContext): Promise<bool
       return true;
     }
     json(res, 200, { secret: toView(view) });
+    return true;
+  }
+
+  // Stale-sessions probe — match before the bare /:id DELETE so the more-specific
+  // path wins. Surface for the post-save banner: which running containers were
+  // spawned BEFORE this secret's last update AND would inject it on next spawn?
+  const staleMatch = pathname.match(/^\/api\/secrets\/([^/]+)\/stale-sessions$/);
+  if (staleMatch && method === 'GET') {
+    const id = decodeURIComponent(staleMatch[1]);
+    const meta = getSecretById(id);
+    if (!meta) {
+      error(res, 404, `secret not found: ${id}`);
+      return true;
+    }
+    const stale = findStaleSessionsForSecret(id);
+    json(res, 200, {
+      secretId: id,
+      secretUpdatedAt: meta.updated_at,
+      staleSessions: stale,
+    });
     return true;
   }
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -752,6 +752,31 @@ export async function setSecretAssignments(secretId: string, agentGroupIds: stri
   return r.agentGroupIds;
 }
 
+/**
+ * Sessions whose container was spawned BEFORE this secret's last update AND
+ * whose agent group would still inject it. The post-save banner surfaces
+ * these so the operator can restart specific sessions to pick up the change
+ * — env vars are spawn-time-only, so a running container will never see a
+ * mid-life edit otherwise.
+ */
+export interface StaleSession {
+  sessionId: string;
+  agentGroupId: string;
+  agentGroupName: string;
+  agentGroupFolder: string;
+  sessionCreatedAt: string;
+  secretUpdatedAt: string;
+}
+
+export async function listStaleSessionsForSecret(secretId: string): Promise<StaleSession[]> {
+  const r = await request<{
+    secretId: string;
+    secretUpdatedAt: string;
+    staleSessions: StaleSession[];
+  }>(`/secrets/${encodeURIComponent(secretId)}/stale-sessions`);
+  return r.staleSessions;
+}
+
 // --- Approvals ---
 
 export type ApprovalKind = 'install_packages' | 'add_mcp_server' | 'access-new-credential' | string;

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -133,7 +133,7 @@ export function GroupDetail() {
     if (!folder) return;
     if (
       !window.confirm(
-        "Restart this agent's container? The current session will end; the agent's next reply will spawn a fresh container picking up the latest secrets, env, and code. The conversation context is reset.",
+        "Restart this agent's container? The current session ends; the agent's next reply will spawn a fresh container picking up the latest secrets, env, and code. The chat thread is preserved; only the container's in-memory state resets.",
       )
     ) {
       return;

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -8,6 +8,7 @@ import { VaultPicker } from '../components/VaultPicker.tsx';
 import {
   attachVault,
   clearGroupAgentProvider,
+  closeSession,
   detachVault,
   getGroup,
   getGroupAgentProvider,
@@ -46,6 +47,7 @@ export function GroupDetail() {
   const [tokenLabel, setTokenLabel] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [spawning, setSpawning] = useState(false);
+  const [restartingSessionId, setRestartingSessionId] = useState<string | null>(null);
   const [flash, setFlash] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
 
   const reload = useCallback(async () => {
@@ -119,6 +121,36 @@ export function GroupDetail() {
       });
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  // Reap a running session's container. The host's session-close path is
+  // synchronous (kill + mark closed), so by the time `closeSession` resolves
+  // the container is gone. Next inbound message spawns fresh — that's what
+  // makes this the canonical way to pick up secrets/env/code changes that
+  // were baked at spawn time and aren't readable mid-life.
+  const onRestartSession = async (sessionId: string) => {
+    if (!folder) return;
+    if (
+      !window.confirm(
+        "Restart this agent's container? The current session will end; the agent's next reply will spawn a fresh container picking up the latest secrets, env, and code. The conversation context is reset.",
+      )
+    ) {
+      return;
+    }
+    setRestartingSessionId(sessionId);
+    setFlash(null);
+    try {
+      await closeSession(sessionId);
+      await reload();
+      setFlash({
+        kind: 'ok',
+        text: `Session ${sessionId} closed. The agent's next message will spawn a fresh container.`,
+      });
+    } catch (err) {
+      setFlash({ kind: 'error', text: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setRestartingSessionId(null);
     }
   };
 
@@ -282,7 +314,15 @@ export function GroupDetail() {
             </div>
           </div>
 
-          {group.status && <StatusSection status={group.status} onSpawn={onSpawn} spawning={spawning} />}
+          {group.status && (
+            <StatusSection
+              status={group.status}
+              onSpawn={onSpawn}
+              spawning={spawning}
+              onRestartSession={onRestartSession}
+              restartingSessionId={restartingSessionId}
+            />
+          )}
 
           {folder && <AgentProviderSection folder={folder} />}
 
@@ -586,7 +626,19 @@ function DetailTabs({ tab, onChange }: { tab: DetailTab; onChange: (next: Detail
   );
 }
 
-function StatusSection({ status, onSpawn, spawning }: { status: GroupStatus; onSpawn: () => void; spawning: boolean }) {
+function StatusSection({
+  status,
+  onSpawn,
+  spawning,
+  onRestartSession,
+  restartingSessionId,
+}: {
+  status: GroupStatus;
+  onSpawn: () => void;
+  spawning: boolean;
+  onRestartSession: (sessionId: string) => void;
+  restartingSessionId: string | null;
+}) {
   return (
     <div className="section">
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
@@ -595,6 +647,10 @@ function StatusSection({ status, onSpawn, spawning }: { status: GroupStatus; onS
           {spawning ? 'Spawning…' : '+ New session'}
         </button>
       </div>
+      <p className="dim" style={{ marginTop: '0.5rem', marginBottom: 0 }}>
+        Container env (secrets, agent provider, code) is set at session spawn. To pick up changes, use{' '}
+        <strong>Restart</strong> on a running session — the agent's next message will spawn a fresh container.
+      </p>
       <div className="kv" style={{ marginTop: '1rem' }}>
         <div>container</div>
         <div>
@@ -653,23 +709,41 @@ function StatusSection({ status, onSpawn, spawning }: { status: GroupStatus; onS
             Sessions ({status.sessions.length}):
           </div>
           <ul className="session-list">
-            {status.sessions.map((s) => (
-              <li key={s.sessionId}>
-                <code>{s.sessionId}</code>{' '}
-                {s.alive ? (
-                  <span className="status-text alive">alive</span>
-                ) : (
-                  <span className="status-text idle">{s.containerStatus}</span>
-                )}{' '}
-                <span className="dim">— {s.status}</span>
-                {s.lastHeartbeatAt && (
-                  <>
-                    {' '}
-                    <span className="dim">· hb {formatRelative(s.lastHeartbeatAt)}</span>
-                  </>
-                )}
-              </li>
-            ))}
+            {status.sessions.map((s) => {
+              const restartable = s.containerStatus === 'running' && s.status === 'active';
+              const isRestarting = restartingSessionId === s.sessionId;
+              return (
+                <li key={s.sessionId}>
+                  <code>{s.sessionId}</code>{' '}
+                  {s.alive ? (
+                    <span className="status-text alive">alive</span>
+                  ) : (
+                    <span className="status-text idle">{s.containerStatus}</span>
+                  )}{' '}
+                  <span className="dim">— {s.status}</span>
+                  {s.lastHeartbeatAt && (
+                    <>
+                      {' '}
+                      <span className="dim">· hb {formatRelative(s.lastHeartbeatAt)}</span>
+                    </>
+                  )}
+                  {restartable && (
+                    <>
+                      {' '}
+                      <button
+                        type="button"
+                        className="secondary"
+                        style={{ marginLeft: '0.5rem', padding: '0.15rem 0.6rem', fontSize: '0.85rem' }}
+                        onClick={() => onRestartSession(s.sessionId)}
+                        disabled={restartingSessionId !== null}
+                      >
+                        {isRestarting ? 'Restarting…' : 'Restart'}
+                      </button>
+                    </>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </>
       )}

--- a/web/ui/src/routes/SecretsList.tsx
+++ b/web/ui/src/routes/SecretsList.tsx
@@ -717,6 +717,11 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
 
               {showAssignmentsGrid && (
                 <div className="row">
+                  <p className="dim" style={{ marginTop: 0, marginBottom: '0.5rem' }}>
+                    Secrets are injected into agent containers at <strong>session spawn</strong>. Changes apply to new
+                    sessions; running containers won't see them until restarted (the post-save banner below flags any
+                    affected sessions, with a one-click Restart per session).
+                  </p>
                   <label>Assigned to ({assignments.size})</label>
                   {!assignmentsLoaded && <p className="dim">Loading current assignments…</p>}
                   {assignmentsLoaded && groups.length === 0 && (

--- a/web/ui/src/routes/SecretsList.tsx
+++ b/web/ui/src/routes/SecretsList.tsx
@@ -25,16 +25,19 @@ import { Link } from 'react-router-dom';
 import { CredentialForm } from '../components/CredentialForm.tsx';
 import { formatRelative } from '../components/StatusDot.tsx';
 import {
+  closeSession,
   deleteSecret,
   listGroups,
   listSecretAssignments,
   listSecrets,
+  listStaleSessionsForSecret,
   putSecret,
   setSecretAssignments,
   type AgentGroupView,
   type AssignedMode,
   type SecretKind,
   type SecretView,
+  type StaleSession,
 } from '../lib/api.ts';
 
 // Kind display order — channel-tokens first since they're the most common
@@ -448,17 +451,38 @@ interface EditorProps {
 }
 
 /**
- * Edit drawer rendered as a native <dialog>. Three concurrent edits in scope:
- *   1. Inject mode (all|selective)
- *   2. Selective assignments (multi-select agent groups)
- *   3. Value rotation
+ * Edit drawer rendered as a native <dialog>. Concurrent edits in scope:
+ *   1. Per-group accept-mode (only for SCOPED secrets — the radio flips the
+ *      parent agent group's `secret_mode`, which gates how that group accepts
+ *      every secret routed to it, not just this one).
+ *   2. Selective assignments (multi-select agent groups). Always shown for
+ *      globals; shown for scoped only when accept-mode is `selective`.
+ *   3. Value rotation.
  *
- * Mode flips and kind changes both require value re-paste because the server's
- * POST upsert wire requires `value`. Assignment-only edits go straight to the
- * /assignments PUT and don't touch the secret value at all.
+ * Globals do NOT get a per-secret mode toggle: post-migration-023, mode lives
+ * on the recipient agent group, so flipping a "mode" on a global has no
+ * destination to land in (paraclaw#103 — Bug A: silent-mode-toggle on
+ * globals). The assignment grid is the operator's actual handle for
+ * scoping a global.
+ *
+ * Mode flips for SCOPED secrets still require value re-paste because the
+ * server's POST upsert wire requires `value` and that's how the parent
+ * group's mode change gets persisted today. Assignment-only edits go
+ * straight to /assignments PUT and don't touch the secret value at all.
+ *
+ * Post-save, the editor probes /api/secrets/:id/stale-sessions and surfaces
+ * a banner with [Restart] buttons when running containers were spawned
+ * before this secret's last update — env vars are spawn-time-only, so a
+ * mid-life edit is invisible to a container that's already running
+ * (paraclaw#103 — Bug B: stale-container env).
  */
 function SecretEditor({ secret, groups, onClose }: EditorProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  const isGlobal = secret.agentGroupId === null;
+  const groupName = secret.agentGroupId
+    ? (groups.find((g) => g.id === secret.agentGroupId)?.name ?? secret.agentGroupId.slice(0, 8))
+    : 'global';
 
   const [mode, setMode] = useState<AssignedMode>(secret.assignedMode);
   const [assignments, setAssignments] = useState<Set<string>>(new Set());
@@ -467,6 +491,9 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
   const [value, setValue] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [staleSessions, setStaleSessions] = useState<StaleSession[] | null>(null);
+  const [restartingId, setRestartingId] = useState<string | null>(null);
+  const saved = staleSessions !== null;
 
   // Open the dialog on mount, close imperatively on unmount. Native <dialog>
   // gives us focus-trap + ESC-to-close for free.
@@ -510,7 +537,9 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
       return next;
     });
 
-  const modeChanged = mode !== secret.assignedMode;
+  // Mode changes only have meaning for SCOPED secrets — for globals there
+  // is no parent group to flip, so we never expose a UI for it.
+  const modeChanged = !isGlobal && mode !== secret.assignedMode;
   const assignmentsChanged = (() => {
     if (!assignmentsLoaded || !initialAssignmentsRef.current) return false;
     const init = initialAssignmentsRef.current;
@@ -520,10 +549,16 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
   })();
   const valueProvided = value.trim().length > 0;
 
+  // Globals: always show the assignment grid (it's the only handle).
+  // Scoped: show only when accept-mode is `selective` (else group accepts all).
+  const showAssignmentsGrid = isGlobal || mode === 'selective';
+
   const save = async () => {
     setError(null);
     if (modeChanged && !valueProvided) {
-      setError('Switching inject mode requires re-pasting the secret value (the server upsert wire requires it).');
+      setError(
+        `Changing how ${groupName} accepts secrets requires re-pasting this secret's value (the server upsert wire requires it).`,
+      );
       return;
     }
     setBusy(true);
@@ -534,16 +569,25 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
           value: value.trim(),
           kind: secret.kind,
           agentGroupId: secret.agentGroupId,
-          assignedMode: mode,
+          // Globals have no parent group to land mode on — sending it would
+          // silently no-op on the server. Scoped flips the parent group.
+          assignedMode: isGlobal ? undefined : mode,
         });
       }
       // Push assignments whenever they changed, OR whenever we just upserted
       // the secret with selective mode (so the join-table reflects intent
       // even on first switch).
-      if (mode === 'selective' && (assignmentsChanged || (modeChanged && valueProvided))) {
+      if (showAssignmentsGrid && (assignmentsChanged || (modeChanged && valueProvided))) {
         await setSecretAssignments(secret.id, Array.from(assignments));
       }
-      onClose(true);
+      // Probe staleness — running containers spawned before this update
+      // won't see the change until next session spawn. Banner stays open
+      // so the operator can restart specific sessions inline.
+      const stale = await listStaleSessionsForSecret(secret.id);
+      setStaleSessions(stale);
+      if (stale.length === 0) {
+        onClose(true);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -551,15 +595,44 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
     }
   };
 
-  const noAssignmentsWarn = mode === 'selective' && assignmentsLoaded && assignments.size === 0;
-  const scopeLabel = secret.agentGroupId
-    ? (groups.find((g) => g.id === secret.agentGroupId)?.name ?? secret.agentGroupId.slice(0, 8))
-    : 'global';
+  const restartSession = async (sessionId: string) => {
+    setError(null);
+    setRestartingId(sessionId);
+    try {
+      await closeSession(sessionId);
+      setStaleSessions((prev) => (prev ?? []).filter((s) => s.sessionId !== sessionId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRestartingId(null);
+    }
+  };
+
+  const restartAll = async () => {
+    if (!staleSessions || staleSessions.length === 0) return;
+    setError(null);
+    setBusy(true);
+    try {
+      // Sequential — count is small (one running container per agent group),
+      // and serializing keeps the runtime from being hammered with concurrent
+      // killContainer calls in the rare large-fanout case.
+      for (const s of staleSessions) {
+        await closeSession(s.sessionId);
+      }
+      setStaleSessions([]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const noAssignmentsWarn = !isGlobal && mode === 'selective' && assignmentsLoaded && assignments.size === 0;
 
   return (
     <dialog
       ref={dialogRef}
-      onClose={() => onClose(false)}
+      onClose={() => onClose(saved)}
       className="secret-editor"
       style={{
         width: 'min(560px, 92vw)',
@@ -578,7 +651,7 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
             <button
               type="button"
               className="secondary"
-              onClick={() => onClose(false)}
+              onClick={() => onClose(saved)}
               style={{ padding: '0.3rem 0.7rem' }}
               aria-label="Close"
             >
@@ -587,7 +660,7 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
           </div>
           <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem', flexWrap: 'wrap' }}>
             <span className="tag muted">{secret.kind}</span>
-            <span className="tag muted">{scopeLabel}</span>
+            <span className="tag muted">{groupName}</span>
           </div>
           <div className="dim" style={{ marginTop: '0.5rem' }}>
             created <span title={new Date(secret.createdAt).toLocaleString()}>{formatRelative(secret.createdAt)}</span>
@@ -598,113 +671,232 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
         <div style={{ padding: '1.25rem 1.5rem' }}>
           {error && <div className="error-banner">{error}</div>}
 
-          <div className="row">
-            <label>Inject mode</label>
-            <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
-              <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
-                <input
-                  type="radio"
-                  name="mode"
-                  value="all"
-                  checked={mode === 'all'}
-                  onChange={() => setMode('all')}
-                  disabled={busy}
-                />
-                <span>all</span>
-              </label>
-              <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
-                <input
-                  type="radio"
-                  name="mode"
-                  value="selective"
-                  checked={mode === 'selective'}
-                  onChange={() => setMode('selective')}
-                  disabled={busy}
-                />
-                <span>selective</span>
-              </label>
-            </div>
-            <p className="dim" style={{ marginTop: '0.4rem' }}>
-              {mode === 'all'
-                ? 'Injected into every agent container whose scope matches.'
-                : 'Injected only into the agent groups you check below.'}
-            </p>
-          </div>
-
-          {mode === 'selective' && (
-            <div className="row">
-              <label>Assigned to ({assignments.size})</label>
-              {!assignmentsLoaded && <p className="dim">Loading current assignments…</p>}
-              {assignmentsLoaded && groups.length === 0 && (
-                <p className="dim">No agent groups exist yet — create one to assign this secret.</p>
-              )}
-              {assignmentsLoaded && groups.length > 0 && (
-                <div
-                  style={{
-                    display: 'grid',
-                    gap: '0.35rem',
-                    maxHeight: '14rem',
-                    overflowY: 'auto',
-                    border: '1px solid var(--border)',
-                    borderRadius: 6,
-                    padding: '0.5rem 0.75rem',
-                  }}
-                >
-                  {groups.map((g) => (
-                    <label key={g.id} style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', fontWeight: 400 }}>
+          {!saved && (
+            <>
+              {isGlobal ? (
+                <p className="dim" style={{ marginBottom: '1rem' }}>
+                  <strong>Global secret.</strong> Eligible for every agent group. Inject targets are the groups
+                  checked below, plus any group whose own accept-mode is <code>all</code>. Per-group accept-mode
+                  lives on the agent group, not the secret.
+                </p>
+              ) : (
+                <div className="row">
+                  <label>
+                    <strong>{groupName}</strong> accepts
+                  </label>
+                  <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
+                    <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
                       <input
-                        type="checkbox"
-                        checked={assignments.has(g.id)}
-                        onChange={() => toggleAssignment(g.id)}
+                        type="radio"
+                        name="mode"
+                        value="all"
+                        checked={mode === 'all'}
+                        onChange={() => setMode('all')}
                         disabled={busy}
                       />
-                      <span>{g.name}</span>
-                      <code style={{ fontSize: '0.78rem', color: 'var(--fg-dim)' }}>{g.folder}</code>
+                      <span>all in-scope secrets</span>
                     </label>
-                  ))}
+                    <label style={{ display: 'inline-flex', gap: '0.4rem', alignItems: 'center', fontWeight: 400 }}>
+                      <input
+                        type="radio"
+                        name="mode"
+                        value="selective"
+                        checked={mode === 'selective'}
+                        onChange={() => setMode('selective')}
+                        disabled={busy}
+                      />
+                      <span>only assigned secrets</span>
+                    </label>
+                  </div>
+                  <p className="dim" style={{ marginTop: '0.4rem' }}>
+                    This setting controls how <strong>{groupName}</strong> accepts secrets from any source — not
+                    just this one. Changing it affects every secret destined for this group.
+                  </p>
                 </div>
               )}
-              {noAssignmentsWarn && (
-                <div className="warn-banner" style={{ marginTop: '0.5rem' }}>
-                  Selective mode with zero assignments — this secret will inject into nothing. OK if intentional, but
-                  containers that read this name will see it as unset.
+
+              {showAssignmentsGrid && (
+                <div className="row">
+                  <label>Assigned to ({assignments.size})</label>
+                  {!assignmentsLoaded && <p className="dim">Loading current assignments…</p>}
+                  {assignmentsLoaded && groups.length === 0 && (
+                    <p className="dim">No agent groups exist yet — create one to assign this secret.</p>
+                  )}
+                  {assignmentsLoaded && groups.length > 0 && (
+                    <div
+                      style={{
+                        display: 'grid',
+                        gap: '0.35rem',
+                        maxHeight: '14rem',
+                        overflowY: 'auto',
+                        border: '1px solid var(--border)',
+                        borderRadius: 6,
+                        padding: '0.5rem 0.75rem',
+                      }}
+                    >
+                      {groups.map((g) => (
+                        <label
+                          key={g.id}
+                          style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', fontWeight: 400 }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={assignments.has(g.id)}
+                            onChange={() => toggleAssignment(g.id)}
+                            disabled={busy}
+                          />
+                          <span>{g.name}</span>
+                          <code style={{ fontSize: '0.78rem', color: 'var(--fg-dim)' }}>{g.folder}</code>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                  {noAssignmentsWarn && (
+                    <div className="warn-banner" style={{ marginTop: '0.5rem' }}>
+                      Selective mode with zero assignments — this secret will inject into nothing. OK if intentional,
+                      but containers that read this name will see it as unset.
+                    </div>
+                  )}
                 </div>
               )}
-            </div>
+
+              <div className="row">
+                <label htmlFor="rotateValue">
+                  {modeChanged ? 'Value (required to apply accept-mode change)' : 'Rotate value (optional)'}
+                </label>
+                <input
+                  id="rotateValue"
+                  type="password"
+                  autoComplete="off"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  disabled={busy}
+                  placeholder={modeChanged ? 'paste current value' : 'leave blank to keep current value'}
+                />
+                <p className="dim" style={{ marginTop: '0.25rem' }}>
+                  Value is never read back over the API; rotating writes a new ciphertext under the same name.
+                </p>
+              </div>
+
+              <div className="actions" style={{ marginTop: '1rem', justifyContent: 'flex-end' }}>
+                <button type="button" className="secondary" onClick={() => onClose(false)} disabled={busy}>
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={save}
+                  disabled={busy || (!modeChanged && !assignmentsChanged && !valueProvided)}
+                >
+                  {busy ? 'Saving…' : 'Save changes'}
+                </button>
+              </div>
+            </>
           )}
 
-          <div className="row">
-            <label htmlFor="rotateValue">
-              {modeChanged ? 'Value (required to apply mode change)' : 'Rotate value (optional)'}
-            </label>
-            <input
-              id="rotateValue"
-              type="password"
-              autoComplete="off"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              disabled={busy}
-              placeholder={modeChanged ? 'paste current value' : 'leave blank to keep current value'}
+          {saved && (
+            <StalenessBanner
+              staleSessions={staleSessions ?? []}
+              restartingId={restartingId}
+              busy={busy}
+              onRestart={restartSession}
+              onRestartAll={restartAll}
+              onDone={() => onClose(true)}
             />
-            <p className="dim" style={{ marginTop: '0.25rem' }}>
-              Value is never read back over the API; rotating writes a new ciphertext under the same name.
-            </p>
-          </div>
-
-          <div className="actions" style={{ marginTop: '1rem', justifyContent: 'flex-end' }}>
-            <button type="button" className="secondary" onClick={() => onClose(false)} disabled={busy}>
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              disabled={busy || (!modeChanged && !assignmentsChanged && !valueProvided)}
-            >
-              {busy ? 'Saving…' : 'Save changes'}
-            </button>
-          </div>
+          )}
         </div>
       </form>
     </dialog>
+  );
+}
+
+interface StalenessBannerProps {
+  staleSessions: StaleSession[];
+  restartingId: string | null;
+  busy: boolean;
+  onRestart: (sessionId: string) => void;
+  onRestartAll: () => void;
+  onDone: () => void;
+}
+
+/**
+ * Post-save banner. Lists running containers spawned BEFORE the secret's
+ * latest update — they won't see the change until next spawn. The operator
+ * can restart specific sessions or all at once. "Done" closes the editor
+ * regardless of whether any restart happened.
+ */
+function StalenessBanner({
+  staleSessions,
+  restartingId,
+  busy,
+  onRestart,
+  onRestartAll,
+  onDone,
+}: StalenessBannerProps) {
+  if (staleSessions.length === 0) {
+    return (
+      <div className="row">
+        <p>Saved. No running containers needed a restart to see the change.</p>
+        <div className="actions" style={{ marginTop: '1rem', justifyContent: 'flex-end' }}>
+          <button type="button" onClick={onDone}>
+            Done
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="row">
+      <div className="warn-banner" style={{ marginBottom: '1rem' }}>
+        <strong>
+          {staleSessions.length} running {staleSessions.length === 1 ? 'container was' : 'containers were'} spawned
+          before this change.
+        </strong>{' '}
+        Env vars are baked at spawn time, so the new value won't reach{' '}
+        {staleSessions.length === 1 ? 'it' : 'them'} until next session. Restart to apply.
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gap: '0.5rem',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+          padding: '0.5rem 0.75rem',
+        }}
+      >
+        {staleSessions.map((s) => (
+          <div
+            key={s.sessionId}
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.75rem' }}
+          >
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <div>
+                <strong>{s.agentGroupName}</strong>{' '}
+                <code style={{ fontSize: '0.78rem', color: 'var(--fg-dim)' }}>{s.agentGroupFolder}</code>
+              </div>
+              <div className="dim" style={{ fontSize: '0.85em' }} title={new Date(s.sessionCreatedAt).toLocaleString()}>
+                spawned {formatRelative(s.sessionCreatedAt)}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => onRestart(s.sessionId)}
+              disabled={busy || restartingId === s.sessionId}
+            >
+              {restartingId === s.sessionId ? 'Restarting…' : 'Restart'}
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="actions" style={{ marginTop: '1rem', justifyContent: 'space-between' }}>
+        <button type="button" className="secondary" onClick={onRestartAll} disabled={busy}>
+          {busy ? 'Restarting all…' : `Restart all ${staleSessions.length}`}
+        </button>
+        <button type="button" onClick={onDone} disabled={busy}>
+          Done
+        </button>
+      </div>
+    </div>
   );
 }

--- a/web/ui/src/routes/SecretsList.tsx
+++ b/web/ui/src/routes/SecretsList.tsx
@@ -854,7 +854,7 @@ function StalenessBanner({
   if (staleSessions.length === 0) {
     return (
       <div className="row">
-        <p>Saved. No running containers needed a restart to see the change.</p>
+        <p>Saved. No outstanding stale containers.</p>
         <div className="actions" style={{ marginTop: '1rem', justifyContent: 'flex-end' }}>
           <button type="button" onClick={onDone}>
             Done

--- a/web/ui/src/routes/SecretsList.tsx
+++ b/web/ui/src/routes/SecretsList.tsx
@@ -610,18 +610,32 @@ function SecretEditor({ secret, groups, onClose }: EditorProps) {
 
   const restartAll = async () => {
     if (!staleSessions || staleSessions.length === 0) return;
+    if (
+      !window.confirm(
+        `Restart ${staleSessions.length} agent session(s)? Each agent's current conversation will end and a fresh container will spawn on next inbound message.`,
+      )
+    ) {
+      return;
+    }
     setError(null);
     setBusy(true);
+    // Sequential — count is small (one running container per agent group),
+    // and serializing keeps the runtime from being hammered with concurrent
+    // killContainer calls in the rare large-fanout case. Track successes
+    // inside the loop so a mid-run throw on session N doesn't leave the
+    // banner showing 1..N-1 as still-stale (they were already closed).
+    const closed = new Set<string>();
     try {
-      // Sequential — count is small (one running container per agent group),
-      // and serializing keeps the runtime from being hammered with concurrent
-      // killContainer calls in the rare large-fanout case.
       for (const s of staleSessions) {
         await closeSession(s.sessionId);
+        closed.add(s.sessionId);
       }
       setStaleSessions([]);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setStaleSessions((prev) => (prev ?? []).filter((s) => !closed.has(s.sessionId)));
+      setError(
+        `Restarted ${closed.size}/${staleSessions.length} session(s); ${err instanceof Error ? err.message : String(err)}`,
+      );
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
## Summary

Two bugs from Aaron's WovenBoulder credential attach + a UX gap surfaced during diagnosis. All visible from the same operator-flow (`/claw/secrets` → `/claw/groups/<id>`).

### Bug A — silent mode-toggle on globals (UI)

Per-secret `assignedMode` lost meaning post-migration-023 (mode lives on the recipient `agent_groups.secret_mode` now). For globals there's no parent group to flip into, so the radio was a no-op that pretended to do something.

**Fix:** hide the radio entirely for globals (with explainer); for scoped secrets, reframe as `<groupName> accepts: [all in-scope secrets | only assigned secrets]` so the per-group nature of the setting is clear.

### Bug B — stale-container env (server + UI)

Container env vars are baked at spawn time and never updated. Aaron's wovenboulder container spawned 30 minutes before `WOVENBOULDER_GITHUB` was attached — `docker exec env` showed nothing even though `resolveInjectableSecrets` resolved correctly for the next spawn. No signal to the operator that a restart was required.

**Fix:**
- `findStaleSessionsForSecret(secretId)` walks running sessions whose agent group would inject the secret AND whose `created_at < secret.updated_at`.
- `GET /api/secrets/:id/stale-sessions` exposes it (`claw:read`).
- `SecretEditor` probes after save and renders a banner: per-session `[Restart]` buttons + `Restart all N`. Restart calls `closeSession` so paraclaw lifecycle reaps the container; the next spawn picks up the fresh env.

### Restart UX + messaging (broadened scope, per Aaron)

The contextual staleness banner only fires post-save in the secrets editor. Operators also need an unconditional path to restart an agent's container — for code / agent-provider / env changes too, not just secrets.

**Added:**
- `GroupDetail.tsx`: per-session `[Restart]` button on running, active sessions in the Live status list. Same `closeSession` path; confirmation modal spells out trade-offs (fresh secrets/env/code; conversation context resets).
- `GroupDetail.tsx`: inline help under the Live status header explaining the spawn-time env semantics.
- `SecretEditor`: inline help above the assignment grid noting running containers won't pick up new secrets until restarted, with a forward-pointer to the post-save banner.

No new server endpoints — every restart surface uses the existing `POST /api/sessions/:id/close`.

## Commits

- `ffb7260` — Bug A + Bug B (server + post-save banner). Bug A and the SecretEditor banner share `SecretEditor`, so a per-feature split would break the intermediate file state.
- `8d0af78` — prettier-only fixup from a post-hook reformat that landed after staging.
- `d74c33d` — broadened scope: per-session Restart on GroupDetail + spawn-time messaging.

## Gates

- `pnpm test` — 501/501 pass (24/24 in `src/secrets/secrets.test.ts`, 9 new for staleness + `getSecretById`)
- `pnpm exec tsc --noEmit` — clean
- `pnpm run build:spa` — clean
- `pnpm run lint` — 0 new errors (9 pre-existing baseline unchanged)

## Bumps to `0.0.14-rc.41`

## Test plan

- [ ] `/claw/secrets`: edit a global secret — radio hidden, explainer + assignment grid + assignment-grid inline-help shown.
- [ ] `/claw/secrets`: edit a scoped secret — radio reframed as `<groupName> accepts:` with helper text.
- [ ] `/claw/secrets`: save a secret with a running pre-existing container — staleness banner appears with `[Restart]` buttons that close the session.
- [ ] `/claw/groups/<folder>`: Live status shows inline help; running sessions have `[Restart]` button; click triggers confirm modal then closes session.
- [ ] WovenBoulder agent receives `WOVENBOULDER_GITHUB` env on next message after restart.

## Out of scope (filed separately)

- #104 — Gap C: per-agent Secrets section on GroupDetail (deferred per team-lead direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)