### PR TITLE
fix: auto-retag container image when INSTALL_SLUG shifts (paraclaw#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.3] - 2026-05-05
+
+### Fixed
+
+- **Auto-retag the per-install container image when `INSTALL_SLUG` shifts.** `INSTALL_SLUG = sha1(process.cwd())[:8]`, so an operator dir-rename (the trigger that exposed this bug today: `mv paraclaw parachute-agent`) flips the slug. The previously-built image carried the old slug; new container spawns went out under the new slug; `docker run` returned `code=125` ("image not found") and every Telegram message produced a silent crashloop. New `ensureContainerImage()` step in `src/index.ts` (between `ensureContainerRuntimeRunning` and `cleanupOrphans`) detects the mismatch at boot and `docker tag`s any `parachute-agent-image-<peer-slug>:latest` it finds onto the expected name. Pre-0.1.0 `paraclaw-agent-<slug>:latest` peers also match (one cycle of compat). When no peer is on disk at all (fresh install, no `./container/build.sh` run yet), the daemon now fails visibly at startup with an actionable error instead of crashlooping silently. Closes paraclaw#114.
+
 ## [0.1.2-rc.2] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.2",
+  "version": "0.1.2-rc.3",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -22,9 +22,10 @@ import {
   readonlyMountArgs,
   stopContainer,
   ensureContainerRuntimeRunning,
+  ensureContainerImage,
   cleanupOrphans,
 } from './container-runtime.js';
-import { CONTAINER_INSTALL_LABEL, LEGACY_PARACLAW_INSTALL_LABEL } from './config.js';
+import { CONTAINER_IMAGE, CONTAINER_INSTALL_LABEL, LEGACY_PARACLAW_INSTALL_LABEL } from './config.js';
 import { log } from './log.js';
 
 beforeEach(() => {
@@ -79,6 +80,105 @@ describe('ensureContainerRuntimeRunning', () => {
 
     expect(() => ensureContainerRuntimeRunning()).toThrow('Container runtime is required but failed to start');
     expect(log.error).toHaveBeenCalled();
+  });
+});
+
+// --- ensureContainerImage ---
+
+describe('ensureContainerImage', () => {
+  // Each test enumerates its own queue rather than going through a helper —
+  // throwing scenarios skip the retag call, so a generic helper would queue
+  // a `mockReturnValueOnce` that never gets consumed and leaks into the next
+  // test (vi.clearAllMocks doesn't drain the response queue).
+  const inspectFailed = () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error('No such image');
+    });
+  };
+
+  it('no-ops when the expected image is already present', () => {
+    mockExecSync.mockReturnValueOnce('{}'); // inspect — image exists
+
+    ensureContainerImage();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    expect(mockExecSync).toHaveBeenCalledWith(
+      `${CONTAINER_RUNTIME_BIN} image inspect ${CONTAINER_IMAGE}`,
+      expect.objectContaining({ stdio: 'pipe' }),
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('retags from a current-prefix peer when the expected image is missing', () => {
+    // Operator dir-rename case: the previously-built image carries the old
+    // INSTALL_SLUG (16f7e9e8); the daemon now boots under a new slug.
+    const peer = 'parachute-agent-image-16f7e9e8:latest';
+    inspectFailed();
+    mockExecSync.mockReturnValueOnce(`${peer}\nnode:24-bookworm-slim\n`); // list
+    mockExecSync.mockReturnValueOnce(''); // tag
+
+    ensureContainerImage();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(3);
+    expect(mockExecSync).toHaveBeenNthCalledWith(
+      3,
+      `${CONTAINER_RUNTIME_BIN} tag ${peer} ${CONTAINER_IMAGE}`,
+      expect.objectContaining({ stdio: 'pipe' }),
+    );
+    expect(log.warn).toHaveBeenCalledWith(
+      'Container image missing for current install slug — retagging from peer',
+      expect.objectContaining({ expected: CONTAINER_IMAGE, peer }),
+    );
+  });
+
+  it('retags from a pre-0.1.0 paraclaw-agent peer (one cycle of back-compat)', () => {
+    // Operator upgrades a pre-0.1.0 install: their on-disk image is named
+    // `paraclaw-agent-<slug>:latest`. Auto-retag rather than forcing a
+    // 5-minute rebuild they didn't ask for.
+    const legacyPeer = 'paraclaw-agent-deadbeef:latest';
+    inspectFailed();
+    mockExecSync.mockReturnValueOnce(legacyPeer);
+    mockExecSync.mockReturnValueOnce('');
+
+    ensureContainerImage();
+
+    expect(mockExecSync).toHaveBeenNthCalledWith(
+      3,
+      `${CONTAINER_RUNTIME_BIN} tag ${legacyPeer} ${CONTAINER_IMAGE}`,
+      expect.objectContaining({ stdio: 'pipe' }),
+    );
+  });
+
+  it('throws an actionable error when no peer exists (fresh install, no build yet)', () => {
+    // No matching prefix on disk: only unrelated base images. Better to fail
+    // visibly at startup than crashloop code=125 on every container spawn.
+    inspectFailed();
+    mockExecSync.mockReturnValueOnce('node:24-bookworm-slim\nubuntu:22.04\n');
+
+    expect(() => ensureContainerImage()).toThrow(/build\.sh/);
+    expect(mockExecSync).toHaveBeenCalledTimes(2); // inspect + list, no tag
+  });
+
+  it('skips the (missing) expected name when picking a peer from the listing', () => {
+    // Belt-and-suspenders: the inspect already confirmed the expected name
+    // is absent, but the peer-search guard against picking it back up keeps
+    // the function safe if a future caller pre-checks a different way.
+    inspectFailed();
+    mockExecSync.mockReturnValueOnce(`${CONTAINER_IMAGE}\nparachute-agent-image-16f7e9e8:latest\n`);
+    mockExecSync.mockReturnValueOnce('');
+
+    ensureContainerImage();
+
+    const tagCall = mockExecSync.mock.calls.find((call) => String(call[0]).startsWith(`${CONTAINER_RUNTIME_BIN} tag`));
+    expect(tagCall).toBeDefined();
+    expect(String(tagCall![0])).toContain('parachute-agent-image-16f7e9e8:latest');
+  });
+
+  it('ignores arbitrary non-matching tags (e.g. base images, unrelated projects)', () => {
+    inspectFailed();
+    mockExecSync.mockReturnValueOnce('node:24-bookworm-slim\nparachute-vault:latest\nrandomthing:v2\n');
+
+    expect(() => ensureContainerImage()).toThrow(/build\.sh/);
   });
 });
 

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -5,8 +5,17 @@
 import { execSync } from 'child_process';
 import os from 'os';
 
-import { CONTAINER_INSTALL_LABEL, LEGACY_PARACLAW_INSTALL_LABEL } from './config.js';
+import { CONTAINER_IMAGE, CONTAINER_INSTALL_LABEL, LEGACY_PARACLAW_INSTALL_LABEL } from './config.js';
 import { log } from './log.js';
+
+// Per-install image tag schemas:
+//   - 0.1.0+:    `parachute-agent-image-<8-hex-slug>:latest`
+//   - pre-0.1.0: `paraclaw-agent-<8-hex-slug>:latest` (kept for one cycle of
+//                back-compat so an operator who upgrades into a 0.1.x checkout
+//                without rebuilding the image still gets a working spawn).
+// Both prefixes are stable + content-equivalent — Dockerfile baseline
+// matches across slugs — so a `docker tag` of any peer is safe.
+const PEER_IMAGE_PATTERN = /^(parachute-agent-image|paraclaw-agent)-[0-9a-f]{8}:latest$/;
 
 /** The container runtime binary name. */
 export const CONTAINER_RUNTIME_BIN = 'docker';
@@ -55,6 +64,71 @@ export function ensureContainerRuntimeRunning(): void {
       cause: err,
     });
   }
+}
+
+/**
+ * Ensure the per-install container image is reachable before we start
+ * spawning sessions.
+ *
+ * INSTALL_SLUG = sha1(process.cwd())[:8], so an operator dir-rename
+ * (paraclaw#114: `mv paraclaw parachute-agent` was the trigger) flips the
+ * slug. The previously-built image carries the OLD slug; the daemon goes
+ * to spawn against the NEW slug; `docker run` returns code=125 ("image
+ * not found") and every container spawn crashloops silently.
+ *
+ * Resolution path, ordered fail-fast → cheap → loud:
+ *   1. Expected tag present → no-op.
+ *   2. Any peer image (`parachute-agent-image-*` or pre-0.1.0
+ *      `paraclaw-agent-*`) present → `docker tag` it to the expected
+ *      name. Safe because the Dockerfile baseline doesn't fork per slug.
+ *   3. No peer found → throw with an actionable hint. The daemon was
+ *      going to crashloop anyway; failing visibly at startup is strictly
+ *      better than silent code=125 on every Telegram message.
+ */
+export function ensureContainerImage(): void {
+  if (imageExists(CONTAINER_IMAGE)) {
+    log.debug('Container image present', { image: CONTAINER_IMAGE });
+    return;
+  }
+  const peer = findPeerImage(CONTAINER_IMAGE);
+  if (peer) {
+    // The dir-rename / upgrade case. Loud-warn so the operator can see in
+    // the log what happened — silent retags become folklore.
+    log.warn('Container image missing for current install slug — retagging from peer', {
+      expected: CONTAINER_IMAGE,
+      peer,
+      hint: 'Operator dir-rename or upgrade likely changed INSTALL_SLUG. Auto-retagging is safe; rebuild via ./container/build.sh next time you want to refresh dependencies.',
+    });
+    execSync(`${CONTAINER_RUNTIME_BIN} tag ${peer} ${CONTAINER_IMAGE}`, { stdio: 'pipe' });
+    return;
+  }
+  throw new Error(
+    `No parachute-agent container image found. Build one with: ./container/build.sh\n` +
+      `Expected image: ${CONTAINER_IMAGE}`,
+  );
+}
+
+function imageExists(ref: string): boolean {
+  try {
+    execSync(`${CONTAINER_RUNTIME_BIN} image inspect ${ref}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findPeerImage(exclude: string): string | null {
+  const output = execSync(`${CONTAINER_RUNTIME_BIN} images --format '{{.Repository}}:{{.Tag}}'`, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+  // `docker images` lists newest-created first by default. Take the first
+  // matching peer so a recent rebuild wins over a stale legacy tag.
+  for (const ref of output.trim().split('\n').filter(Boolean)) {
+    if (ref === exclude) continue;
+    if (PEER_IMAGE_PATTERN.test(ref)) return ref;
+  }
+  return null;
 }
 
 /**

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -12,7 +12,8 @@ import { log } from './log.js';
 //   - 0.1.0+:    `parachute-agent-image-<8-hex-slug>:latest`
 //   - pre-0.1.0: `paraclaw-agent-<8-hex-slug>:latest` (kept for one cycle of
 //                back-compat so an operator who upgrades into a 0.1.x checkout
-//                without rebuilding the image still gets a working spawn).
+//                without rebuilding the image still gets a working spawn;
+//                drop in 0.2.0 — same lifecycle as LEGACY_PARACLAW_INSTALL_LABEL).
 // Both prefixes are stable + content-equivalent — Dockerfile baseline
 // matches across slugs — so a `docker tag` of any peer is safe.
 const PEER_IMAGE_PATTERN = /^(parachute-agent-image|paraclaw-agent)-[0-9a-f]{8}:latest$/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { CENTRAL_DB_PATH } from './config.js';
 import { migrateGroupsToClaudeLocal } from './claude-md-compose.js';
 import { initDb, migrateCentralDbLocation, migrateMasterKeyLocation } from './db/connection.js';
 import { runMigrations } from './db/migrations/index.js';
-import { ensureContainerRuntimeRunning, cleanupOrphans } from './container-runtime.js';
+import { ensureContainerRuntimeRunning, ensureContainerImage, cleanupOrphans } from './container-runtime.js';
 import { startActiveDeliveryPoll, startSweepDeliveryPoll, setDeliveryAdapter, stopDeliveryPolls } from './delivery.js';
 import { startHostSweep, stopHostSweep } from './host-sweep.js';
 import { routeInbound } from './router.js';
@@ -89,6 +89,11 @@ async function main(): Promise<void> {
 
   // 2. Container runtime
   ensureContainerRuntimeRunning();
+  // Auto-retag the per-install image when an operator dir-rename has flipped
+  // INSTALL_SLUG out from under a previously-built image (paraclaw#114).
+  // Throws with an actionable hint when no image at all is on disk — better
+  // than the silent code=125 crashloop the daemon used to fall into.
+  ensureContainerImage();
   cleanupOrphans();
 
   // 3. Channel adapters


### PR DESCRIPTION
## Summary

Closes [paraclaw#114](https://github.com/ParachuteComputer/paraclaw/issues/114). `INSTALL_SLUG = sha1(process.cwd())[:8]`, so an operator dir-rename flips the slug — and the previously-built image carries the *old* slug. The daemon then spawns containers against the *new* slug, `docker run` returns `code=125` ("image not found"), and every Telegram message produces a silent crashloop.

Aaron hit this today after `mv paraclaw parachute-agent` (old slug `16f7e9e8`, new slug `0438d4b1`). Workaround was a manual `docker tag`. This PR makes the daemon do that itself at startup.

## Changes

**`src/container-runtime.ts`** — new exported `ensureContainerImage()`:
1. **Expected tag present** → no-op (debug log only).
2. **Peer found** (any `parachute-agent-image-<8hex>:latest`, or pre-0.1.0 `paraclaw-agent-<8hex>:latest` for one cycle of upgrade compat) → `docker tag <peer> <expected>` and `log.warn` so the operator can see in the log what happened. Silent retags become folklore; visible ones become a paper trail.
3. **No peer on disk** → throw with an actionable hint pointing at `./container/build.sh`. The daemon was about to crashloop on every spawn anyway — failing visibly at startup is strictly better.

Why retag is safe: the Dockerfile baseline doesn't fork per slug, so an existing peer image is content-equivalent for the new slug.

**`src/index.ts`** — wired `ensureContainerImage()` into the boot path between `ensureContainerRuntimeRunning` (we need docker working first) and `cleanupOrphans` (best-effort, doesn't depend on the image).

**`src/container-runtime.test.ts`** — six new tests using the existing mocked-execSync pattern from `cleanupOrphans` tests:
- expected image present → no-op (one inspect call, no list, no tag)
- expected missing + `parachute-agent-image-*` peer → retag (asserts the exact `docker tag` invocation + the `log.warn` shape)
- expected missing + pre-0.1.0 `paraclaw-agent-*` peer → retag (one cycle of compat)
- expected missing + no matching prefix on disk → throws with `/build\.sh/` in the message
- exclude-guard: even if `docker images` listing happens to contain the missing expected name, peer search skips it
- arbitrary unrelated tags (`node:24-bookworm-slim`, `parachute-vault:latest`, etc.) are ignored

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 536/536 pass (was 530 on `main`; +6 new tests)
- [x] No container-runner.ts changes; `bun:test` gate not relevant
- [x] Lint unchanged from `main` (none in files this PR touches)

## Manual verification path

Per the brief, against Aaron's install — coordinate before doing this:

1. `docker rmi parachute-agent-image-0438d4b1:latest` (delete the workaround tag)
2. Restart agent daemon
3. **Expect**: log line `Container image missing for current install slug — retagging from peer { expected: '...0438d4b1...', peer: '...16f7e9e8...', hint: '...' }`
4. New container spawn (any incoming Telegram message) succeeds; no `code=125`

Or against a fixture install:

1. `mv parachute-agent parachute-agent-renamed && cd parachute-agent-renamed`
2. `bun src/index.ts` → image-missing log + auto-retag log + clean spawn

## Notes

- Fail-loud-no-peer case is the new fresh-install behavior: instead of silently building/spawning, the daemon errors at startup with the build.sh hint. Operators who do a fresh `git clone && pnpm install` and try to start without running `./container/build.sh` first now get a useful error instead of a crashloop. Documented in CLAUDE.md already (`./container/build.sh` is in the dev quick-reference).
- Version bumped 0.1.2-rc.2 → 0.1.2-rc.3 per RC governance.
- Per `feedback_serial_pr_flow`, no other in-flight follow-ups bundled.