### PR TITLE
test: dup-skip + sender-approval replay integration coverage (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.9] - 2026-05-05
+
+### Added
+
+- **Integration coverage for `writeSessionMessage` dup-skip + sender-approval replay (paraclaw#97).** The unit test added with #95 proved `insertMessage` returns `inserted=false` on a duplicate id, but the write-path side effects layered above it were never asserted at the integration level. Adds two new test surfaces. (1) `src/session-manager.dup-skip.test.ts` — four tests using real session DBs and real fs, asserting that `writeSessionMessage` does NOT bump `sessions.last_active` on a duplicate dispatch (captured timestamp before/after, equality check), emits the documented `log.debug` payload with `agentGroupId / sessionId / messageId` exactly once, absorbs N near-concurrent same-id calls (Promise.all of 6 → one row, one inbox file, no spurious siblings), and still lands distinct ids in the same burst (sanity check that dup-skip is keyed on id, not on burst). (2) Two new tests in `src/modules/permissions/sender-approval.test.ts` exercise the approval-replay chain end-to-end: an attachment-bearing message routed through the request_approval gate, persisted in `pending_sender_approvals.original_message`, then replayed via `routeInbound` after approve — first that the replay lands cleanly at the namespaced `messages_in.id` path with the file at `inbox/<id>:<agentGroupId>/photo.jpg`; second that when `original_message` has been mutated since first write (accumulate-mode wiring already wrote the row + extracted the file with original bytes, then someone path-normalizes or re-encodes the JSON), the on-disk file is preserved byte-for-byte — the #96 file-clobber invariant under the sender-approval entry point. Stash-and-rerun discipline confirmed both regression tests catch the underlying bugs: pre-#96 ordering (extract before insert) makes the mutated-replay test fail on the file-bytes assertion; moving `updateSession` outside the `inserted` gate makes the last_active test fail with a non-equal timestamp. Closes paraclaw#97. Refs paraclaw#92, #95, #96, #120.
+
 ## [0.1.2-rc.8] - 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.8",
+  "version": "0.1.2-rc.9",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -10,13 +10,23 @@
  *  - Approve path: member added, original message replayed via routeInbound,
  *    container woken
  *  - Deny path: pending row deleted, no member added
+ *  - Approve replay with attachment: row + file land cleanly at the
+ *    namespaced messages_in.id path (paraclaw#97)
+ *  - Approve replay with MUTATED original_message: on-disk attachment file
+ *    is preserved byte-for-byte; the dup-skip path absorbs the second write
+ *    so a path-normalization or any pre-replay mutation can't clobber state
+ *    that's already committed (paraclaw#97 — #96 invariant under the
+ *    sender-approval entry point)
  */
 import fs from 'fs';
+import path from 'path';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
+import { openDb } from '../../db/connection.js';
 import { initTestDb, closeDb, runMigrations } from '../../db/index.js';
 import { createAgentGroup } from '../../db/agent-groups.js';
 import { createMessagingGroup, createMessagingGroupAgent } from '../../db/messaging-groups.js';
+import { inboundDbPath, sessionDir } from '../../session-manager.js';
 import { upsertUser } from './db/users.js';
 import { grantRole } from './db/user-roles.js';
 
@@ -466,5 +476,159 @@ describe('unknown-sender request_approval flow', () => {
       .prepare('SELECT 1 AS x FROM agent_group_members WHERE user_id = ? AND agent_group_id = ?')
       .get('tg:stranger', 'ag-1');
     expect(member).toBeDefined();
+  });
+
+  // ── paraclaw#97: replay-path coverage ──────────────────────────────────
+  //
+  // The unit tests above prove the response handler's bookkeeping (member
+  // added, pending row cleared, wake fired). The two tests below assert the
+  // full chain through routeInbound → writeSessionMessage on a message
+  // carrying a real attachment, plus the #96 file-clobber invariant under
+  // this entry point.
+
+  function strangerWithAttachment(textValue: string, attachmentBytes: Buffer) {
+    return {
+      channelType: 'telegram',
+      platformId: 'chat-123',
+      threadId: null,
+      message: {
+        id: 'tg-msg-with-att',
+        kind: 'chat' as const,
+        content: JSON.stringify({
+          senderId: 'tg:stranger',
+          senderName: 'Stranger',
+          text: textValue,
+          attachments: [
+            { name: 'photo.jpg', type: 'image', size: attachmentBytes.length, data: attachmentBytes.toString('base64') },
+          ],
+        }),
+        timestamp: now(),
+      },
+    };
+  }
+
+  it('approve replay → attachment lands cleanly at the namespaced messages_in.id path (paraclaw#97)', async () => {
+    const ORIGINAL_BYTES = Buffer.from('first-pic');
+    const event = strangerWithAttachment('see photo', ORIGINAL_BYTES);
+
+    const { routeInbound } = await import('../../router.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+
+    // First route: gate denies (request_approval), pending row created. The
+    // wired agent has ignored_message_policy='drop', so no accumulate write
+    // happens — the replay will be the first writer of this messages_in.id.
+    await routeInbound(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const { getDb } = await import('../../db/connection.js');
+    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    expect(pending).toBeDefined();
+
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: pending.id,
+        value: 'approve',
+        userId: 'owner',
+        channelType: 'telegram',
+        platformId: 'dm-owner',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    // The replay's deliverToAgent created the session — find it for the
+    // wired agent group and assert the row + file landed at the right spot.
+    const sess = getDb().prepare('SELECT id FROM sessions WHERE agent_group_id = ?').get('ag-1') as { id: string };
+    expect(sess).toBeDefined();
+
+    const inboundDb = openDb(inboundDbPath('ag-1', sess.id));
+    const rows = inboundDb.prepare('SELECT id, content FROM messages_in').all() as Array<{
+      id: string;
+      content: string;
+    }>;
+    inboundDb.close();
+
+    expect(rows).toHaveLength(1);
+    // messageIdForAgent namespaces the platform id with agent_group_id so a
+    // multi-agent fan-out can't collide on messages_in.id (router.ts).
+    const namespacedId = 'tg-msg-with-att:ag-1';
+    expect(rows[0].id).toBe(namespacedId);
+
+    // Row content carries localPath after extractAttachmentFiles ran post-
+    // commit; inline base64 is gone.
+    const parsed = JSON.parse(rows[0].content);
+    expect(parsed.attachments[0].localPath).toBe(`inbox/${namespacedId}/photo.jpg`);
+    expect(parsed.attachments[0].data).toBeUndefined();
+
+    const filePath = path.join(sessionDir('ag-1', sess.id), 'inbox', namespacedId, 'photo.jpg');
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath).equals(ORIGINAL_BYTES)).toBe(true);
+  });
+
+  it('approve replay with MUTATED original_message: on-disk file preserved (paraclaw#97 — #96 invariant)', async () => {
+    // Switch the wired agent to accumulate so the gate-denied first attempt
+    // writes the row + extracts the file BEFORE the approval card is acted
+    // on. This is the racing-dispatch shape #92 caught: two writers for the
+    // same messages_in.id, one from accumulate-on-gate-deny, one from the
+    // approval replay.
+    const { getDb } = await import('../../db/connection.js');
+    getDb().prepare(`UPDATE messaging_group_agents SET ignored_message_policy = 'accumulate' WHERE id = ?`).run('mga-1');
+
+    const ORIGINAL_BYTES = Buffer.from('first-pic');
+    const MUTATED_BYTES = Buffer.from('CLOBBERED');
+    const event = strangerWithAttachment('see photo', ORIGINAL_BYTES);
+
+    const { routeInbound } = await import('../../router.js');
+    const { getResponseHandlers } = await import('../../response-registry.js');
+
+    // First route: gate denies, but accumulate writes the row + extracts the
+    // file with ORIGINAL_BYTES.
+    await routeInbound(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const sess = getDb().prepare('SELECT id FROM sessions WHERE agent_group_id = ?').get('ag-1') as { id: string };
+    expect(sess).toBeDefined();
+    const namespacedId = 'tg-msg-with-att:ag-1';
+    const filePath = path.join(sessionDir('ag-1', sess.id), 'inbox', namespacedId, 'photo.jpg');
+    expect(fs.readFileSync(filePath).equals(ORIGINAL_BYTES)).toBe(true);
+
+    // Mutate the pending row's original_message to carry MUTATED_BYTES. This
+    // mirrors any pre-replay normalization (path replacement, ContentRecord
+    // re-encoding, retry with re-fetched payload) that produces a JSON event
+    // whose attachment bytes don't match what's already on disk.
+    const pending = getDb().prepare('SELECT id FROM pending_sender_approvals').get() as { id: string };
+    expect(pending).toBeDefined();
+    const mutatedEvent = strangerWithAttachment('see photo', MUTATED_BYTES);
+    getDb()
+      .prepare('UPDATE pending_sender_approvals SET original_message = ? WHERE id = ?')
+      .run(JSON.stringify(mutatedEvent), pending.id);
+
+    // Approve. Replay's writeSessionMessage hits ON CONFLICT (id already
+    // present from the accumulate write), so extractAttachmentFiles never
+    // runs and the on-disk file stays put.
+    for (const handler of getResponseHandlers()) {
+      const claimed = await handler({
+        questionId: pending.id,
+        value: 'approve',
+        userId: 'owner',
+        channelType: 'telegram',
+        platformId: 'dm-owner',
+        threadId: null,
+      });
+      if (claimed) break;
+    }
+
+    // 1. File on disk is byte-for-byte the original — no mutated clobber.
+    const onDisk = fs.readFileSync(filePath);
+    expect(onDisk.equals(ORIGINAL_BYTES)).toBe(true);
+    expect(onDisk.equals(MUTATED_BYTES)).toBe(false);
+
+    // 2. Exactly one row in messages_in (the accumulate write); the replay
+    //    didn't slip a second row in.
+    const inboundDb = openDb(inboundDbPath('ag-1', sess.id));
+    const rows = inboundDb.prepare('SELECT id FROM messages_in').all() as Array<{ id: string }>;
+    inboundDb.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(namespacedId);
   });
 });

--- a/src/modules/permissions/sender-approval.test.ts
+++ b/src/modules/permissions/sender-approval.test.ts
@@ -499,7 +499,12 @@ describe('unknown-sender request_approval flow', () => {
           senderName: 'Stranger',
           text: textValue,
           attachments: [
-            { name: 'photo.jpg', type: 'image', size: attachmentBytes.length, data: attachmentBytes.toString('base64') },
+            {
+              name: 'photo.jpg',
+              type: 'image',
+              size: attachmentBytes.length,
+              data: attachmentBytes.toString('base64'),
+            },
           ],
         }),
         timestamp: now(),
@@ -572,7 +577,9 @@ describe('unknown-sender request_approval flow', () => {
     // same messages_in.id, one from accumulate-on-gate-deny, one from the
     // approval replay.
     const { getDb } = await import('../../db/connection.js');
-    getDb().prepare(`UPDATE messaging_group_agents SET ignored_message_policy = 'accumulate' WHERE id = ?`).run('mga-1');
+    getDb()
+      .prepare(`UPDATE messaging_group_agents SET ignored_message_policy = 'accumulate' WHERE id = ?`)
+      .run('mga-1');
 
     const ORIGINAL_BYTES = Buffer.from('first-pic');
     const MUTATED_BYTES = Buffer.from('CLOBBERED');

--- a/src/session-manager.dup-skip.test.ts
+++ b/src/session-manager.dup-skip.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration coverage for paraclaw#97 — writeSessionMessage's dup-skip
+ * side effects beyond the SQL-layer assertions in #95.
+ *
+ * After paraclaw#92 / #95, ON CONFLICT(id) DO NOTHING absorbs the second
+ * INSERT, and writeSessionMessage gates two side effects on inserted=true:
+ *   1. session.last_active is NOT bumped on the dup
+ *   2. extractAttachmentFiles never runs (paraclaw#96 / #120)
+ *   3. A debug log fires so drops are observable
+ *
+ * The session-manager.attachments.test.ts file already covers #2 with
+ * sequential pairs. This file adds the integration-level invariants the
+ * issue calls out as still untested at the writeSessionMessage layer:
+ * last_active discipline, debug log shape, and dup-skip behavior under
+ * realistic dispatcher pressure (Promise.all'd same-id calls).
+ *
+ * Real session DBs + real fs — last_active and file invariants are the
+ * kind that mocks can fake green.
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { openDb } from './db/connection.js';
+import { initTestDb, closeDb, runMigrations, createAgentGroup, getSession } from './db/index.js';
+import { log } from './log.js';
+import { initSessionFolder, inboundDbPath, sessionDir, writeSessionMessage } from './session-manager.js';
+
+vi.mock('./config.js', async () => {
+  const actual = await vi.importActual('./config.js');
+  return { ...actual, DATA_DIR: '/tmp/paraclaw-test-dup-skip' };
+});
+
+const TEST_DIR = '/tmp/paraclaw-test-dup-skip';
+const AG = 'ag-1';
+const SESS = 'sess-dup';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function rowsInMessagesIn(): Array<{ id: string }> {
+  const db = openDb(inboundDbPath(AG, SESS));
+  const rows = db.prepare('SELECT id FROM messages_in').all() as Array<{ id: string }>;
+  db.close();
+  return rows;
+}
+
+function makeMessage(id: string) {
+  return {
+    id,
+    kind: 'chat',
+    timestamp: nowIso(),
+    platformId: 'chan-1',
+    channelType: 'discord',
+    threadId: null as string | null,
+    content: JSON.stringify({
+      text: 'hello',
+      attachments: [{ name: 'doc.bin', type: 'file', size: 4, data: Buffer.from('aaaa').toString('base64') }],
+    }),
+  };
+}
+
+beforeEach(() => {
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+
+  const db = initTestDb();
+  runMigrations(db);
+
+  createAgentGroup({
+    id: AG,
+    name: 'Test Agent',
+    folder: 'test-agent',
+    agent_provider: null,
+    created_at: nowIso(),
+  });
+  db.prepare(
+    `INSERT INTO sessions (id, agent_group_id, messaging_group_id, thread_id, agent_provider,
+       status, container_status, last_active, created_at)
+     VALUES (@id, @agent_group_id, @messaging_group_id, @thread_id, @agent_provider,
+       @status, @container_status, @last_active, @created_at)`,
+  ).run({
+    id: SESS,
+    agent_group_id: AG,
+    messaging_group_id: null,
+    thread_id: null,
+    agent_provider: null,
+    status: 'active' as const,
+    container_status: 'stopped' as const,
+    last_active: null,
+    created_at: nowIso(),
+  });
+  initSessionFolder(AG, SESS);
+});
+
+afterEach(() => {
+  closeDb();
+  if (fs.existsSync(TEST_DIR)) fs.rmSync(TEST_DIR, { recursive: true });
+  vi.restoreAllMocks();
+});
+
+describe('writeSessionMessage — dup-skip side effects (paraclaw#97)', () => {
+  it('does NOT bump session.last_active on a duplicate dispatch', async () => {
+    writeSessionMessage(AG, SESS, makeMessage('msg-1'));
+
+    const firstActive = getSession(SESS)!.last_active;
+    expect(firstActive).not.toBeNull();
+
+    // Sleep enough for any new ISO timestamp to differ from the first.
+    await new Promise((r) => setTimeout(r, 25));
+
+    writeSessionMessage(AG, SESS, makeMessage('msg-1'));
+
+    const secondActive = getSession(SESS)!.last_active;
+    expect(secondActive).toBe(firstActive);
+
+    expect(rowsInMessagesIn()).toHaveLength(1);
+  });
+
+  it('emits a debug log on dup-skip with the expected payload', () => {
+    const debugSpy = vi.spyOn(log, 'debug');
+
+    writeSessionMessage(AG, SESS, makeMessage('msg-2'));
+    writeSessionMessage(AG, SESS, makeMessage('msg-2'));
+
+    const dupCalls = debugSpy.mock.calls.filter(([msg]) =>
+      typeof msg === 'string' && msg.includes('messages_in id already present'),
+    );
+    expect(dupCalls).toHaveLength(1);
+
+    const [, fields] = dupCalls[0]!;
+    expect(fields).toMatchObject({
+      agentGroupId: AG,
+      sessionId: SESS,
+      messageId: 'msg-2',
+    });
+  });
+
+  it('absorbs N near-concurrent same-id dispatches: one row, one file, no spurious sibling files', async () => {
+    // Promise.all-style dispatcher pressure. better-sqlite3 is synchronous so
+    // these serialize on the event loop, but the test shape captures what a
+    // future async refactor would have to preserve: same-id calls collapse
+    // to a single row + a single attachment file regardless of fan-in.
+    const calls = Array.from({ length: 6 }, () => writeSessionMessage(AG, SESS, makeMessage('msg-burst')));
+    await Promise.all(calls);
+
+    expect(rowsInMessagesIn()).toHaveLength(1);
+
+    const inboxDir = path.join(sessionDir(AG, SESS), 'inbox', 'msg-burst');
+    expect(fs.existsSync(inboxDir)).toBe(true);
+    const files = fs.readdirSync(inboxDir);
+    expect(files).toEqual(['doc.bin']);
+  });
+
+  it('different ids in the same burst all land — dup-skip is keyed on id, not on burst', async () => {
+    // Sanity check that the dup-skip absorption is NOT overly broad — distinct
+    // messages_in.id values still get their own rows + their own inbox dirs.
+    await Promise.all([
+      writeSessionMessage(AG, SESS, makeMessage('msg-a')),
+      writeSessionMessage(AG, SESS, makeMessage('msg-b')),
+      writeSessionMessage(AG, SESS, makeMessage('msg-c')),
+    ]);
+
+    const ids = rowsInMessagesIn()
+      .map((r) => r.id)
+      .sort();
+    expect(ids).toEqual(['msg-a', 'msg-b', 'msg-c']);
+
+    expect(fs.readdirSync(path.join(sessionDir(AG, SESS), 'inbox')).sort()).toEqual(['msg-a', 'msg-b', 'msg-c']);
+  });
+});

--- a/src/session-manager.dup-skip.test.ts
+++ b/src/session-manager.dup-skip.test.ts
@@ -125,8 +125,8 @@ describe('writeSessionMessage — dup-skip side effects (paraclaw#97)', () => {
     writeSessionMessage(AG, SESS, makeMessage('msg-2'));
     writeSessionMessage(AG, SESS, makeMessage('msg-2'));
 
-    const dupCalls = debugSpy.mock.calls.filter(([msg]) =>
-      typeof msg === 'string' && msg.includes('messages_in id already present'),
+    const dupCalls = debugSpy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.includes('messages_in id already present'),
     );
     expect(dupCalls).toHaveLength(1);
 


### PR DESCRIPTION
## Summary

Closes paraclaw#97 — adds integration coverage for the two writeSessionMessage paths the existing unit tests don't fully exercise. After paraclaw#92/#95 (ON CONFLICT(id) DO NOTHING) and paraclaw#96/#120 (extract-attachments-after-row-commits), the SQL-layer + sequential-pair tests are green, but a few invariants the issue calls out were still untested at the integration layer.

Two test surfaces, both real fixture DBs + real fs (per `feedback_migration_real_data_testing` — clobber-class hazards mocks can fake green):

**`src/session-manager.dup-skip.test.ts`** (new file, 4 tests):
- `does NOT bump session.last_active on a duplicate dispatch` — captures `getSession(SESS).last_active` before/after the second write, asserts equality, asserts exactly one row.
- `emits a debug log on dup-skip with the expected payload` — `vi.spyOn(log, 'debug')`, asserts the dup-skip log fires once with `{agentGroupId, sessionId, messageId}`.
- `absorbs N near-concurrent same-id dispatches: one row, one file, no spurious sibling files` — Promise.all of 6 same-id calls → exactly one row, exactly one file at `inbox/<id>/doc.bin`. better-sqlite3 is sync so these serialize on the event loop, but the test shape captures what a future async refactor would have to preserve.
- `different ids in the same burst all land — dup-skip is keyed on id, not on burst` — sanity check that absorption isn't overly broad.

**`src/modules/permissions/sender-approval.test.ts`** (+2 tests):
- `approve replay → attachment lands cleanly at the namespaced messages_in.id path` — drop-policy wiring, stranger sends attachment-bearing message, approve handler fired, asserts session created, exactly one row at `tg-msg-with-att:ag-1`, content has `localPath: 'inbox/.../photo.jpg'` with no inline `data`, file bytes match the original.
- `approve replay with MUTATED original_message: on-disk file preserved (#96 invariant)` — accumulate-mode wiring writes the row+file with ORIGINAL_BYTES on the gate-denied first attempt, then directly mutates `pending_sender_approvals.original_message` to carry MUTATED_BYTES before approve. Asserts the on-disk file is NOT clobbered (`onDisk.equals(ORIGINAL_BYTES)===true`, `onDisk.equals(MUTATED_BYTES)===false`). Exercises #96 under the sender-approval entry point.

Refs: paraclaw#97 (this issue), #95 (ON CONFLICT migration), #96 (extract-attachments-after-row-commits invariant), #120 (the PR that landed #96).

## Test plan

- [x] `pnpm test` host gate — 565/565 passing (was 559, +6 across the two test files).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean on touched files.
- [x] **Stash-and-rerun confirmed both regressions catch real bugs**:
  - Pre-#96 ordering (extractAttachmentFiles before insertMessage) → mutated-replay test fails on `expected false to be true` for `onDisk.equals(ORIGINAL_BYTES)`.
  - Moving `updateSession({ last_active })` outside the `if (!inserted) return` early-return → last_active test fails (`expected '...075Z' to be '...047Z'`).
  - Both fixes restored to current main behavior.

## Notes for reviewer

- Fresh-replay test uses **drop policy** so the replay is the FIRST writer at the namespaced id (`tg-msg-with-att:ag-1`). Mutated-replay test switches wiring to **accumulate policy** mid-test via direct `UPDATE messaging_group_agents SET ignored_message_policy = 'accumulate'` so the gate-denied first attempt writes the row+file, then mutates `pending_sender_approvals.original_message` before approve. This shape lets the dup-skip absorb the second insert while the test asserts on-disk bytes were not clobbered.
- The Promise.all "burst" test acknowledges in a comment that better-sqlite3 serializes synchronously today; the test shape exists for the future-async-refactor invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)