### PR TITLE
fix: master.key migration warn-on-both-exist + SPA title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.1] - 2026-05-05
+
+### Fixed
+
+- **Master-key migration: detect the both-exist split-state explicitly.** `migrateMasterKeyLocation` previously silent-no-op'd when both `<PARACHUTE_DIR>/claw/master.key` and `<PARACHUTE_DIR>/agent/master.key` existed — masking the case where an earlier 0.1.x boot generated a fresh key at the new path before the legacy was copied (so encrypted secrets sealed under the legacy key became undecryptable). The function now logs a `warn` with both paths and copy-pasteable recovery commands. Standalone scripts that ran `migrateCentralDbLocation` (`init-cli-agent`, `init-first-agent`, `seed-discord`) now also run `migrateMasterKeyLocation` before opening the DB, so a script-driven first touch of the central DB no longer skips the key copy.
+- **SPA browser title.** `<title>Paraclaw</title>` → `<title>Parachute Agent</title>` and the meta description now references "Parachute Agent groups". Two GitHub repo links in the navbar and the group-detail page point at `parachute-agent` (not the renamed-from `paraclaw` repo URL).
+
 ## [0.1.1] - 2026-05-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.1",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/scripts/init-cli-agent.ts
+++ b/scripts/init-cli-agent.ts
@@ -21,7 +21,7 @@ import path from 'path';
 
 import { CENTRAL_DB_PATH } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { initDb, migrateCentralDbLocation } from '../src/db/connection.js';
+import { initDb, migrateCentralDbLocation, migrateMasterKeyLocation } from '../src/db/connection.js';
 import {
   createMessagingGroup,
   createMessagingGroupAgent,
@@ -78,6 +78,7 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
   migrateCentralDbLocation();
+  migrateMasterKeyLocation();
   const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db);
 

--- a/scripts/init-first-agent.ts
+++ b/scripts/init-first-agent.ts
@@ -35,7 +35,7 @@ import path from 'path';
 
 import { CENTRAL_DB_PATH, DATA_DIR } from '../src/config.js';
 import { createAgentGroup, getAgentGroupByFolder } from '../src/db/agent-groups.js';
-import { initDb, migrateCentralDbLocation } from '../src/db/connection.js';
+import { initDb, migrateCentralDbLocation, migrateMasterKeyLocation } from '../src/db/connection.js';
 import {
   createMessagingGroup,
   createMessagingGroupAgent,
@@ -170,6 +170,7 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
   migrateCentralDbLocation();
+  migrateMasterKeyLocation();
   const db = initDb(CENTRAL_DB_PATH);
   runMigrations(db); // idempotent
 

--- a/scripts/seed-discord.ts
+++ b/scripts/seed-discord.ts
@@ -4,7 +4,7 @@
  * Usage: pnpm exec tsx scripts/seed-discord.ts
  */
 import { CENTRAL_DB_PATH } from '../src/config.js';
-import { initDb, migrateCentralDbLocation } from '../src/db/connection.js';
+import { initDb, migrateCentralDbLocation, migrateMasterKeyLocation } from '../src/db/connection.js';
 import { runMigrations } from '../src/db/migrations/index.js';
 import { createAgentGroup, getAgentGroup } from '../src/db/agent-groups.js';
 import {
@@ -14,6 +14,7 @@ import {
 } from '../src/db/messaging-groups.js';
 
 migrateCentralDbLocation();
+migrateMasterKeyLocation();
 const db = initDb(CENTRAL_DB_PATH);
 runMigrations(db);
 

--- a/src/db/connection.migrate.test.ts
+++ b/src/db/connection.migrate.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { migrateCentralDbLocation, migrateMasterKeyLocation } from './connection.js';
+import { log } from '../log.js';
 
 let tmp: string;
 let legacy: string;
@@ -129,15 +130,47 @@ describe('migrateMasterKeyLocation', () => {
     }
   });
 
-  it('current key already exists — legacy left untouched (no clobber)', () => {
-    mkdirSync(legacyDir, { recursive: true });
-    writeFileSync(legacyKey, 'old-key-bytes-padding-to-32-aaaa');
+  it('current key already exists, no legacy — noop (already migrated, or fresh install)', () => {
     mkdirSync(currentDir, { recursive: true });
     writeFileSync(currentKey, 'new-key-bytes-padding-to-32-aaaa');
 
     migrateMasterKeyLocation(legacyDir, currentDir);
 
     expect(readFileSync(currentKey, 'utf8')).toBe('new-key-bytes-padding-to-32-aaaa');
+    expect(existsSync(legacyKey)).toBe(false);
+  });
+
+  it('both keys exist — log a warn with recovery hint, leave both untouched', () => {
+    // Regression for parachute-agent#114: a previous boot generated a fresh
+    // key at the new path before the legacy was copied, so encrypted-secret
+    // rows sealed under the legacy key are now undecryptable. Don't
+    // clobber — surface it loudly so the operator can choose how to recover.
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(legacyKey, 'old-key-bytes-padding-to-32-aaaa');
+    mkdirSync(currentDir, { recursive: true });
+    writeFileSync(currentKey, 'new-key-bytes-padding-to-32-aaaa');
+
+    const original = log.warn;
+    const calls: Array<[string, Record<string, unknown> | undefined]> = [];
+    log.warn = ((msg: string, data?: Record<string, unknown>) => {
+      calls.push([msg, data]);
+    }) as typeof log.warn;
+    try {
+      migrateMasterKeyLocation(legacyDir, currentDir);
+    } finally {
+      log.warn = original;
+    }
+
+    expect(readFileSync(currentKey, 'utf8')).toBe('new-key-bytes-padding-to-32-aaaa');
     expect(readFileSync(legacyKey, 'utf8')).toBe('old-key-bytes-padding-to-32-aaaa');
+    expect(calls).toHaveLength(1);
+    const [msg, ctx] = calls[0]!;
+    expect(msg).toMatch(/both/i);
+    const ctxObj = ctx as { legacy: string; current: string; note: string };
+    expect(ctxObj.legacy).toBe(legacyKey);
+    expect(ctxObj.current).toBe(currentKey);
+    // Recovery hint must name both paths so an operator can copy/paste it.
+    expect(ctxObj.note).toContain(legacyKey);
+    expect(ctxObj.note).toContain(currentKey);
   });
 });

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -67,10 +67,29 @@ export function migrateCentralDbLocation(
  * One-shot migration: copy `<PARACHUTE_DIR>/claw/master.key` to
  * `<PARACHUTE_DIR>/agent/master.key` so encrypted-secret rows decrypted under
  * the old key continue to decrypt after the paraclaw → parachute-agent
- * rename. Idempotent — noop if the new key already exists OR the legacy
- * key doesn't.
+ * rename. Idempotent.
  *
- * The legacy file is left in place — same rationale as the DB migration.
+ * Three cases:
+ *   1. Only legacy exists  → copy to current, chmod 0600. Legacy stays as
+ *      backup (operators verify and rm manually — same rationale as the DB).
+ *   2. Both exist          → log a `warn` with both paths and a recovery
+ *      hint, then noop. This is the silent-corruption bug from
+ *      `parachute-agent#114`: a previous boot generated a fresh key at the
+ *      new path before the legacy was copied, so the new key can't decrypt
+ *      the operator's existing secret rows. Don't overwrite — a partial
+ *      restore would lose secrets that were re-encrypted under the fresh
+ *      key. Surface it loudly so the operator can choose.
+ *   3. Neither exists      → noop (fresh install).
+ *   4. Only current exists → noop (already migrated, or fresh install where
+ *      first boot created the key directly at the new path).
+ *
+ * MUST run before any caller of `loadOrCreateMasterKey()`. That function
+ * generates a fresh 32-byte key at the new path on first miss, which would
+ * shadow the legacy and trip case 2 on the next boot. `src/index.ts:main`
+ * calls this immediately after `migrateCentralDbLocation`. Standalone
+ * scripts (init-cli-agent, init-first-agent, seed-discord) call it for
+ * the same reason: any path that may end up touching the secrets store
+ * needs the legacy in place first.
  *
  * Path overrides exist for tests; production callers pass no args.
  */
@@ -80,8 +99,24 @@ export function migrateMasterKeyLocation(
 ): void {
   const legacyKey = path.join(legacyDir, 'master.key');
   const currentKey = path.join(currentDir, 'master.key');
-  if (fs.existsSync(currentKey)) return;
-  if (!fs.existsSync(legacyKey)) return;
+  const legacyExists = fs.existsSync(legacyKey);
+  const currentExists = fs.existsSync(currentKey);
+
+  if (currentExists && legacyExists) {
+    log.warn('Master key exists at both new and legacy locations', {
+      legacy: legacyKey,
+      current: currentKey,
+      note:
+        'this means an earlier boot created a fresh key at the new path before the legacy was copied; ' +
+        `existing encrypted secrets were sealed under the legacy key and the fresh key cannot decrypt them. ` +
+        `If you have NOT yet entered new secrets under the fresh key, recover with: ` +
+        `mv ${currentKey} ${currentKey}.fresh-backup && cp ${legacyKey} ${currentKey} && chmod 600 ${currentKey}. ` +
+        `If you HAVE entered new secrets, the two are now mixed and you must re-enter the legacy ones manually.`,
+    });
+    return;
+  }
+  if (currentExists) return;
+  if (!legacyExists) return;
 
   fs.mkdirSync(currentDir, { recursive: true, mode: 0o700 });
   fs.copyFileSync(legacyKey, currentKey);

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Paraclaw</title>
-    <meta name="description" content="Manage Parachute Vault access for your Paraclaw agents." />
+    <title>Parachute Agent</title>
+    <meta name="description" content="Manage Parachute Vault access for your Parachute Agent groups." />
   </head>
   <body>
     <div id="root"></div>

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -49,7 +49,7 @@ export function App() {
         <Link to="/settings/approvals">Settings</Link>
         <Link to="/setup">Setup</Link>
         <a
-          href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
+          href="https://github.com/ParachuteComputer/parachute-agent/blob/main/docs/parachute-integration.md"
           target="_blank"
           rel="noreferrer"
         >

--- a/web/ui/src/routes/GroupDetail.tsx
+++ b/web/ui/src/routes/GroupDetail.tsx
@@ -448,7 +448,7 @@ export function GroupDetail() {
             <p className="muted">
               Parachute Agent doesn't impose a vault-note layout — the agent decides how to use vault access. (See{' '}
               <a
-                href="https://github.com/ParachuteComputer/paraclaw/blob/main/docs/parachute-integration.md"
+                href="https://github.com/ParachuteComputer/parachute-agent/blob/main/docs/parachute-integration.md"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
## Summary

Two pitch-day bugs, one PR off `main`. Bumps to `0.1.2-rc.1`.

### Bug 1 — master.key auto-migration could silently break encrypted secrets

**The leak**: an early 0.1.x boot path (any standalone script that called `migrateCentralDbLocation()` but not `migrateMasterKeyLocation()`, plus any code path hitting `loadOrCreateMasterKey()` before the migrator runs) generates a fresh 32-byte key at `~/.parachute/agent/master.key` while the legacy `~/.parachute/claw/master.key` still sits there. Encrypted secret rows from before the upgrade were sealed under the legacy key — the fresh key cannot decrypt them, and they look corrupt to the operator. Aaron's local install actually hit this (a `master.key.may5-replaced` recovery artifact is on disk).

**Fix** (`src/db/connection.ts`):
- `migrateMasterKeyLocation` now detects the both-exist split-state explicitly. Logs a `log.warn` with the legacy + current paths and a copy-pasteable recovery hint. Does **not** clobber either file — silent overwrite is exactly the failure mode that got us here.
- Back-filled `migrateMasterKeyLocation()` calls in three standalone scripts that ran the DB migration but not the key migration: `scripts/init-cli-agent.ts`, `scripts/init-first-agent.ts`, `scripts/seed-discord.ts`. The main service path in `src/index.ts` already runs both in the right order.

**Regression test** (`src/db/connection.migrate.test.ts`): exercises the both-exist case end-to-end, asserts the warn fires once with both paths in the recovery `note`, neither file is touched. Also split the previously combined "current exists" case into a no-legacy-only variant for symmetry.

### Bug 2 — SPA browser tab still said "Paraclaw"

`web/ui/index.html` `<title>` and meta description updated to "Parachute Agent". Swept `web/ui/src` for other user-visible strings — repo URL in `App.tsx` and `GroupDetail.tsx` updated to `parachute-agent`. Source comments referencing past `paraclaw#NN` issue numbers left as historical record.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 529/529 pass (host vitest)
- [x] `cd web/ui && pnpm test` — 50/50 pass
- [x] SPA dist rebuilt; verified output contains `<title>Parachute Agent</title>`
- [x] Lint: 9 pre-existing errors on `main`, none in files this PR touches (verified via `git stash`)

## Files

- `src/db/connection.ts` — both-exist warn case in `migrateMasterKeyLocation`
- `src/db/connection.migrate.test.ts` — regression test for both-exist + split current-exists tests
- `scripts/init-cli-agent.ts`, `scripts/init-first-agent.ts`, `scripts/seed-discord.ts` — back-fill `migrateMasterKeyLocation()` after `migrateCentralDbLocation()`
- `web/ui/index.html` — title + meta description
- `web/ui/src/App.tsx`, `web/ui/src/routes/GroupDetail.tsx` — repo URL
- `package.json` — 0.1.1 → 0.1.2-rc.1
- `CHANGELOG.md` — entry