### PR TITLE
test: lockstep parallel-equality for resolveInjectableSecrets ↔ listInjectableSecretsForGroup (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.10] - 2026-05-05
+
+### Added
+
+- **Parallel-equality test for `resolveInjectableSecrets ↔ listInjectableSecretsForGroup` lockstep (paraclaw#129).** The two functions in `src/secrets/index.ts` are SQL-identical mirrors with a load-bearing doc-comment requiring lockstep edits — today the invariant is preserved by careful reading and a #126-era reviewer note. Adds a `describe('… lockstep …')` block in `src/secrets/secrets.test.ts` with an `expectLockstep(groupId, expectedNames)` helper that calls both functions, asserts name-set equality, and walks each name through `getSecret(name, groupId)` to verify the chosen row id (the `ORDER BY s.agent_group_id IS NULL` scoped-wins ordering) agrees with the plaintext returned. Five fixtures cover the configs the issue calls out: rich mix (scoped+all + global+assigned + global+mode=all + name collision), mode=selective with mixed reachable/unreachable globals, the orphaned-scoped (selective + no assignment) "unreachable via UI" corner the `findStaleSessionsForSecret` doc-comment flags, the unknown-agent-group selective-default path, and an empty store. Stash-and-rerun confirmed: flipping `listInjectableSecretsForGroup`'s `ORDER BY s.agent_group_id IS NULL` to `s.agent_group_id IS NOT NULL` (the dedup-picks-global drift mode) fails the rich-mix name-collision check, and dropping the gate clause `(g.secret_mode = 'all' OR a.secret_id IS NOT NULL)` from one function fails the orphaned-scoped check. Mechanical guard, no production code change. Closes paraclaw#129. Refs paraclaw#126.
+
 ## [0.1.2-rc.9] - 2026-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.9",
+  "version": "0.1.2-rc.10",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/secrets/secrets.test.ts
+++ b/src/secrets/secrets.test.ts
@@ -440,3 +440,97 @@ describe('listInjectableSecretsForGroup', () => {
     expect(rows[0]).not.toHaveProperty('value_encrypted');
   });
 });
+
+describe('resolveInjectableSecrets ↔ listInjectableSecretsForGroup lockstep (paraclaw#129)', () => {
+  /**
+   * Mechanical guard against drift between the two SQL-identical functions in
+   * src/secrets/index.ts. Both walk identical row predicates + gate clauses;
+   * any future SQL edit must touch both. Today the invariant is preserved by
+   * careful reading + a load-bearing doc-comment. This block tests it.
+   *
+   * For each fixture, calls both functions and asserts:
+   *   - same set of names (the row gate matches)
+   *   - per-name plaintext from resolveInjectableSecrets matches the value
+   *     getSecret returns when scoped to the same group (the dedup-by-name
+   *     `ORDER BY s.agent_group_id IS NULL` scoped-wins ordering matches)
+   *
+   * If a future SQL change makes one function accept a row the other rejects,
+   * the name-set assertion fails. If the ORDER BY drifts so dedup picks the
+   * wrong row on collision, the per-name plaintext assertion fails.
+   */
+  function expectLockstep(agentGroupId: string, expectedNames: string[]): void {
+    const resolved = resolveInjectableSecrets(agentGroupId);
+    const listed = listInjectableSecretsForGroup(agentGroupId);
+
+    const sortedExpected = expectedNames.slice().sort();
+    expect([...resolved.keys()].sort()).toEqual(sortedExpected);
+    expect(listed.map((r) => r.name).sort()).toEqual(sortedExpected);
+
+    for (const view of listed) {
+      expect(resolved.get(view.name)).toBe(getSecret(view.name, agentGroupId));
+    }
+  }
+
+  it('rich mix: scoped+all + global+assigned + global+mode=all + name collision', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'A', 'all');
+
+    putSecret('SCOPED_ONLY', 'sv', { agent_group_id: 'A' });
+    const assignedId = putSecret('GLOBAL_ASSIGNED', 'gv-assigned');
+    addAssignment(assignedId, 'A');
+    putSecret('GLOBAL_MODE_ALL', 'gv-mode-all');
+    putSecret('TOKEN', 'global-token');
+    putSecret('TOKEN', 'scoped-token', { agent_group_id: 'A' });
+
+    expectLockstep('A', ['SCOPED_ONLY', 'GLOBAL_ASSIGNED', 'GLOBAL_MODE_ALL', 'TOKEN']);
+
+    // Spot-check the collision picked the scoped row in BOTH views.
+    expect(resolveInjectableSecrets('A').get('TOKEN')).toBe('scoped-token');
+    expect(listInjectableSecretsForGroup('A').find((r) => r.name === 'TOKEN')?.scope).toBe('scoped');
+  });
+
+  it('mode=selective: mixed reachable + unreachable globals + scoped-with-assignment', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'B', 'selective');
+
+    putSecret('UNREACHABLE_GLOBAL', 'gv'); // mode=selective + no assignment → excluded
+    const reachableId = putSecret('REACHABLE', 'gv2');
+    addAssignment(reachableId, 'B');
+    const scopedAssignedId = putSecret('SCOPED_AND_ASSIGNED', 'sv', { agent_group_id: 'B' });
+    addAssignment(scopedAssignedId, 'B');
+
+    expectLockstep('B', ['REACHABLE', 'SCOPED_AND_ASSIGNED']);
+  });
+
+  it('orphaned-scoped (selective + scoped + no assignment): both exclude', () => {
+    // The "unreachable via UI" config the doc-comment in findStaleSessionsForSecret
+    // calls out — selective mode + scoped secret + no assignment row. The shared
+    // gate `(g.secret_mode='all' OR a.secret_id IS NOT NULL)` rejects from BOTH.
+    // If a future SQL change makes one function accept it, this catches the drift.
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'C', 'selective');
+
+    putSecret('ORPHAN', 'v', { agent_group_id: 'C' });
+
+    expectLockstep('C', []);
+  });
+
+  it('unknown agent_group_id: both return empty (selective default)', () => {
+    putSecret('GLOBAL', 'v');
+    expectLockstep('does-not-exist', []);
+  });
+
+  it('empty secret store + mode=all: both return empty', () => {
+    const db = initTestDb();
+    runMigrations(db);
+    _setMasterKeyForTest(crypto.randomBytes(32));
+    seedAgentGroup(db, 'D', 'all');
+    expectLockstep('D', []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes paraclaw#129 — mechanical regression guard for the SQL-identical mirror pair in `src/secrets/index.ts`. Both functions walk identical row predicates + gate clauses, with a load-bearing doc-comment requiring lockstep edits. Today the invariant is preserved by careful reading + the #126-era reviewer note — this adds a test that mechanizes it.

New `describe('… lockstep …')` block in `src/secrets/secrets.test.ts` with an `expectLockstep(groupId, expectedNames)` helper that:
- calls both functions
- asserts name-set equality (the row predicate + gate matches)
- walks each name through `getSecret(name, groupId)` and asserts the plaintext matches what `resolveInjectableSecrets` returns (the `ORDER BY s.agent_group_id IS NULL` scoped-wins ordering matches)

Five fixtures cover the configs the issue calls out:
1. **rich mix** — scoped+all + global+assigned + global+mode=all + name collision (with a spot-check that the collision picked the scoped row in BOTH views)
2. **mode=selective** — mixed reachable + unreachable globals + scoped-with-assignment
3. **orphaned-scoped** — selective + scoped + no assignment, the "unreachable via UI" corner the `findStaleSessionsForSecret` doc-comment flags; both should exclude
4. **unknown agent_group_id** — selective default, both empty
5. **empty store + mode=all** — both empty

No production code change. Mechanical safety on the invariant from paraclaw#126.

Refs: paraclaw#129 (this issue), paraclaw#126 (the PR whose reviewer note flagged the lockstep risk).

## Test plan

- [x] `pnpm test` host gate — **570/570 passing** (was 565, +5 lockstep tests).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean on touched file (pre-existing warnings/errors elsewhere unrelated).
- [x] **Stash-and-rerun confirmed both regression modes**:
  - Dropping the gate clause `(g.secret_mode = 'all' OR a.secret_id IS NOT NULL)` from `listInjectableSecretsForGroup` → 6 failures across the new lockstep tests AND existing `secrets.test.ts` / `web/routes/secrets.test.ts` tests that exercise the same path. Specifically, the orphaned-scoped lockstep fixture fires (`expected []`/`["GLOBAL", "ORPHAN"]` set mismatch).
  - Flipping `ORDER BY s.agent_group_id IS NULL` to `IS NOT NULL` (the dedup-picks-global drift mode) → name-collision spot-check fails: `expected 'global' to be 'scoped'`.
  - Both fixes restored.

## Notes for reviewer

- The per-name plaintext check uses `getSecret(name, groupId)` as the bridge between resolve's `Map<name,plaintext>` and list's `id`-bearing rows. `getSecret` has its own scoped-wins resolution (separate code path); the test's strength comes from agreement across ALL THREE — drift in any one of the three would surface.
- Stash-and-rerun choice rationale: the gate-drop tests the WHERE clause invariant; the ORDER BY flip tests the dedup-ordering invariant. Together they cover the two distinct ways the SQL pair could drift in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)