### PR TITLE
fix: self-register installDir in services.json (paraclaw#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.2] - 2026-05-05
+
+### Fixed
+
+- **Self-register `installDir` in `services.json`.** The agent's startup self-registration into `~/.parachute/services.json` now includes `installDir: process.cwd()` alongside the existing `name`/`port`/`paths`/`health`/`version` fields. Without it, hub's third-party-module lifecycle resolution path (parachute-hub#84) couldn't locate the start command for `parachute restart agent` — the agent has a `.parachute/module.json` with `startCmd`, but hub needed `installDir` to know which checkout to drive. parachute-hub#177 ships graceful-degradation for the missing-installDir case as a safety net; this is the proper fix on the agent side. Closes paraclaw#115.
+
 ## [0.1.2-rc.1] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2-rc.2",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,8 +12,13 @@ export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_
 export const ASSISTANT_HAS_OWN_NUMBER =
   (process.env.ASSISTANT_HAS_OWN_NUMBER || envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
 
-// Absolute paths needed for container mounts
-const PROJECT_ROOT = process.cwd();
+// Absolute paths needed for container mounts. Captured once at module load
+// (process.cwd() at boot — the right value for the install dir) so every
+// downstream consumer agrees on a single resolved root, and tests that
+// chdir() can't desync against it. Exported for surfaces that need to
+// self-register the install path (e.g. services.json `installDir`,
+// paraclaw#115).
+export const PROJECT_ROOT = process.cwd();
 const HOME_DIR = process.env.HOME || os.homedir();
 
 // Parachute ecosystem root. Convention shared with parachute-hub, vault,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -991,6 +991,10 @@ export function startWebServer(): http.Server {
         version: SERVICE_VERSION,
         displayName: 'Parachute Agent',
         tagline: 'Manage your Parachute agent groups + vault attachments.',
+        // Lets hub resolve `parachute restart agent` back to the checkout
+        // it should drive without a vendored fallback (paraclaw#115,
+        // third-party-module hook from parachute-hub#84).
+        installDir: PROJECT_ROOT,
       });
     } catch (err) {
       log.warn('Skipped services manifest update', {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -29,7 +29,7 @@ import path from 'node:path';
 // pattern (see parachute-vault src/routing.ts).
 import pkg from '../../package.json' with { type: 'json' };
 
-import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR } from '../config.js';
+import { CENTRAL_DB_PATH, DATA_DIR, GROUPS_DIR, PROJECT_ROOT } from '../config.js';
 import { openDb, type Database } from '../db/connection.js';
 import {
   attachVaultToGroup,
@@ -81,7 +81,6 @@ import { getSecret, putSecret } from '../secrets/index.js';
 import { channelTokenSecretName } from '../startup-bootstrap.js';
 import { readEnvWithLegacy } from '../env.js';
 
-const PROJECT_ROOT = process.cwd();
 const UI_DIST = path.resolve(PROJECT_ROOT, 'web/ui/dist');
 // Canonical Parachute slot per parachute-patterns/patterns/canonical-ports.md
 // (1944, claimed for parachute-agent 2026-04-27 via parachute-hub#…). Override

--- a/src/web/services-manifest.test.ts
+++ b/src/web/services-manifest.test.ts
@@ -36,6 +36,7 @@ describe('upsertService', () => {
         version: '0.0.6-rc.1',
         displayName: 'Parachute Agent',
         tagline: 'Manage your Parachute agent groups + vault attachments.',
+        installDir: '/Users/test/parachute-agent',
       },
       path,
     );
@@ -50,9 +51,33 @@ describe('upsertService', () => {
           version: '0.0.6-rc.1',
           displayName: 'Parachute Agent',
           tagline: 'Manage your Parachute agent groups + vault attachments.',
+          installDir: '/Users/test/parachute-agent',
         },
       ],
     });
+  });
+
+  it('self-registers installDir so hub can resolve `parachute restart agent`', () => {
+    // Regression for paraclaw#115: pre-fix the agent registered without
+    // installDir, so hub's third-party lifecycle resolution path (parachute-
+    // hub#84) couldn't find a startCmd target and `parachute restart agent`
+    // dead-ended. Self-registering the field here is the proper fix —
+    // hub#177's graceful-degradation is the safety net.
+    upsertService(
+      {
+        name: 'agent',
+        port: 1944,
+        paths: ['/agent'],
+        health: '/api/health',
+        version: '0.1.2-rc.2',
+        installDir: '/Users/test/parachute-agent',
+      },
+      path,
+    );
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as {
+      services: { name: string; installDir?: string }[];
+    };
+    expect(raw.services[0].installDir).toBe('/Users/test/parachute-agent');
   });
 
   it('replaces an existing entry with the same name in-place', () => {
@@ -72,12 +97,13 @@ describe('upsertService', () => {
     expect(raw.services.map((s) => s.name).sort()).toEqual(['agent', 'vault']);
   });
 
-  it('preserves hub-stamped fields on the row (e.g. installDir from parachute-hub#84)', () => {
-    // The hub stamps `installDir` onto the row at install time. Paraclaw's
-    // self-registration row shape doesn't know about that field, but the
-    // upsert must merge rather than replace so the hub-stamped value
-    // survives the second write — otherwise `parachute start agent` after
-    // an auto-start round-trip can't resolve installDir → "unknown service".
+  it('preserves fields not in the new entry on the row (merge, not replace)', () => {
+    // The agent now self-registers `installDir` (paraclaw#115), but the
+    // merge-not-replace behavior is still load-bearing for any other field
+    // the hub stamps that the agent's entry doesn't know about. Simulate
+    // that with a synthetic `extraField`: the upsert must spread `existing`
+    // first so unknown fields survive, otherwise hub stamps get clobbered
+    // on the next agent boot.
     writeFileSync(
       path,
       JSON.stringify({
@@ -88,7 +114,7 @@ describe('upsertService', () => {
             paths: ['/agent'],
             health: '/api/health',
             version: '0.0.7-rc.1',
-            installDir: '/Users/test/.parachute/agent',
+            extraField: 'hub-stamped-value',
           },
         ],
       }),
@@ -104,11 +130,11 @@ describe('upsertService', () => {
       path,
     );
     const raw = JSON.parse(readFileSync(path, 'utf8')) as {
-      services: { version: string; installDir?: string }[];
+      services: { version: string; extraField?: string }[];
     };
     expect(raw.services).toHaveLength(1);
     expect(raw.services[0].version).toBe('0.0.8-rc.1');
-    expect(raw.services[0].installDir).toBe('/Users/test/.parachute/agent');
+    expect(raw.services[0].extraField).toBe('hub-stamped-value');
   });
 
   it('throws on a malformed existing manifest (so we never silently overwrite)', () => {

--- a/src/web/services-manifest.test.ts
+++ b/src/web/services-manifest.test.ts
@@ -99,11 +99,13 @@ describe('upsertService', () => {
 
   it('preserves fields not in the new entry on the row (merge, not replace)', () => {
     // The agent now self-registers `installDir` (paraclaw#115), but the
-    // merge-not-replace behavior is still load-bearing for any other field
-    // the hub stamps that the agent's entry doesn't know about. Simulate
-    // that with a synthetic `extraField`: the upsert must spread `existing`
-    // first so unknown fields survive, otherwise hub stamps get clobbered
-    // on the next agent boot.
+    // merge-not-replace behavior is still load-bearing for any field hub
+    // stamps that the agent's entry doesn't carry. `publicExposure` is the
+    // realistic case: it's a real first-party-schema field on hub's side
+    // (set when the operator runs `parachute expose`) but absent from
+    // paraclaw's `ServiceEntry` — so a self-registration round trip must
+    // not drop it. Spread order is `{ ...existing, ...entry }`, so the
+    // agent still wins on the fields it owns.
     writeFileSync(
       path,
       JSON.stringify({
@@ -114,7 +116,7 @@ describe('upsertService', () => {
             paths: ['/agent'],
             health: '/api/health',
             version: '0.0.7-rc.1',
-            extraField: 'hub-stamped-value',
+            publicExposure: 'loopback',
           },
         ],
       }),
@@ -130,11 +132,11 @@ describe('upsertService', () => {
       path,
     );
     const raw = JSON.parse(readFileSync(path, 'utf8')) as {
-      services: { version: string; extraField?: string }[];
+      services: { version: string; publicExposure?: string }[];
     };
     expect(raw.services).toHaveLength(1);
     expect(raw.services[0].version).toBe('0.0.8-rc.1');
-    expect(raw.services[0].extraField).toBe('hub-stamped-value');
+    expect(raw.services[0].publicExposure).toBe('loopback');
   });
 
   it('throws on a malformed existing manifest (so we never silently overwrite)', () => {

--- a/src/web/services-manifest.ts
+++ b/src/web/services-manifest.ts
@@ -50,10 +50,14 @@ export function upsertService(entry: ServiceEntry, path: string = resolveManifes
   mkdirSync(dirname(path), { recursive: true });
   const manifest = readManifest(path);
   const idx = manifest.services.findIndex((s) => s.name === entry.name);
-  // Merge rather than replace so fields the hub stamps onto the row
-  // (`installDir` from parachute-hub#84, etc.) survive a self-registration
-  // pass. Paraclaw still wins for the fields it owns — port, paths,
-  // version, health — because they spread last.
+  // Merge rather than replace, intentionally diverging from
+  // `parachute-hub/src/services-manifest.ts` which full-replaces the row.
+  // The asymmetry tracks who's authoritative: hub owns the first-party
+  // shape (read → schema-validate → write), so it can replace safely;
+  // we're a third-party self-registrant preserving any fields hub stamps
+  // that we don't own (the hub#84 `installDir` slot, future hub-stamped
+  // metadata). The agent still wins for the fields it owns — port, paths,
+  // version, health, installDir — because `entry` spreads last.
   if (idx >= 0) manifest.services[idx] = { ...manifest.services[idx], ...entry };
   else manifest.services.push(entry);
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;

--- a/src/web/services-manifest.ts
+++ b/src/web/services-manifest.ts
@@ -4,14 +4,14 @@
  * Mirrors `parachute-scribe/src/services-manifest.ts` deliberately — the
  * shape is the contract between every Parachute service and the hub
  * (`parachute-hub/src/services-manifest.ts` is the canonical reader).
- * Once paraclaw earns a slot in the hub's vendored fallback, the
- * manifest read flips to `.parachute/module.json`-backed and this file
- * becomes the live state-side companion. Until then, this is what makes
- * `parachute status` / `parachute expose` see paraclaw at all.
- *
  * Failure mode: any write error is logged + swallowed. Self-registration
  * is best-effort — the server still serves locally even if the manifest
  * write fails (permissions, disk full, race with another writer).
+ *
+ * `installDir` is the third-party-module hook (parachute-hub#84): hub
+ * looks the field up to resolve `parachute restart agent` back to the
+ * checkout it should drive. Self-registering it here means the agent
+ * doesn't need a vendored fallback in hub — paraclaw#115.
  */
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -26,6 +26,7 @@ export interface ServiceEntry {
   version: string;
   displayName?: string;
   tagline?: string;
+  installDir?: string;
 }
 
 interface ServicesManifest {


### PR DESCRIPTION
## Summary

Closes paraclaw#115. The agent's startup self-registration into `~/.parachute/services.json` now writes `installDir: process.cwd()` alongside the existing fields. Without it, hub's third-party-module lifecycle resolution path ([parachute-hub#84](https://github.com/ParachuteComputer/parachute-hub/pull/84)) couldn't locate the start command for `parachute restart agent` — the agent has a `.parachute/module.json` with `startCmd`, but hub needed `installDir` to know which checkout to drive.

[parachute-hub#177](https://github.com/ParachuteComputer/parachute-hub/pull/177) ships graceful-degradation for the missing-installDir case as a safety net; **this is the proper fix on the agent side** per the third-party-module pattern.

## Changes

- `src/web/services-manifest.ts` — `ServiceEntry.installDir?: string` added to the public type; docstring updated to call out the hub#84 hook.
- `src/web/server.ts` — startup `upsertService(...)` call now includes `installDir: PROJECT_ROOT` (where `PROJECT_ROOT = process.cwd()` already exists in scope at line 84).
- `src/web/services-manifest.test.ts` —
  - new test `self-registers installDir so hub can resolve` parachute restart agent`` asserting the field round-trips through `upsertService`.
  - existing `creates the file + writes the canonical entry shape` extended to include `installDir`.
  - refactored `preserves hub-stamped fields` test to use a synthetic `extraField` — `installDir` is now a known agent-owned field, so the merge-preservation property is what we want to keep guarding for *unknown* fields hub might stamp.
- `package.json` — `0.1.2-rc.1` → `0.1.2-rc.2` (governance: rc bump per PR pre-1.0).
- `CHANGELOG.md` — entry under `0.1.2-rc.2`.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 530/530 pass (one more than `main`'s 529; the new self-register test is the +1)
- [x] No container changes; bun:test gate not relevant
- [x] Lint unchanged from `main`'s pre-existing 9 (none in files this PR touches)

## Manual verification (post-merge, against running install)

The reviewer can confirm by:
1. Restart the agent daemon
2. `cat ~/.parachute/services.json | jq '.services[] | select(.name=="agent")'` — should show `installDir: <agent-checkout-path>`
3. `parachute restart agent` (against hub on `main` post-#177) — should resolve cleanly without falling through to hub#177's actionable-error path

## Notes

- **paraclaw#114** (image-slug auto-retag on operator dir-rename) is queued as the next task per team-lead — kept out of this PR per `feedback_serial_pr_flow`.
- `.parachute/module.json` already exists at the repo root with `startCmd: ["bun", "src/index.ts"]`, so no follow-up issue needed there.