### PR TITLE
fix(spa): three SPA OAuth bootstrap fixes — narrow scopes, regression-pin client_name, redirect_uri-aware cache (rc.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.2-rc.14] - 2026-05-05
+
+### Fixed
+
+- **SPA OAuth bootstrap — three narrowing fixes for the agent web UI (paraclaw#136, #137, #138).** Bundled audit of `web/ui/src/lib/auth.ts`:
+
+  1. **Drop `vault:read vault:write` from `REQUESTED_SCOPES` (paraclaw#136).** The agent SPA used to ask for broad vault read/write at bootstrap, but every vault interaction in the UI (VaultDetail, GroupDetail, NewGroupWizard) already runs the paraclaw#56 re-consent pattern — calling `beginLogin([\`vault:\${name}:admin\`])` with the narrow per-vault scope when the operator's existing JWT doesn't carry admin for the targeted vault. The bootstrap-time `vault:read vault:write` were dead weight: never used by any code path, but visible on the hub's consent screen as "this app wants to read/write all your vaults" — the wrong story for an SPA whose vault touches are narrowly per-vault and on-demand. Narrow `REQUESTED_SCOPES` to `agent:admin agent:write`. Refactor `beginLogin`'s URL-construction inline-block into a pure exported `buildAuthorizeUrl(opts)` helper so tests can pin the scope string and the `extraScopes` append-and-dedupe behavior without mocking `window.location.replace`. 5 new tests pin the post-narrowing surface: REQUESTED_SCOPES literal, no-vault output when extraScopes is empty (belt-and-suspenders against URL-encoded `vault:` reappearing), narrow scope appended, dedupe of scopes already in REQUESTED_SCOPES, full PKCE-S256 query-param coverage.
+
+  2. **Regression-pin OAuth `client_name` in the registerClient body (paraclaw#137).** The hub renders this string verbatim on its DCR consent screen — operator-visible UX, not an internal identifier. The 0.1.0 brand sweep (PR #112, commit 2a83e77) renamed it from `Paraclaw web UI` to `Parachute Agent web UI`; this commit adds the wire-level test that pins it. Two new tests on `ensureClient`: first-registration mocks fetch and asserts the POST body carries `client_name: "Parachute Agent web UI"` plus belt assertions on `scope` (= REQUESTED_SCOPES) and `token_endpoint_auth_method` ("none"); cached-path asserts a pre-seeded match returns without calling fetch. Production-code change is a single `export` keyword on `ensureClient` — no behavior change.
+
+  3. **Re-register OAuth client when `redirect_uri` changes (paraclaw#138).** The hub-side DCR row binds each `client_id` to the specific `redirect_uris` it registered with; if the SPA's mount path changes (e.g. an operator flips `PARACHUTE_AGENT_WEB_MOUNT` from `/claw/` to `/agent/` after the 0.1.0 rename), the cached `client_id` keeps coming through `getRedirectUri()` as the new path while the hub still has the old one — `/oauth/authorize` errors out before the consent screen and the operator is stranded. Extend `ClientRecord` to `{ client_id, redirect_uri }`, compare in the `ensureClient` cache check before returning cached, treat any mismatch (or a legacy record with no `redirect_uri` field at all) as a cache miss → re-register fresh under the current path. Records written before this commit lack the field; the legacy-shape branch self-heals on the first 0.1.x bootstrap after upgrade (one extra `/oauth/register` round-trip per operator, then steady-state). 3 new tests cover the matrix: mismatch re-registers + persists the current redirect_uri (so subsequent loads cache-hit), legacy-shape self-heal, first-registration persists both fields. The Commit-2 cached-hit test was tightened to seed both fields under the new contract. Closes paraclaw#136, #137, #138.
+
 ## [0.1.2-rc.13] - 2026-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2-rc.13",
+  "version": "0.1.2-rc.14",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -237,10 +237,14 @@ describe('ensureClient — /oauth/register body', () => {
     expect(body.token_endpoint_auth_method).toBe('none');
   });
 
-  it('does not call fetch when a cached client_id is already in localStorage', async () => {
+  it('reuses the cached client_id when redirect_uri matches the current bootstrap', async () => {
+    // Pre-seed a record whose redirect_uri matches what getRedirectUri()
+    // computes in this test environment (same logic as the prod helper:
+    // origin + BASE_URL + 'oauth/callback'). Cache hit ⇒ no fetch.
+    const expectedRedirect = `${window.location.origin}${import.meta.env.BASE_URL}oauth/callback`;
     localStorage.setItem(
       'parachute-agent.client.http://hub.test',
-      JSON.stringify({ client_id: 'cached-client-id' }),
+      JSON.stringify({ client_id: 'cached-client-id', redirect_uri: expectedRedirect }),
     );
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
@@ -249,5 +253,100 @@ describe('ensureClient — /oauth/register body', () => {
 
     expect(id).toBe('cached-client-id');
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Re-register the OAuth client when the SPA's redirect_uri changes —
+ * paraclaw#138. The hub binds each DCR client_id to the redirect_uri it
+ * was registered with; if the operator changes the SPA's mount path
+ * (e.g. `/claw/` → `/agent/` after the 0.1.0 rename, or any custom
+ * `PARACHUTE_AGENT_WEB_MOUNT` change), the cached client_id stops
+ * matching and `/oauth/authorize` errors out before the consent screen.
+ *
+ * Fix: cache the redirect_uri alongside the client_id and treat any
+ * mismatch (or a legacy record with no redirect_uri at all) as a cache
+ * miss so the SPA registers a fresh client_id under the new path.
+ */
+describe('ensureClient — redirect_uri-aware cache', () => {
+  function mockFetchOk(clientId: string) {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ client_id: clientId }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    return fetchSpy;
+  }
+
+  it('re-registers when the cached redirect_uri does not match the current one', async () => {
+    // Stale cache from before a mount-path change: redirect_uri points
+    // at the old path. Current bootstrap computes a different URI, so
+    // the cached client_id is unusable on the hub.
+    localStorage.setItem(
+      'parachute-agent.client.http://hub.test',
+      JSON.stringify({
+        client_id: 'stale-client-id',
+        redirect_uri: 'http://app.test/claw/oauth/callback',
+      }),
+    );
+    const fetchSpy = mockFetchOk('fresh-client-id');
+
+    const id = await ensureClient('http://hub.test');
+
+    expect(id).toBe('fresh-client-id');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // The cache must now hold the freshly-registered client_id paired
+    // with the *current* redirect_uri, not the stale one — otherwise
+    // the next bootstrap would re-register on every page load.
+    const updated = JSON.parse(
+      localStorage.getItem('parachute-agent.client.http://hub.test') ?? 'null',
+    );
+    expect(updated.client_id).toBe('fresh-client-id');
+    const expectedRedirect = `${window.location.origin}${import.meta.env.BASE_URL}oauth/callback`;
+    expect(updated.redirect_uri).toBe(expectedRedirect);
+  });
+
+  it('re-registers a legacy ClientRecord that lacks a redirect_uri field (self-heals)', async () => {
+    // Records written before paraclaw#138 had only `{ client_id }`. On
+    // the first bootstrap after upgrade we treat the missing-field case
+    // as a cache miss and re-register so subsequent loads have the full
+    // record. This means existing operators see exactly one extra
+    // registration round-trip on first 0.1.x reload.
+    localStorage.setItem(
+      'parachute-agent.client.http://hub.test',
+      JSON.stringify({ client_id: 'legacy-client-id' }),
+    );
+    const fetchSpy = mockFetchOk('healed-client-id');
+
+    const id = await ensureClient('http://hub.test');
+
+    expect(id).toBe('healed-client-id');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const healed = JSON.parse(
+      localStorage.getItem('parachute-agent.client.http://hub.test') ?? 'null',
+    );
+    expect(healed.client_id).toBe('healed-client-id');
+    expect(typeof healed.redirect_uri).toBe('string');
+    expect(healed.redirect_uri.length).toBeGreaterThan(0);
+  });
+
+  it('persists redirect_uri alongside client_id on first registration', async () => {
+    // No prior cache. After first registration, the persisted record
+    // must include both fields — otherwise subsequent bootstraps would
+    // legacy-self-heal on every load and burn a hub /oauth/register
+    // call per page reload.
+    const fetchSpy = mockFetchOk('first-client-id');
+
+    await ensureClient('http://hub.test');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const persisted = JSON.parse(
+      localStorage.getItem('parachute-agent.client.http://hub.test') ?? 'null',
+    );
+    expect(persisted).toMatchObject({
+      client_id: 'first-client-id',
+    });
+    const expectedRedirect = `${window.location.origin}${import.meta.env.BASE_URL}oauth/callback`;
+    expect(persisted.redirect_uri).toBe(expectedRedirect);
   });
 });

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -10,7 +10,12 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildAuthorizeUrl, migrateLegacyAuthKeys, REQUESTED_SCOPES } from './auth.ts';
+import {
+  buildAuthorizeUrl,
+  ensureClient,
+  migrateLegacyAuthKeys,
+  REQUESTED_SCOPES,
+} from './auth.ts';
 
 // jsdom's Storage in this vitest config doesn't reliably expose the full
 // Storage prototype methods (the `--localstorage-file` warning at runtime
@@ -195,5 +200,54 @@ describe('REQUESTED_SCOPES + buildAuthorizeUrl', () => {
     expect(u.searchParams.get('code_challenge')).toBe('challenge-xyz');
     expect(u.searchParams.get('code_challenge_method')).toBe('S256');
     expect(u.searchParams.get('state')).toBe('state-123');
+  });
+});
+
+/**
+ * Regression-pin the OAuth client_name in the `/oauth/register` body —
+ * paraclaw#137. The hub's consent screen renders this string verbatim, so
+ * it's operator-visible UX, not a free-form internal identifier. The
+ * 0.1.0 brand sweep renamed "Paraclaw web UI" → "Parachute Agent web UI"
+ * (commit 2a83e77 / PR #112); this test prevents a future rename or copy
+ * regression from silently shipping a stale brand on the consent screen.
+ *
+ * No production behavior change — the existing string literal at line ~166
+ * is the only thing this test asserts on.
+ */
+describe('ensureClient — /oauth/register body', () => {
+  it('sends client_name "Parachute Agent web UI" on first registration', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ client_id: 'returned-client-id' }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await ensureClient('http://hub.test');
+
+    expect(id).toBe('returned-client-id');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://hub.test/oauth/register');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.client_name).toBe('Parachute Agent web UI');
+    // Belt: also pin scope + auth method so a future copy edit can't ship
+    // a partially-renamed body.
+    expect(body.scope).toBe(REQUESTED_SCOPES);
+    expect(body.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('does not call fetch when a cached client_id is already in localStorage', async () => {
+    localStorage.setItem(
+      'parachute-agent.client.http://hub.test',
+      JSON.stringify({ client_id: 'cached-client-id' }),
+    );
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const id = await ensureClient('http://hub.test');
+
+    expect(id).toBe('cached-client-id');
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -10,7 +10,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { migrateLegacyAuthKeys } from './auth.ts';
+import { buildAuthorizeUrl, migrateLegacyAuthKeys, REQUESTED_SCOPES } from './auth.ts';
 
 // jsdom's Storage in this vitest config doesn't reliably expose the full
 // Storage prototype methods (the `--localstorage-file` warning at runtime
@@ -135,5 +135,65 @@ describe('migrateLegacyAuthKeys', () => {
 
     expect(localStorage.getItem('paraclaw.unrelated')).toBe('keep-me');
     expect(localStorage.getItem('parachute-agent.discovery')).toBe('{"hubOrigin":"http://hub"}');
+  });
+});
+
+/**
+ * Bootstrap-scope narrowing — paraclaw#136. The agent SPA used to request
+ * `vault:read vault:write` at bootstrap, but every vault flow already runs
+ * the paraclaw#56 re-consent pattern (narrow `vault:<name>:admin` via
+ * extraScopes), so the broad bootstrap scopes were dead weight on the
+ * consent screen. These tests pin the post-narrowing surface so a future
+ * edit can't silently re-add vault scopes to the bootstrap grant.
+ */
+describe('REQUESTED_SCOPES + buildAuthorizeUrl', () => {
+  const baseOpts = {
+    hubOrigin: 'http://hub.test',
+    clientId: 'client-abc',
+    redirectUri: 'http://app.test/agent/oauth/callback',
+    challenge: 'challenge-xyz',
+    state: 'state-123',
+  };
+
+  it('REQUESTED_SCOPES is exactly "agent:admin agent:write" — no vault:* at bootstrap', () => {
+    expect(REQUESTED_SCOPES).toBe('agent:admin agent:write');
+    expect(REQUESTED_SCOPES).not.toMatch(/vault:/);
+  });
+
+  it('builds an authorize URL with only agent:* scopes when extraScopes is empty', () => {
+    const u = buildAuthorizeUrl(baseOpts);
+    expect(u.searchParams.get('scope')).toBe('agent:admin agent:write');
+    // Belt-and-suspenders: the URL string itself must not carry any
+    // vault scope, even URL-encoded.
+    expect(u.toString()).not.toMatch(/vault(%3A|:)/);
+  });
+
+  it('appends a narrow vault:<name>:admin scope when passed in extraScopes', () => {
+    const u = buildAuthorizeUrl({ ...baseOpts, extraScopes: ['vault:default:admin'] });
+    const scope = u.searchParams.get('scope') ?? '';
+    expect(scope.split(' ')).toEqual(['agent:admin', 'agent:write', 'vault:default:admin']);
+  });
+
+  it('de-dupes extraScopes that are already in REQUESTED_SCOPES', () => {
+    const u = buildAuthorizeUrl({
+      ...baseOpts,
+      extraScopes: ['agent:admin', 'vault:foo:admin'],
+    });
+    const scope = u.searchParams.get('scope') ?? '';
+    // agent:admin should appear exactly once even though it was passed
+    // again — the consent screen would otherwise show the same scope twice.
+    expect(scope.split(' ').filter((s) => s === 'agent:admin')).toHaveLength(1);
+    expect(scope.split(' ')).toContain('vault:foo:admin');
+  });
+
+  it('writes the standard PKCE-S256 query params alongside the scope', () => {
+    const u = buildAuthorizeUrl(baseOpts);
+    expect(u.origin + u.pathname).toBe('http://hub.test/oauth/authorize');
+    expect(u.searchParams.get('client_id')).toBe('client-abc');
+    expect(u.searchParams.get('redirect_uri')).toBe('http://app.test/agent/oauth/callback');
+    expect(u.searchParams.get('response_type')).toBe('code');
+    expect(u.searchParams.get('code_challenge')).toBe('challenge-xyz');
+    expect(u.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(u.searchParams.get('state')).toBe('state-123');
   });
 });

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -11,13 +11,18 @@
  *   5. POST <hub>/oauth/token         — authorization_code, then refresh_token
  *                                       on 401 from /api/* before re-login.
  *
- * Scopes: `agent:admin agent:write vault:read vault:write`. `agent:admin` is
- * required for /api/secrets writes + the setup wizard install-channel
- * step; `agent:write` is the bar for /api/approvals decisions and
- * /api/sessions/:id/close. The vault scopes anticipate the vault tokens-API
- * REST endpoint (paraclaw#4 companion vault issue); today the server still
- * shells out, but minting the user JWT with vault:* now means no re-consent
- * later.
+ * Bootstrap scopes: `agent:admin agent:write`. `agent:admin` is required
+ * for /api/secrets writes + the setup wizard install-channel step;
+ * `agent:write` is the bar for /api/approvals decisions and
+ * /api/sessions/:id/close. The agent SPA is self-contained — vault is one
+ * per-agent-group action, not the SPA's identity, so vault scopes are
+ * NOT requested at bootstrap. Per-vault flows extend with `extraScopes`
+ * on `beginLogin([\`vault:\${name}:admin\`])` (see line 199-200) — this is
+ * the paraclaw#56 re-consent pattern, request-on-demand. (paraclaw#136)
+ *
+ * Vault listing for pickers reads `/.well-known/parachute.json` (public,
+ * no scope needed); per-vault token-API access enforces `vault:<name>:admin`
+ * on the vault side regardless of what the bootstrap JWT carries.
  *
  * Existing users with cached tokens that lack a newly-required scope will
  * hit 403 with a body like `requires the X scope`. The api.ts wrapper
@@ -46,7 +51,7 @@ interface FlowState {
   hub_origin: string;
 }
 
-const REQUESTED_SCOPES = "agent:admin agent:write vault:read vault:write";
+export const REQUESTED_SCOPES = "agent:admin agent:write";
 const DISCOVERY_KEY = "parachute-agent.discovery";
 const FLOW_KEY = "parachute-agent.flow";
 
@@ -217,23 +222,51 @@ export async function beginLogin(extraScopes: string[] = []): Promise<never> {
     hub_origin: hubOrigin,
   };
   writeJson(sessionStorage, FLOW_KEY, flow);
-  const scopes = new Set(REQUESTED_SCOPES.split(/\s+/).filter(Boolean));
-  for (const s of extraScopes) {
-    const trimmed = s.trim();
-    if (trimmed) scopes.add(trimmed);
-  }
-  const u = new URL(`${hubOrigin}/oauth/authorize`);
-  u.searchParams.set("client_id", clientId);
-  u.searchParams.set("redirect_uri", redirectUri);
-  u.searchParams.set("response_type", "code");
-  u.searchParams.set("scope", Array.from(scopes).join(" "));
-  u.searchParams.set("code_challenge", challenge);
-  u.searchParams.set("code_challenge_method", "S256");
-  u.searchParams.set("state", state);
+  const u = buildAuthorizeUrl({
+    hubOrigin,
+    clientId,
+    redirectUri,
+    challenge,
+    state,
+    extraScopes,
+  });
   window.location.replace(u.toString());
   // Block until navigation actually happens — callers expect this never
   // returns control.
   return new Promise<never>(() => {});
+}
+
+/**
+ * Build the `/oauth/authorize` URL. Pure — no side effects, no storage
+ * reads, no network. Exported so tests can pin the scope string and the
+ * extraScopes append behavior without mocking `window.location.replace`.
+ *
+ * `extraScopes` are appended after `REQUESTED_SCOPES` and de-duped, so a
+ * caller passing a scope already in REQUESTED_SCOPES doesn't double it on
+ * the consent screen.
+ */
+export function buildAuthorizeUrl(opts: {
+  hubOrigin: string;
+  clientId: string;
+  redirectUri: string;
+  challenge: string;
+  state: string;
+  extraScopes?: string[];
+}): URL {
+  const scopes = new Set(REQUESTED_SCOPES.split(/\s+/).filter(Boolean));
+  for (const s of opts.extraScopes ?? []) {
+    const trimmed = s.trim();
+    if (trimmed) scopes.add(trimmed);
+  }
+  const u = new URL(`${opts.hubOrigin}/oauth/authorize`);
+  u.searchParams.set("client_id", opts.clientId);
+  u.searchParams.set("redirect_uri", opts.redirectUri);
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", Array.from(scopes).join(" "));
+  u.searchParams.set("code_challenge", opts.challenge);
+  u.searchParams.set("code_challenge_method", "S256");
+  u.searchParams.set("state", opts.state);
+  return u;
 }
 
 /**

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -36,6 +36,17 @@ interface DiscoveryResponse {
 
 interface ClientRecord {
   client_id: string;
+  /**
+   * The redirect_uri the client_id was registered with. Hub-side, the
+   * DCR row is bound to the original redirect_uri — sending an authorize
+   * request with a different redirect_uri (e.g. after a mount-path
+   * change like `/claw/` → `/agent/`) fails the hub's redirect_uri
+   * check and the operator sees a hub error instead of the consent
+   * screen. Stash this alongside the client_id so bootstrap can detect
+   * the mismatch and re-register a fresh client_id with the new path.
+   * (paraclaw#138)
+   */
+  redirect_uri: string;
 }
 
 interface TokenSet {
@@ -154,9 +165,19 @@ async function getDiscovery(): Promise<DiscoveryResponse> {
 }
 
 export async function ensureClient(hubOrigin: string): Promise<string> {
-  const cached = readJson<ClientRecord>(localStorage, clientKey(hubOrigin));
-  if (cached?.client_id) return cached.client_id;
   const redirectUri = getRedirectUri();
+  const cached = readJson<ClientRecord>(localStorage, clientKey(hubOrigin));
+  // Cache hit only if BOTH client_id is present AND the cached
+  // redirect_uri matches the current bootstrap's redirect_uri. A mismatch
+  // means the SPA's mount path changed (e.g. `/claw/` → `/agent/`) and
+  // the hub-side DCR row is bound to the old redirect_uri — re-using the
+  // stale client_id would fail the hub's redirect_uri check on
+  // /oauth/authorize. Treat as cache-miss → re-register a fresh client.
+  // Records written before this guard landed lack `redirect_uri`; treat
+  // those as miss so the migration self-heals. (paraclaw#138)
+  if (cached?.client_id && cached.redirect_uri === redirectUri) {
+    return cached.client_id;
+  }
   const res = await fetch(`${hubOrigin}/oauth/register`, {
     method: "POST",
     headers: { "content-type": "application/json", accept: "application/json" },
@@ -171,7 +192,10 @@ export async function ensureClient(hubOrigin: string): Promise<string> {
     throw new Error(`hub /oauth/register failed: ${res.status} ${await res.text()}`);
   }
   const body = (await res.json()) as { client_id: string };
-  writeJson(localStorage, clientKey(hubOrigin), { client_id: body.client_id });
+  writeJson(localStorage, clientKey(hubOrigin), {
+    client_id: body.client_id,
+    redirect_uri: redirectUri,
+  });
   return body.client_id;
 }
 

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -153,7 +153,7 @@ async function getDiscovery(): Promise<DiscoveryResponse> {
   return fresh;
 }
 
-async function ensureClient(hubOrigin: string): Promise<string> {
+export async function ensureClient(hubOrigin: string): Promise<string> {
   const cached = readJson<ClientRecord>(localStorage, clientKey(hubOrigin));
   if (cached?.client_id) return cached.client_id;
   const redirectUri = getRedirectUri();


### PR DESCRIPTION
## Summary

Bundled audit of `web/ui/src/lib/auth.ts` — three independent issues that share the same file and the same hub-side OAuth surface, fixed as one PR with one per-issue commit each (no merge-shape benefit to splitting).

- **Commit 1 — `feat(spa): narrow REQUESTED_SCOPES — drop vault:* from bootstrap` (paraclaw#136).** Drops `vault:read vault:write` from the bootstrap scope grant. Every vault flow already uses the paraclaw#56 narrow per-vault re-consent pattern (`vault:<name>:admin` via `extraScopes`), so the broad bootstrap scopes were dead weight on the consent screen. Refactors `beginLogin`'s URL construction into a pure exported `buildAuthorizeUrl(opts)` helper and exports `REQUESTED_SCOPES` so tests can pin both. **5 new tests.**

- **Commit 2 — `test(spa): regression-pin OAuth client_name in registerClient body` (paraclaw#137).** Pins `"Parachute Agent web UI"` at the wire level with two `ensureClient` tests (first-registration body assertion + cached-path fetch-not-called assertion). Production change is a single `export` keyword — no behavior change. The 0.1.0 brand sweep (PR #112) already renamed it from `"Paraclaw web UI"`; this commit makes a future copy regression catchable. **2 new tests.**

- **Commit 3 — `fix(spa): re-register OAuth client when redirect_uri changes` (paraclaw#138).** The hub binds each DCR `client_id` to the redirect_uri it registered with. If the SPA's mount path changes (operator flips `PARACHUTE_AGENT_WEB_MOUNT` from `/claw/` → `/agent/` after the 0.1.0 rename, or any custom remount), the cached client_id stops matching and `/oauth/authorize` errors out before the consent screen — operator stranded on a hub error page. Extends `ClientRecord` to `{ client_id, redirect_uri }`, compares in `ensureClient`, treats mismatch (or legacy missing-field record) as cache miss → re-register. Legacy records self-heal on first 0.1.x reload. **3 new tests, plus tightening of the Commit-2 cached-hit test under the new contract.**

CHANGELOG covers all three under one rc.14 entry. Bumps `0.1.2-rc.13` → `0.1.2-rc.14`.

## Why bundled, not split

All three fixes touch the same file (`web/ui/src/lib/auth.ts`) and the same module surface — sequential commits avoid cascade conflicts on the shared file and let one rc.14 carry the full fix surface to operators. Each commit is independently buildable + tested; reviewer can read them as three separate diffs.

## Architectural rationale (Fix 1)

The agent SPA is self-contained: vault is **one per-agent-group action**, not the SPA's identity. Per-vault flows in VaultDetail.tsx, GroupDetail.tsx, and NewGroupWizard.tsx all already invoke `beginLogin([\`vault:\${name}:admin\`])` (or pass `authExtraScopes` through `api.ts`) when the operator's existing JWT doesn't carry the narrow vault scope. Bootstrap-time `vault:read vault:write` were never used by any code path — they only widened the consent-screen story for no UX benefit.

## Test plan

- [x] SPA `pnpm test` (in `web/ui/`): **65/65** passing (was 55/55 baseline). 10 new tests across the three commits.
- [x] SPA `pnpm exec tsc --noEmit`: clean.
- [x] Host `pnpm typecheck` (from repo root): clean.
- [x] No production behavior change in Commit 2 (single `export` keyword).
- [ ] **Live install validation (for Aaron after merge):** behavioral test on the live install — sign in, confirm no `vault:*` in the consent screen, confirm consent screen shows "Parachute Agent web UI". For Fix 3: pre-this-PR operators (existing 0.1.x) reload once and OAuth still works (legacy-shape self-heal); a new mount-path change (e.g. swap `PARACHUTE_AGENT_WEB_MOUNT`) successfully re-registers and proceeds to consent rather than erroring.

## Issues

- Closes paraclaw#136
- Closes paraclaw#137
- Closes paraclaw#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)