### PR TITLE
fix(mount-security): import HOME_DIR from config.ts (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.7] - 2026-05-05
+
+### Changed
+
+- **Mount-security: import `HOME_DIR` from `src/config.ts` instead of redrawing `os.homedir()` in-place (paraclaw#99).** `expandPath` in `src/modules/mount-security/index.ts` resolves operator-supplied `~/projects` etc. paths inside the mount-allowlist; before this change it called `process.env.HOME || os.homedir()` directly, the only remaining offender after #98 routed the rest of the host's HOME-derived paths through `config.ts`. Now `HOME_DIR` is exported from `config.ts` and imported here, so a future precedence-rule refactor (e.g. add a `PARACHUTE_AGENT_HOME` override) is one edit upstream. Default behavior unchanged.
+
+  Deliberate non-change: mount-allowlist's on-disk location stays at `<HOME>/.config/parachute-agent/mount-allowlist.json`; it does NOT route through `PARACHUTE_DIR`. Mount-allowlist is **operator-host policy** ("which paths can the agent ever mount on this host"), not per-install runtime state — two installs sharing a host should agree on the same allowlist, and a sandbox at `PARACHUTE_HOME=/tmp/sandbox` deliberately reads the same file the live install does. Runtime state (central DB + master.key) routes through `PARACHUTE_DIR` per #98; this PR pins the split with a regression test that fails if a future refactor accidentally collapses the two. Test coverage added in `src/modules/mount-security/expand-path.test.ts` (5 cases — default expansion, bare `~`, absolute passthrough, HOME-override, PARACHUTE_HOME-collapse-check). Closes #99.
+
 ## [0.1.2-rc.6] - 2026-05-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.6",
+  "version": "0.1.2-rc.7",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,13 @@ export const ASSISTANT_HAS_OWN_NUMBER =
 // self-register the install path (e.g. services.json `installDir`,
 // paraclaw#115).
 export const PROJECT_ROOT = process.cwd();
-const HOME_DIR = process.env.HOME || os.homedir();
+// Operator's home dir. Resolved once at module load — every downstream
+// consumer that needs to expand `~` or derive a HOME-relative path imports
+// this rather than calling `os.homedir()` itself, so a future precedence
+// change (e.g. add a `PARACHUTE_AGENT_HOME` override) is one edit. Honors
+// `HOME` env var first (sandbox-friendly, matches POSIX convention) before
+// falling back to the real home dir.
+export const HOME_DIR = process.env.HOME || os.homedir();
 
 // Parachute ecosystem root. Convention shared with parachute-hub, vault,
 // scribe — every module's persistent state lands under this directory
@@ -33,6 +39,15 @@ export const PARACHUTE_DIR = process.env.PARACHUTE_HOME || path.join(HOME_DIR, '
 // pre-existing files from the legacy dir on first 0.1.0 boot. The legacy
 // constants are exported for the migration to consult; nothing else should
 // read them. Drop in 0.2.0.
+//
+// Note (paraclaw#99): the allowlist sits at `<HOME>/.config/parachute-agent/`,
+// NOT under `PARACHUTE_DIR`. This is intentional — the file is operator-host
+// policy ("which paths can the agent ever mount on this host"), not runtime
+// state of any one install. Two installs sharing a host should agree on the
+// allowlist; a sandbox at `PARACHUTE_HOME=/tmp/sandbox` deliberately reads
+// the same file the live install does. Runtime state (central DB +
+// master.key) routes through `PARACHUTE_DIR` instead — see CENTRAL_DB_DIR
+// below and the sandbox-isolation block in CLAUDE.md.
 export const ALLOWLIST_DIR = path.join(HOME_DIR, '.config', 'parachute-agent');
 export const LEGACY_ALLOWLIST_DIR = path.join(HOME_DIR, '.config', 'paraclaw');
 export const MOUNT_ALLOWLIST_PATH = path.join(ALLOWLIST_DIR, 'mount-allowlist.json');

--- a/src/modules/mount-security/expand-path.test.ts
+++ b/src/modules/mount-security/expand-path.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `expandPath` resolves operator-supplied paths inside the mount-allowlist
+ * (`~/projects` etc.) against `HOME_DIR` from src/config.ts. paraclaw#99
+ * pulled the HOME-resolution out of this module so the precedence rule
+ * (`process.env.HOME` → `os.homedir()`) lives in one place; these tests pin
+ * the contract.
+ *
+ * `vi.resetModules()` is required because config.ts captures HOME_DIR at
+ * module load — tests that flip env vars must re-import both config and the
+ * mount-security module so the new HOME_DIR threads through.
+ */
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ORIGINAL_HOME = process.env.HOME;
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+});
+
+describe('expandPath HOME resolution', () => {
+  it("expands '~/foo' against config.HOME_DIR (default)", async () => {
+    process.env.HOME = '/Users/test-default';
+    const cfg = await import('../../config.js');
+    const { expandPath } = await import('./index.js');
+    expect(cfg.HOME_DIR).toBe('/Users/test-default');
+    expect(expandPath('~/projects')).toBe(path.join('/Users/test-default', 'projects'));
+  });
+
+  it("expands bare '~' to config.HOME_DIR", async () => {
+    process.env.HOME = '/Users/test-bare-tilde';
+    const { expandPath } = await import('./index.js');
+    expect(expandPath('~')).toBe('/Users/test-bare-tilde');
+  });
+
+  it('passes absolute paths through path.resolve unchanged', async () => {
+    process.env.HOME = '/Users/test-abs';
+    const { expandPath } = await import('./index.js');
+    // Absolute paths should NOT consult HOME_DIR — they resolve as-is.
+    expect(expandPath('/var/data/x')).toBe('/var/data/x');
+  });
+
+  it('honors HOME override at module load (sandbox-style override)', async () => {
+    // The override path: PARACHUTE_HOME does NOT route mount-allowlist (#99
+    // path 2 — operator-host policy is intentionally separate from runtime
+    // state), but the bare HOME env var IS honored by config.HOME_DIR for
+    // operators who reroute their entire shell session. Pin that flow.
+    process.env.HOME = '/tmp/sandbox-home-99';
+    const cfg = await import('../../config.js');
+    const { expandPath } = await import('./index.js');
+    expect(cfg.HOME_DIR).toBe('/tmp/sandbox-home-99');
+    expect(expandPath('~/repos')).toBe('/tmp/sandbox-home-99/repos');
+    // ALLOWLIST_DIR derives from HOME_DIR — it should follow.
+    expect(cfg.ALLOWLIST_DIR).toBe('/tmp/sandbox-home-99/.config/parachute-agent');
+  });
+
+  it('does NOT route through PARACHUTE_HOME (operator-policy stays at <HOME>/.config)', async () => {
+    // paraclaw#99 path 2 contract: PARACHUTE_HOME reroutes runtime state
+    // (DB + master.key) but NOT operator-host policy (mount-allowlist).
+    // Pin the split — if a future refactor accidentally collapses the two,
+    // sandboxes would silently see different mount permissions than the
+    // live install they share a host with.
+    process.env.HOME = '/Users/operator';
+    process.env.PARACHUTE_HOME = '/tmp/sandbox-home-collapse-check';
+    try {
+      const cfg = await import('../../config.js');
+      expect(cfg.PARACHUTE_DIR).toBe('/tmp/sandbox-home-collapse-check');
+      // CENTRAL_DB_DIR follows PARACHUTE_HOME — runtime state.
+      expect(cfg.CENTRAL_DB_DIR).toBe('/tmp/sandbox-home-collapse-check/agent');
+      // ALLOWLIST_DIR does NOT — operator-host policy.
+      expect(cfg.ALLOWLIST_DIR).toBe('/Users/operator/.config/parachute-agent');
+      expect(cfg.MOUNT_ALLOWLIST_PATH).toBe('/Users/operator/.config/parachute-agent/mount-allowlist.json');
+    } finally {
+      delete process.env.PARACHUTE_HOME;
+    }
+  });
+});

--- a/src/modules/mount-security/index.ts
+++ b/src/modules/mount-security/index.ts
@@ -4,14 +4,22 @@
  * Validates additional mounts against an allowlist stored OUTSIDE the project root.
  * This prevents container agents from modifying security configuration.
  *
- * Allowlist location: ~/.config/parachute-agent/mount-allowlist.json
- * (pre-0.1.0 installs auto-migrate from ~/.config/paraclaw/ on startup —
- * see migrateLegacyAllowlistDir below).
+ * Allowlist location: `<HOME>/.config/parachute-agent/mount-allowlist.json`
+ * (pre-0.1.0 installs auto-migrate from `<HOME>/.config/paraclaw/` on startup —
+ * see migrateLegacyAllowlistDir below). Path stays under `<HOME>/.config/`,
+ * NOT under `PARACHUTE_DIR`, because mount-allowlist is operator-host policy
+ * rather than per-install runtime state — see the doc-block on `ALLOWLIST_DIR`
+ * in src/config.ts (paraclaw#99).
+ *
+ * `HOME_DIR` is imported from src/config.ts so the precedence rule
+ * (`process.env.HOME` → `os.homedir()`) lives in one place. expandPath uses
+ * the same HOME_DIR for `~`-expansion in operator-supplied paths inside the
+ * allowlist (`~/projects` etc.), ensuring expansion agrees with the rest of
+ * the host process.
  */
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import { ALLOWLIST_DIR, LEGACY_ALLOWLIST_DIR, MOUNT_ALLOWLIST_PATH } from '../../config.js';
+import { ALLOWLIST_DIR, HOME_DIR, LEGACY_ALLOWLIST_DIR, MOUNT_ALLOWLIST_PATH } from '../../config.js';
 import { log } from '../../log.js';
 
 export interface AdditionalMount {
@@ -119,15 +127,18 @@ export function loadMountAllowlist(): MountAllowlist | null {
 }
 
 /**
- * Expand ~ to home directory and resolve to absolute path
+ * Expand ~ to home directory and resolve to absolute path. `HOME_DIR` comes
+ * from src/config.ts so a future change to the precedence rule
+ * (`HOME` → `os.homedir()`) is one edit upstream rather than redrawn here.
+ * Exported for direct test coverage of the expansion (paraclaw#99); not
+ * intended for use outside this module.
  */
-function expandPath(p: string): string {
-  const homeDir = process.env.HOME || os.homedir();
+export function expandPath(p: string): string {
   if (p.startsWith('~/')) {
-    return path.join(homeDir, p.slice(2));
+    return path.join(HOME_DIR, p.slice(2));
   }
   if (p === '~') {
-    return homeDir;
+    return HOME_DIR;
   }
   return path.resolve(p);
 }


### PR DESCRIPTION
## Summary

- `expandPath` in `src/modules/mount-security/index.ts` was the only remaining consumer of raw `os.homedir()` after #98 routed the host's HOME-derived paths through `src/config.ts`. Promoted `HOME_DIR` to an export from `config.ts` and imported it here so a future precedence-rule refactor (e.g. add a `PARACHUTE_AGENT_HOME` override) is one edit upstream.
- **Deliberate non-change:** mount-allowlist's on-disk location stays at `<HOME>/.config/parachute-agent/` — does NOT route through `PARACHUTE_DIR`. Mount-allowlist is operator-host policy ("which paths can the agent ever mount on this host"), not per-install runtime state. Two installs sharing a host should agree on the same allowlist; a sandbox at `PARACHUTE_HOME=/tmp/sandbox` deliberately reads the same file the live install does. Runtime state (central DB + master.key) routes through `PARACHUTE_DIR` per #98; this PR pins the split so a future refactor can't accidentally collapse the two.
- bumps `0.1.2-rc.6` → `0.1.2-rc.7` per governance.

## Decision (path 2 of the two-paths in #99)

Issue #99 offered two shapes:
1. Route mount-allowlist through `PARACHUTE_DIR` (full consistency with #98)
2. Keep at `<HOME>/.config/parachute-agent/` and document the operator-policy / runtime-state distinction

Picked (2). Reasoning:
- Mount-allowlist exists to declare which host paths the agent is ever allowed to mount. That's the **operator's** decision about **this machine** — it should not vary by install, and a sandbox running on the same host is subject to the same operator's same security stance.
- The "consistency" argument for (1) actually conflates two categories of state. Runtime state (DB + master.key) is per-install and MUST be isolated for sandbox correctness; operator-policy state is per-host and SHOULD be shared.
- (2) needs no new migration and no new override knob. The file location stays exactly where it is today.

The bigger goal — `os.homedir()` redrawn in only one place (config.ts) so a future precedence change is one edit — is achieved either way; that's the part that actually moved.

## Files changed

- `src/config.ts` — promote `HOME_DIR` to an export with a doc-comment on the precedence rule. Add a doc-block on `ALLOWLIST_DIR` explaining why it stays under `<HOME>/.config/` rather than `PARACHUTE_DIR`.
- `src/modules/mount-security/index.ts` — `expandPath` imports `HOME_DIR` from `config.ts`; remove the local `process.env.HOME || os.homedir()` redraw and the now-unused `os` import. Export `expandPath` for direct test coverage. Updated file-header doc explains the operator-policy vs runtime-state distinction.
- `src/modules/mount-security/expand-path.test.ts` (new) — 5 cases covering default `~/foo` expansion, bare `~`, absolute passthrough, HOME-override at module load, and a regression test pinning that PARACHUTE_HOME does NOT collapse with ALLOWLIST_DIR.
- `package.json` — `0.1.2-rc.6` → `0.1.2-rc.7`.
- `CHANGELOG.md` — rc.7 entry under `### Changed`.

## Test plan

- [x] `pnpm test` — 551/551 passed in fully-resolved tree, post-pnpm-install (was 546 pre-PR; +5 from the new `expand-path.test.ts`)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint src/modules/mount-security/ src/config.ts` — 0 errors on changed files (6 pre-existing catch-all warnings unchanged)
- [x] Sanity-check: stashed `src/modules/mount-security/index.ts` locally and re-ran the new test file — 4 of 5 cases fail (the one that passes is the PARACHUTE_HOME-collapse-check, which exercises only `config.ts` and is therefore independent of the source-side fix). Confirms the fix is real and the tests actually pin the contract.
- [x] Existing `migrate.test.ts` (mount-security) still green
- [x] No regression on the live-install mount-allowlist read path: file location, `MOUNT_ALLOWLIST_PATH`, `LEGACY_ALLOWLIST_DIR`, and the migration helper are all untouched

## Backwards compatibility

Default behavior unchanged. With neither `HOME` nor `PARACHUTE_HOME` overrides set, `HOME_DIR` resolves identically to before, `ALLOWLIST_DIR` lands at `<HOME>/.config/parachute-agent/`, and `expandPath('~/foo')` returns the same path it always did. No file moves; no migration code added or removed.

## Closes

- Closes #99
- Refs #98 (the precedent that established the convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)