### PR TITLE
chore: depersonalize test fixtures + comments (no behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.5] - 2026-05-05
+
+### Changed
+
+- **Depersonalize test fixtures + comments (no behavior change).** The #119 PR snuck a real install-slug (`16f7e9e8`, the sha1 prefix of one operator's specific path) into `src/container-runtime.test.ts` peer-image fixtures, and a comment in `src/container-runtime.ts` named the specific `mv` command that exposed paraclaw#114. Codebase should be operator-agnostic. Replaced the fixture slug with the synthetic `cafef00d` consistently across all current-prefix and legacy-prefix peer-image tests (the `PEER_IMAGE_PATTERN` regex matches any 8-hex slug, so the choice is cosmetic), and rephrased the comment to reference paraclaw#114 without the personal `mv` command. No behavior change; same 540/540 host tests.
+
 ## [0.1.2-rc.4] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.4",
+  "version": "0.1.2-rc.5",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/container-runtime.test.ts
+++ b/src/container-runtime.test.ts
@@ -111,8 +111,8 @@ describe('ensureContainerImage', () => {
 
   it('retags from a current-prefix peer when the expected image is missing', () => {
     // Operator dir-rename case: the previously-built image carries the old
-    // INSTALL_SLUG (16f7e9e8); the daemon now boots under a new slug.
-    const peer = 'parachute-agent-image-16f7e9e8:latest';
+    // INSTALL_SLUG (cafef00d); the daemon now boots under a new slug.
+    const peer = 'parachute-agent-image-cafef00d:latest';
     inspectFailed();
     mockExecSync.mockReturnValueOnce(`${peer}\nnode:24-bookworm-slim\n`); // list
     mockExecSync.mockReturnValueOnce(''); // tag
@@ -135,7 +135,7 @@ describe('ensureContainerImage', () => {
     // Operator upgrades a pre-0.1.0 install: their on-disk image is named
     // `paraclaw-agent-<slug>:latest`. Auto-retag rather than forcing a
     // 5-minute rebuild they didn't ask for.
-    const legacyPeer = 'paraclaw-agent-deadbeef:latest';
+    const legacyPeer = 'paraclaw-agent-cafef00d:latest';
     inspectFailed();
     mockExecSync.mockReturnValueOnce(legacyPeer);
     mockExecSync.mockReturnValueOnce('');
@@ -164,14 +164,14 @@ describe('ensureContainerImage', () => {
     // is absent, but the peer-search guard against picking it back up keeps
     // the function safe if a future caller pre-checks a different way.
     inspectFailed();
-    mockExecSync.mockReturnValueOnce(`${CONTAINER_IMAGE}\nparachute-agent-image-16f7e9e8:latest\n`);
+    mockExecSync.mockReturnValueOnce(`${CONTAINER_IMAGE}\nparachute-agent-image-cafef00d:latest\n`);
     mockExecSync.mockReturnValueOnce('');
 
     ensureContainerImage();
 
     const tagCall = mockExecSync.mock.calls.find((call) => String(call[0]).startsWith(`${CONTAINER_RUNTIME_BIN} tag`));
     expect(tagCall).toBeDefined();
-    expect(String(tagCall![0])).toContain('parachute-agent-image-16f7e9e8:latest');
+    expect(String(tagCall![0])).toContain('parachute-agent-image-cafef00d:latest');
   });
 
   it('ignores arbitrary non-matching tags (e.g. base images, unrelated projects)', () => {

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -72,10 +72,10 @@ export function ensureContainerRuntimeRunning(): void {
  * spawning sessions.
  *
  * INSTALL_SLUG = sha1(process.cwd())[:8], so an operator dir-rename
- * (paraclaw#114: `mv paraclaw parachute-agent` was the trigger) flips the
- * slug. The previously-built image carries the OLD slug; the daemon goes
- * to spawn against the NEW slug; `docker run` returns code=125 ("image
- * not found") and every container spawn crashloops silently.
+ * (paraclaw#114) flips the slug. The previously-built image carries the
+ * OLD slug; the daemon goes to spawn against the NEW slug; `docker run`
+ * returns code=125 ("image not found") and every container spawn
+ * crashloops silently.
  *
  * Resolution path, ordered fail-fast → cheap → loud:
  *   1. Expected tag present → no-op.


### PR DESCRIPTION
## Summary

Operator-experience-aware cleanup of two operator-specific data points the #119 PR carried into the codebase. Aaron flagged; codebase should be operator-agnostic. **No behavior change.**

## What

**1. `src/container-runtime.test.ts`** — peer-image fixtures used `16f7e9e8`, the sha1 prefix of one specific operator's install path. Replaced with the synthetic `cafef00d` consistently across all current-prefix and legacy-prefix peer-image tests. The `PEER_IMAGE_PATTERN` regex (in `src/container-runtime.ts`) matches any 8-hex slug, so the choice is cosmetic — picking a clearly-fictitious value avoids the fixture-data/real-data ambiguity. Same swap applied to the legacy-peer test (was `paraclaw-agent-deadbeef:latest`, now `paraclaw-agent-cafef00d:latest`) so all six tests use one synthetic slug.

**2. `src/container-runtime.ts`** — doc-comment for `ensureContainerImage` referenced the specific `mv paraclaw parachute-agent` rename that exposed paraclaw#114. Rephrased to reference paraclaw#114 without the personal command. Operators on a fresh checkout don't share that history.

## Out of scope

- CHANGELOG entries naming Aaron historically — left as-is per the brief.
- Other `Aaron`/`aaron` mentions in unrelated `src/` files (test names like 'Aaron DM', historical comments about backfill correctness on Aaron's install in migration tests) — pre-existing context the brief said to leave; the issue is specific to #119 leftovers in `container-runtime.{ts,test.ts}`.

## Test plan

- [x] `pnpm test` — 540/540 (unchanged from rc.4)
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — same baseline as `main` (170 problems, 9 errors, 161 warnings, all pre-existing in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)