### PR TITLE
fix: extract attachments only after row commits (paraclaw#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.4] - 2026-05-05
+
+### Fixed
+
+- **Inbound: extract attachment files only after the row commits.** `writeSessionMessage` previously decoded base64 attachment data and wrote files to `inbox/<messageId>/` *before* the `INSERT … ON CONFLICT(id) DO NOTHING` returned. After paraclaw#92 / #95 made duplicate-dispatch a warm code path (sender-approval replay, Telegram getUpdates retry, chat-sdk re-emit), a replay carrying the same `messages_in.id` but mutated attachment bytes would silently clobber the on-disk file under the original message id while the DB row stayed unchanged — divergent state with no audit trail. Reordered: insert with raw inline-base64 content, check `inserted`, and only when `inserted === true` run `extractAttachmentFiles` and `UPDATE messages_in SET content = ?` with the path-replaced form. Disk state now stays strictly downstream of the row commit. Closes paraclaw#96. Refs #95, #92.
+
 ## [0.1.2-rc.3] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.3",
+  "version": "0.1.2-rc.4",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/session-manager.attachments.test.ts
+++ b/src/session-manager.attachments.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression coverage for paraclaw#96 — silent file clobber on mutated
+ * replays. After paraclaw#92 / #95 made duplicate-dispatch
+ * (sender-approval replay etc.) a warm path, the attachment-extraction
+ * step in writeSessionMessage must run only AFTER the row commits, or a
+ * mutated replay rewrites the on-disk file under the original
+ * messages_in.id while the DB row stays unchanged.
+ *
+ * Real session DBs (no execSync mock) — file-clobber-class hazards are
+ * easy to fake green with mocked filesystem state.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { openDb } from './db/connection.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup } from './db/index.js';
+import { initSessionFolder, inboundDbPath, sessionDir, writeSessionMessage } from './session-manager.js';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/paraclaw-test-attachments' };
+});
+
+const TEST_DIR = '/tmp/paraclaw-test-attachments';
+const AG = 'ag-1';
+const SESS = 'sess-attachments';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function readRowContent(): string {
+  const db = openDb(inboundDbPath(AG, SESS));
+  const row = db.prepare('SELECT content FROM messages_in WHERE id = ?').get('msg-1') as { content: string };
+  db.close();
+  return row.content;
+}
+
+function inboxFilePath(filename: string): string {
+  return path.join(sessionDir(AG, SESS), 'inbox', 'msg-1', filename);
+}
+
+function makeMessageWithAttachment(dataB64: string) {
+  return {
+    id: 'msg-1',
+    kind: 'chat',
+    timestamp: nowIso(),
+    platformId: 'chan-1',
+    channelType: 'discord',
+    threadId: null as string | null,
+    content: JSON.stringify({
+      text: 'see attachment',
+      attachments: [{ name: 'photo.jpg', type: 'image', size: 9, data: dataB64 }],
+    }),
+  };
+}
+
+const ORIGINAL_BYTES = Buffer.from('first-pic');
+const MUTATED_BYTES = Buffer.from('CLOBBERED');
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({
+    id: AG,
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: nowIso(),
+  });
+  // Fresh-start a session manually — we don't need a messaging group for
+  // these tests, just the session folder + DBs.
+  const sessRow = {
+    id: SESS,
+    agent_group_id: AG,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active' as const,
+    container_status: 'stopped' as const,
+    last_active: null,
+    created_at: nowIso(),
+  };
+  db.prepare(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider,
+       status, container_status, last_active, created_at)
+     VALUES (@id, @agent_group_id, @messaging_group_id, @thread_id, @agent_provider,
+       @status, @container_status, @last_active, @created_at)`,
+  ).run(sessRow);
+  initSessionFolder(AG, SESS);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+});
+
+describe('writeSessionMessage — attachment extraction order (paraclaw#96)', () => {
+  it('fresh insert with attachment: row content has localPath, file written to inbox', () => {
+    writeSessionMessage(AG, SESS, makeMessageWithAttachment(ORIGINAL_BYTES.toString('base64')));
+
+    const parsed = JSON.parse(readRowContent());
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].localPath).toBe('inbox/msg-1/photo.jpg');
+    expect(parsed.attachments[0].data).toBeUndefined();
+
+    const onDisk = fs.readFileSync(inboxFilePath('photo.jpg'));
+    expect(onDisk.equals(ORIGINAL_BYTES)).toBe(true);
+  });
+
+  it('fresh insert without attachments: row content unchanged, no inbox dir created', () => {
+    writeSessionMessage(AG, SESS, {
+      id: 'msg-1',
+      kind: 'chat',
+      timestamp: nowIso(),
+      content: JSON.stringify({ text: 'no attachments here' }),
+    });
+
+    expect(JSON.parse(readRowContent()).text).toBe('no attachments here');
+    expect(fs.existsSync(path.join(sessionDir(AG, SESS), 'inbox'))).toBe(false);
+  });
+
+  it('duplicate dispatch with identical bytes: silently absorbed, file untouched', () => {
+    const msg = makeMessageWithAttachment(ORIGINAL_BYTES.toString('base64'));
+
+    writeSessionMessage(AG, SESS, msg);
+    const firstMtime = fs.statSync(inboxFilePath('photo.jpg')).mtimeMs;
+
+    // Sleep just enough to make a re-write detectable in mtime resolution.
+    const wait = Date.now() + 20;
+    while (Date.now() < wait) {
+      /* spin */
+    }
+
+    writeSessionMessage(AG, SESS, msg);
+
+    // File was NOT re-written — mtime unchanged.
+    expect(fs.statSync(inboxFilePath('photo.jpg')).mtimeMs).toBe(firstMtime);
+    expect(fs.readFileSync(inboxFilePath('photo.jpg')).equals(ORIGINAL_BYTES)).toBe(true);
+  });
+
+  it('duplicate dispatch with MUTATED bytes (replay hazard): on-disk file preserved byte-for-byte', () => {
+    // The exact failure shape paraclaw#96 calls out: a replay that re-uses
+    // the same messages_in.id but carries different attachment bytes. Pre-fix,
+    // the second call's extractAttachmentFiles ran before the dup-check and
+    // would have overwritten photo.jpg with MUTATED_BYTES while the DB row
+    // still pointed at the original commit.
+    writeSessionMessage(AG, SESS, makeMessageWithAttachment(ORIGINAL_BYTES.toString('base64')));
+    const rowAfterFirst = readRowContent();
+
+    writeSessionMessage(AG, SESS, makeMessageWithAttachment(MUTATED_BYTES.toString('base64')));
+
+    // 1. On-disk file is byte-for-byte the original — NO clobber.
+    const onDisk = fs.readFileSync(inboxFilePath('photo.jpg'));
+    expect(onDisk.equals(ORIGINAL_BYTES)).toBe(true);
+    expect(onDisk.equals(MUTATED_BYTES)).toBe(false);
+
+    // 2. Only the original row exists; the replay didn't slip a new row in.
+    const db = openDb(inboundDbPath(AG, SESS));
+    const rows = db.prepare('SELECT id, content FROM messages_in').all() as Array<{ id: string; content: string }>;
+    db.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe(rowAfterFirst);
+  });
+});

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -207,6 +207,15 @@ export function writeSessionRouting(agentGroupId: string, sessionId: string): vo
  * ⚠ Opens and closes the DB on every call. Do not refactor to reuse a
  * long-lived connection — see the "Cross-mount visibility invariants" note
  * at the top of this file.
+ *
+ * Attachment-extraction (decode base64 → write file → swap in localPath) is
+ * gated on `inserted === true`. Duplicate dispatches (sender-approval replay,
+ * Telegram getUpdates retry, chat-sdk re-emit) carry the same `message.id`,
+ * so the second INSERT silently no-ops via ON CONFLICT (paraclaw#92 / #95).
+ * Doing the file write up-front meant a mutated replay would clobber the
+ * on-disk file under the original messages_in.id while the row stayed
+ * unchanged — divergent state with no audit trail. Reordering keeps disk
+ * state strictly downstream of the DB row commit (paraclaw#96).
  */
 export function writeSessionMessage(
   agentGroupId: string,
@@ -230,12 +239,12 @@ export function writeSessionMessage(
     trigger?: 0 | 1;
   },
 ): void {
-  // Extract base64 attachment data, save to inbox, replace with file paths
-  const content = extractAttachmentFiles(agentGroupId, sessionId, message.id, message.content);
-
   const db = openInboundDb(agentGroupId, sessionId);
   let inserted: boolean;
   try {
+    // INSERT first with the raw content (potentially carrying inline base64
+    // attachment data). On conflict the helper returns inserted:false and
+    // we exit before any filesystem work happens.
     ({ inserted } = insertMessage(db, {
       id: message.id,
       kind: message.kind,
@@ -243,11 +252,20 @@ export function writeSessionMessage(
       platformId: message.platformId ?? null,
       channelType: message.channelType ?? null,
       threadId: message.threadId ?? null,
-      content,
+      content: message.content,
       processAfter: message.processAfter ?? null,
       recurrence: message.recurrence ?? null,
       trigger: message.trigger ?? 1,
     }));
+
+    if (inserted) {
+      // Row committed — safe to write attachment files to inbox/ and rewrite
+      // the row's content with the localPath form the container reads.
+      const extractedContent = extractAttachmentFiles(agentGroupId, sessionId, message.id, message.content);
+      if (extractedContent !== message.content) {
+        db.prepare('UPDATE messages_in SET content = ? WHERE id = ?').run(extractedContent, message.id);
+      }
+    }
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Summary

- Reorders `writeSessionMessage` so attachment file writes happen **after** the `INSERT … ON CONFLICT(id) DO NOTHING` returns `inserted: true`, eliminating the silent file-clobber on duplicate dispatches with mutated bytes.
- Adds 4 regression tests using real session-DB fixtures (better-sqlite3 + on-disk inbox/) — file-clobber-class hazards are easy to fake green with mocked filesystem state, so this skips mocks.
- Bumps to `0.1.2-rc.4`.

## Why

After paraclaw#92 / #95 made duplicate-dispatch a warm code path (sender-approval replay, Telegram getUpdates retry, chat-sdk re-emit), `extractAttachmentFiles` ran before the dup-check returned. A replay carrying the same `messages_in.id` but mutated attachment bytes would silently overwrite `inbox/<messageId>/<filename>` while the DB row stayed unchanged — divergent state with no audit trail.

Reorder shape (per the suggested fix in #96):
1. INSERT row with the original content (potentially carrying inline base64).
2. Check `inserted`.
3. If `inserted === true`, run `extractAttachmentFiles` + `UPDATE messages_in SET content = ?` with the path-replaced form.
4. If `inserted === false`, return — no filesystem work.

On-disk state is now strictly downstream of the row commit. There's a brief intra-call window where the row carries inline base64 before the UPDATE; the container's `formatAttachments` (`container/agent-runner/src/formatter.ts:225`) degrades gracefully on missing `localPath`, and the host always wakes the container *after* `writeSessionMessage` returns — so a polling container can't observe the inline-base64 form for a row it'll process.

## Test invariants

`src/session-manager.attachments.test.ts`, all using real `inboundDbPath` + filesystem state:

1. **Fresh insert with attachment** — row content has `localPath`, no `data` field, file bytes match.
2. **Fresh insert without attachments** — content unchanged, no `inbox/` dir created.
3. **Duplicate dispatch (identical bytes)** — second call leaves `mtime` unchanged and bytes intact.
4. **Duplicate dispatch (MUTATED bytes — the #96 hazard)** — file is byte-for-byte the original; only the original row exists in `messages_in`.

Pre-fix sanity check: stashed the fix and re-ran — invariants 3 and 4 fail (the mutated-replay test caught the clobber). Post-fix: 540/540 host tests pass.

## Test plan

- [x] `pnpm test` — 540/540 pass (was 536, +4 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — same baseline as `main` (170 problems / 9 errors / 161 warnings, all pre-existing in unrelated files; no new warnings introduced)
- [x] Pre-fix sanity: stashed `src/session-manager.ts`, ran the new test file → invariants 3 + 4 fail with "expected false to be true" on the mutated-bytes assertion. Confirms the regression test catches the original hazard.

Closes paraclaw#96. Refs #95, #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)