### PR TITLE
feat(skills): scribe container skill (REST-as-tool with SCRIBE_TOKEN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.3-rc.1] - 2026-05-06
+
+### Added
+
+- **Container skill: `scribe` (paraclaw#142).** Doc-only skill at `container/skills/scribe/SKILL.md` that teaches the in-container agent how to call parachute-scribe over its REST API using `curl` and a pre-injected `SCRIBE_TOKEN`. Operator mints a hub-issued JWT (or shared-secret token) carrying `scribe:transcribe`, drops it into `/agent/secrets`, and the secret store injects it as an env var at session spawn. Documents the real scribe API surface — `POST /v1/audio/transcriptions` (multipart `file` + optional `cleanup` / `context`), `GET /v1/models`, `GET /health`, `GET /.parachute/info` — verified against `parachute-scribe/src/`. No async-job polling (scribe is synchronous), no `language` form field, no URL ingest. Skills auto-mount via `container-runner.ts:syncSkillSymlinks` when `skills === 'all'` (the default), so adding the directory is the entire ship on the skill side. Architectural reframe parking paraclaw#100 (per-agent-group scribe-MCP attach): for 3–4 leaf operations over HTTP with a Whisper-shape response, skill+secret+REST is lighter than building an MCP server. Pairs with parachute-hub's parallel `parachute auth mint-token` work — operators get a CLI path to mint the JWT.
+
+### Fixed
+
+- **Inject `PARACHUTE_HUB_ORIGIN` into every spawned container with loopback rewritten to `host.docker.internal` (paraclaw#142 review fold).** Pre-fix, `PARACHUTE_HUB_ORIGIN` was read on the host but never pushed into containers via `buildContainerArgs`, so any skill (or future module) that tried `curl ${PARACHUTE_HUB_ORIGIN}/...` from inside the container hit `undefined` or — worse — silently used a hardcoded `http://127.0.0.1:1939` fallback that resolves to the container's own loopback, not the host. New helper `getHubOriginForContainer()` composes `getHubOrigin()` (the host's resolution chain) with `localhostToContainerHost()` (already shipped for MCP URLs in `vault-mcp.ts`) so loopback origins get rewritten to `host.docker.internal`, and tailnet/LAN origins pass through unchanged. The rewrite mirrors the path already in place for HTTP-MCP URLs in `container.json` — same loopback-to-host-gateway problem, same solution. Without this, the new scribe skill (and any future skill that reaches a Parachute service via the hub-aggregated mount) would fail silently on every install that doesn't set `SCRIBE_URL` explicitly. 5 new tests in `src/container-runner.test.ts` cover loopback rewrite, localhost rewrite, tailnet pass-through, default fallback (no env set), override-via-`PARACHUTE_AGENT_HUB_ORIGIN`, and trailing-slash hygiene.
+
 ## [0.1.2] - 2026-05-05
 
 The first patch series after the 0.1.0 paraclaw → parachute-agent rename. Fourteen iterative cuts (rc.1 through rc.14) collapsed into one stable. No operator action required: every change is either a transparent fix, an additive UI affordance, or a behind-the-scenes test addition.

--- a/container/skills/scribe/SKILL.md
+++ b/container/skills/scribe/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: scribe
+description: Transcribe audio to text using parachute-scribe. Use whenever the user shares an audio file (voice memo, meeting recording, podcast clip, .mp3/.m4a/.wav/.flac) or asks for speech-to-text. Calls scribe's HTTP API via curl using a pre-injected SCRIBE_TOKEN.
+allowed-tools: Bash(curl:*)
+---
+
+# Scribe — Audio Transcription via REST
+
+Scribe is a Parachute service that exposes a Whisper-compatible HTTP API. You call it directly with `curl` — no MCP server, no SDK. The operator pre-injects a `SCRIBE_TOKEN` environment variable so you authenticate without ever seeing the token's value.
+
+## When to use
+
+- The user uploads or links an audio file (`.mp3`, `.m4a`, `.wav`, `.flac`, `.ogg`, etc.) and wants the contents.
+- The user asks "what's said in this recording?", "transcribe this voice memo", "summarize this podcast" — any request that requires understanding spoken audio.
+- Even when not asked explicitly: if a downstream step (search, summary, translation) needs the text and only audio is available, transcribe first.
+
+## Prerequisites
+
+`SCRIBE_TOKEN` must be set in your environment — a hub-issued JWT (or shared-secret token) carrying the `scribe:transcribe` scope.
+
+```bash
+[ -n "${SCRIBE_TOKEN}" ] && echo "ready" || echo "missing"
+```
+
+If missing: tell the user that scribe isn't available, and add: *"Operator: add SCRIBE_TOKEN via /agent/secrets, or run `parachute auth mint-token scribe:transcribe` and paste the result as a new secret."* Don't try to mint or rotate the token yourself — you have no path to.
+
+## Endpoint
+
+`SCRIBE_URL` if set, otherwise compute from `PARACHUTE_HUB_ORIGIN` (the host injects this into every container — the loopback case is rewritten to `host.docker.internal` so it's always reachable from inside Docker, see paraclaw#142):
+
+```bash
+SCRIBE_URL="${SCRIBE_URL:-${PARACHUTE_HUB_ORIGIN}/scribe}"
+```
+
+Verify reachability before the first transcribe of a session:
+
+```bash
+curl -fsS "${SCRIBE_URL}/health"
+# → {"ok":true}
+```
+
+## Operations
+
+### 1. Transcribe a local audio file
+
+```bash
+curl -fsS -X POST "${SCRIBE_URL}/v1/audio/transcriptions" \
+  -H "Authorization: Bearer ${SCRIBE_TOKEN}" \
+  -F "file=@/workspace/agent/voice-memo.m4a"
+```
+
+Response shape (synchronous — scribe blocks until done, no job polling):
+
+```json
+{ "text": "Hey, just wanted to record a quick thought about the project..." }
+```
+
+### 2. Transcribe with cleanup off (raw output)
+
+By default scribe runs an LLM cleanup pass — punctuation, filler-word removal, capitalization. Pass `cleanup=false` to get the raw transcript:
+
+```bash
+curl -fsS -X POST "${SCRIBE_URL}/v1/audio/transcriptions" \
+  -H "Authorization: Bearer ${SCRIBE_TOKEN}" \
+  -F "file=@/workspace/agent/recording.wav" \
+  -F "cleanup=false"
+```
+
+Use raw mode when:
+- You want the original disfluencies preserved (linguistic analysis, accessibility transcript).
+- The user explicitly asks for "verbatim" or "as-spoken".
+
+### 3. Transcribe with proper-noun context
+
+Cleanup uses an LLM that doesn't know your domain. To fix proper-noun spelling (people, products, jargon), pass a `context` JSON payload:
+
+```bash
+curl -fsS -X POST "${SCRIBE_URL}/v1/audio/transcriptions" \
+  -H "Authorization: Bearer ${SCRIBE_TOKEN}" \
+  -F "file=@/workspace/agent/standup.m4a" \
+  -F 'context={"entries":[
+    {"name":"Margaret","aliases":["Marg","Maggie"]},
+    {"name":"Learn Vibe Build","aliases":["LVB"]},
+    {"name":"parachute-agent"}
+  ]}'
+```
+
+Each entry needs `name` (canonical spelling); `aliases` and any other free-form fields (`summary`, role hints) help the cleanup LLM disambiguate. Pull entries from your group memory (`CLAUDE.local.md`, contact files, project files) before transcribing meetings or anything name-heavy — that's where the value compounds.
+
+### 4. List configured models
+
+```bash
+curl -fsS "${SCRIBE_URL}/v1/models" \
+  -H "Authorization: Bearer ${SCRIBE_TOKEN}"
+```
+
+Most installs run a single transcription model — you don't pass `model` in the transcribe request; scribe routes to whatever the operator configured.
+
+## Failure modes
+
+| Status | Meaning | What to tell the user |
+|--------|---------|------------------------|
+| **400** `missing 'file' field` | Multipart form-data missing the `file` part | Internal — fix the curl invocation |
+| **401** `unauthorized` | Token missing, expired, or rejected | *"Scribe rejected my token. Operator: rotate `SCRIBE_TOKEN` in `/agent/secrets`."* |
+| **403** `insufficient_scope` | Token valid but lacks `scribe:transcribe` | *"My scribe token doesn't have transcribe access. Operator: re-mint with `scribe:transcribe` scope."* |
+| **404** | Wrong URL or scribe daemon not running | *"Scribe isn't reachable at ${SCRIBE_URL}. Operator: `parachute start scribe` (or check the install)."* |
+| **500** | Transcription provider error (model crashed, audio unreadable) | *"Scribe couldn't process this audio — the file may be corrupt or in an unsupported format. Try re-encoding to mp3 or wav."* |
+| Connection refused | Daemon down or wrong port | Same as 404 |
+
+When you hit 401 / 403 / 404 once, **stop retrying** — these are operator-action failures, not transient. Surface the situation to the user once, clearly, and move on. Don't burn turns on hopeless retries.
+
+## What scribe does NOT do
+
+- **No async jobs.** Every call blocks until done; there's no `job_id` and no `/jobs/:id` endpoint. If a file is large enough that you're worried about timeouts, warn the user before starting.
+- **No URL ingest.** Scribe takes the file bytes via multipart only. If the audio is at a URL, download to `/workspace/agent/` first (use existing tools — `curl`, `agent-browser`), then transcribe the local file.
+- **No language hint.** The current API has no `language` form field; the model auto-detects.
+- **No streaming response.** You get the full transcript in one JSON body when scribe is done.
+
+## Tone for results
+
+When you return the transcript:
+- Lead with the content the user asked for — not "I successfully transcribed your audio."
+- Quote the transcript directly when it's short; summarize first + offer the full text when it's long.
+- Save useful one-time transcripts under `/workspace/agent/transcripts/<date>-<slug>.md` so future sessions can search them. Add a one-line index entry to `CLAUDE.local.md` if it's reference-grade.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.2",
+  "version": "0.1.3-rc.1",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { resolveProviderName } from './container-runner.js';
+import { getHubOriginForContainer, resolveProviderName } from './container-runner.js';
 
 describe('resolveProviderName', () => {
   it('prefers session over group and container.json', () => {
@@ -28,5 +28,71 @@ describe('resolveProviderName', () => {
   it('treats empty string as unset (falls through)', () => {
     expect(resolveProviderName('', 'codex', null)).toBe('codex');
     expect(resolveProviderName(null, '', 'opencode')).toBe('opencode');
+  });
+});
+
+describe('getHubOriginForContainer', () => {
+  // The host injects PARACHUTE_HUB_ORIGIN into every container as a
+  // *rewritten* form: getHubOrigin() composed with localhostToContainerHost
+  // so loopback origins resolve via the host gateway from inside Docker.
+  // Surfaced by paraclaw#142 review (#143) — pre-fix, skills doing
+  // `curl ${PARACHUTE_HUB_ORIGIN}/...` from inside a container hit the
+  // container's own loopback when the hub was local. Tailnet/LAN origins
+  // already container-reachable so they pass through unchanged.
+  let prevAgent: string | undefined;
+  let prevParaclaw: string | undefined;
+  let prevParachute: string | undefined;
+
+  beforeEach(() => {
+    prevAgent = process.env.PARACHUTE_AGENT_HUB_ORIGIN;
+    prevParaclaw = process.env.PARACLAW_HUB_ORIGIN;
+    prevParachute = process.env.PARACHUTE_HUB_ORIGIN;
+    delete process.env.PARACHUTE_AGENT_HUB_ORIGIN;
+    delete process.env.PARACLAW_HUB_ORIGIN;
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+  });
+
+  afterEach(() => {
+    if (prevAgent === undefined) delete process.env.PARACHUTE_AGENT_HUB_ORIGIN;
+    else process.env.PARACHUTE_AGENT_HUB_ORIGIN = prevAgent;
+    if (prevParaclaw === undefined) delete process.env.PARACLAW_HUB_ORIGIN;
+    else process.env.PARACLAW_HUB_ORIGIN = prevParaclaw;
+    if (prevParachute === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+    else process.env.PARACHUTE_HUB_ORIGIN = prevParachute;
+  });
+
+  it('rewrites loopback PARACHUTE_HUB_ORIGIN to host.docker.internal', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'http://127.0.0.1:1939';
+    expect(getHubOriginForContainer()).toBe('http://host.docker.internal:1939');
+  });
+
+  it('rewrites localhost PARACHUTE_HUB_ORIGIN to host.docker.internal', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'http://localhost:1939';
+    expect(getHubOriginForContainer()).toBe('http://host.docker.internal:1939');
+  });
+
+  it('passes tailnet origins through unchanged (already container-reachable)', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.taildf9ce2.ts.net';
+    expect(getHubOriginForContainer()).toBe('https://parachute.taildf9ce2.ts.net');
+  });
+
+  it('falls back to rewritten loopback default when no env is set', () => {
+    // getHubOrigin defaults to http://127.0.0.1:1939; the rewrite must
+    // catch the default too, otherwise containers in a stock dev install
+    // (no PARACHUTE_HUB_ORIGIN set by hub lifecycle) get an unreachable URL.
+    expect(getHubOriginForContainer()).toBe('http://host.docker.internal:1939');
+  });
+
+  it('respects PARACHUTE_AGENT_HUB_ORIGIN override and rewrites if loopback', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'https://parachute.taildf9ce2.ts.net';
+    process.env.PARACHUTE_AGENT_HUB_ORIGIN = 'http://localhost:9999';
+    expect(getHubOriginForContainer()).toBe('http://host.docker.internal:9999');
+  });
+
+  it('strips trailing slash from explicit env (avoids double slash in `${origin}/path`)', () => {
+    process.env.PARACHUTE_HUB_ORIGIN = 'http://127.0.0.1:1939/';
+    const origin = getHubOriginForContainer();
+    expect(origin.endsWith('/')).toBe(false);
+    expect(origin).toBe('http://host.docker.internal:1939');
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,7 +17,8 @@ import {
 } from './config.js';
 import { readContainerConfig, writeContainerConfig } from './container-config.js';
 import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContainer } from './container-runtime.js';
-import { rewriteMcpUrlsForContainer } from './parachute/vault-mcp.js';
+import { localhostToContainerHost, rewriteMcpUrlsForContainer } from './parachute/vault-mcp.js';
+import { getHubOrigin } from './web/auth.js';
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
@@ -436,6 +437,28 @@ function ensureRuntimeFields(
   }
 }
 
+/**
+ * The hub origin a container should use to reach the hub. Composes
+ * `getHubOrigin()` (the host's resolution chain) with
+ * `localhostToContainerHost()` so loopback addresses (`127.0.0.1`,
+ * `localhost`) get rewritten to `host.docker.internal` — which Docker
+ * Desktop / OrbStack expose natively, and which paraclaw maps via
+ * `--add-host=host.docker.internal:host-gateway` on Linux. Tailnet and
+ * LAN origins pass through unchanged. The host's own env var is left
+ * intact; this is purely for what we inject into the container.
+ *
+ * Without this rewrite, a skill that does
+ * `curl ${PARACHUTE_HUB_ORIGIN}/scribe/...` from inside the container
+ * hits the container's own loopback when the hub is local — no service
+ * there, silent fail. Surfaced by paraclaw#142 review (#143).
+ */
+export function getHubOriginForContainer(): string {
+  // URL.toString() normalizes loopback rewrites with a trailing slash; strip
+  // it so callers can safely concat `${PARACHUTE_HUB_ORIGIN}/scribe` etc.
+  // without doubling.
+  return localhostToContainerHost(getHubOrigin()).replace(/\/$/, '');
+}
+
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
@@ -450,6 +473,13 @@ async function buildContainerArgs(
   // Environment — only vars read by code we don't own.
   // Everything host-specific is in container.json (read by runner at startup).
   args.push('-e', `TZ=${TIMEZONE}`);
+
+  // Hub origin (rewritten so loopback resolves to the host gateway from
+  // inside the container). Skills that reach Parachute services via the
+  // hub-aggregated mount (e.g. `${PARACHUTE_HUB_ORIGIN}/scribe`) need
+  // this. Pre-paraclaw#142, the var was never injected — every skill
+  // that depended on it silently failed.
+  args.push('-e', `PARACHUTE_HUB_ORIGIN=${getHubOriginForContainer()}`);
 
   // Provider-contributed env vars (e.g. XDG_DATA_HOME, OPENCODE_*, NO_PROXY).
   if (providerContribution.env) {


### PR DESCRIPTION
## Summary

**Fold + scope expansion after reviewer feedback.** Originally a doc-only skill PR. Reviewer found a critical hole — `PARACHUTE_HUB_ORIGIN` is never injected into containers today, and the skill's URL-fallback chain `(${SCRIBE_URL:-${PARACHUTE_HUB_ORIGIN}/scribe})` would silently fail on every install that didn't set `SCRIBE_URL` explicitly: container's `127.0.0.1:1939` is the container itself, not the host. Folded the host-side fix into this PR.

Now ships:
1. **`feat(container-runner)`** — inject rewritten `PARACHUTE_HUB_ORIGIN` into every spawned container, with loopback rewrite to `host.docker.internal` mirroring the existing HTTP-MCP rewrite path
2. **`feat(skills)`** — the original scribe skill, now able to rely on `${PARACHUTE_HUB_ORIGIN}/scribe` resolving correctly from inside the container

Closes paraclaw#142.

## Why the host-code expansion is justified

The gap is real and load-bearing for any future skill / module that needs to reach the hub from inside a container. Scribe is just the first to surface it — the same crash is waiting for any skill that calls a hub-aggregated service. Better to ship the infrastructure fix once than to layer skill-by-skill workarounds.

## What landed (host code — commit 1: `0b5726b`)

In `src/container-runner.ts`:

- New exported helper `getHubOriginForContainer()` composes `getHubOrigin()` (the host's existing resolution chain — `PARACHUTE_AGENT_HUB_ORIGIN` → `PARACHUTE_HUB_ORIGIN` → loopback default) with the existing `localhostToContainerHost()` rewrite from `vault-mcp.ts`. Loopback origins (`127.0.0.1`, `localhost`, `0.0.0.0`, `::1`) get rewritten to `host.docker.internal`; tailnet and LAN origins pass through unchanged.
- `buildContainerArgs` now pushes `-e PARACHUTE_HUB_ORIGIN=<rewritten>` alongside the existing `TZ` env var.
- Trailing slash stripped post-rewrite so callers can safely concat `${PARACHUTE_HUB_ORIGIN}/scribe` without doubling.

The rewrite mirrors the path already in place for HTTP-MCP URLs in `container.json` — same loopback-to-host-gateway problem, same solution. Reused the existing `localhostToContainerHost` helper rather than duplicating the loopback-set definition.

### Tests (6 new in `src/container-runner.test.ts`)

- Loopback `127.0.0.1` → `host.docker.internal`
- Loopback `localhost` → `host.docker.internal`
- Tailnet origin (`https://parachute.taildf9ce2.ts.net`) passes through unchanged
- Default fallback path (no env set) — getHubOrigin returns loopback, must still rewrite
- `PARACHUTE_AGENT_HUB_ORIGIN` override (test seam) wins, rewrites if loopback
- Trailing slash hygiene (env value with trailing `/` produces clean output)

Env-stash/restore mirrors the pattern in `src/web/auth.test.ts:184` so test isolation is solid.

### Default-fallback decision

Per the team-lead's question: when `PARACHUTE_HUB_ORIGIN` is unset, `getHubOrigin()` already defaults to `http://127.0.0.1:1939` (`DEFAULT_HUB_LOOPBACK` in `auth.ts:35`). The wrapper rewrites that default to `http://host.docker.internal:1939`, so a stock dev install (hub not supervising the agent — direct `pnpm dev`) gets a container env value that's **at least as reachable** as what the host would itself try. If the hub isn't running at all, the call fails for the right reason (connection refused) rather than silent loopback divergence.

I opted not to add a separate `discoverHubOriginFromServicesJson` fallback path — the host's own resolution chain doesn't read services.json (deliberate choice in `auth.ts:13` — "the hub is the dispatcher, not a registered service"), and reaching past that for a container default would be inconsistent. If the hub lifecycle isn't stamping `PARACHUTE_HUB_ORIGIN`, the right fix is upstream in hub, not a workaround here.

## What landed (skill — commit 2: `ca3af69`)

`container/skills/scribe/SKILL.md` (one new file, doc-only):

- Frontmatter `name`, `description`, `allowed-tools: Bash(curl:*)`
- When-to-use, prerequisites with the exact operator-action message if `SCRIBE_TOKEN` is missing
- Endpoint discovery via `SCRIBE_URL` / `PARACHUTE_HUB_ORIGIN` (now reliable post-fold)
- 4 operations: transcribe local file (default), transcribe with `cleanup=false` for raw output, transcribe with proper-noun `context` JSON, list models
- Failure-modes table (401 / 403 / 404 / 500) with operator-action messaging + stop-retrying-after-one-hit rule
- Explicit non-features section (no async jobs, no URL ingest, no `language` field, no streaming)
- Cosmetic nit folded: `/health` comment fixed from `# → ok` to `# → {"ok":true}` (verified against `parachute-scribe/src/server.ts:90` — `Response.json({ ok: true })`)

`package.json` 0.1.2 → 0.1.3-rc.1 + CHANGELOG entry covering both **Added** (skill) and **Fixed** (host injection).

## Why no skill-mount test

Skills auto-mount via `src/container-runner.ts:syncSkillSymlinks` when `skills === 'all'` (the default) — it reads `container/skills/` at spawn and symlinks each subdirectory. Adding a new directory is the entire ship on the skill side. No host-side test exercises the auto-discovery path today (verified `grep -r "container/skills" src/` returns nothing in test files). Reviewer flagged this as a non-blocking optional follow-up; deferred.

## Reviewer's two non-blocking observations

- Skill frontmatter uses `allowed-tools: Bash(curl:*)` consistent with `agent-browser`. Agent runner doesn't parse this today — it's advisory. Leaving as-is for forward-compat.
- No skill-mount regression test for `syncSkillSymlinks`. Adding scribe exercises the `skills === 'all'` branch indirectly via real-spawn smoke. Optional follow-up if anyone wants to harden.

## Gates

- `pnpm typecheck` — clean
- `pnpm test` (host vitest) — **617/617 green** (was 611, +6 new tests in `container-runner.test.ts`)

## Architectural reframe (why skill + REST over MCP)

Original framing held: parks paraclaw#100 (per-agent-group scribe-MCP attach). For scribe's 3–4 leaf operations over HTTP with a Whisper-shape response, skill+secret+REST is lighter than building an MCP server. Pairs with parachute-hub's parallel `parachute auth mint-token` work — operators get a CLI path to mint the JWT. Revisit MCP if scribe later grows a richer tool surface (resources, prompts, structured tool calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)