### PR TITLE
feat(spa): include credentials on /oauth/register so hub session cookie auto-approves DCR (closes #140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.3-rc.2] - 2026-05-08
+
+### Fixed
+
+- **SPA `/oauth/register` sends `credentials: 'include'` so the hub session cookie can auto-approve DCR (parachute-agent#140).** The agent SPA's `ensureClient` posts to `<hub>/oauth/register` from a different origin than the hub (the SPA's container-deployed origin vs the operator's hub origin), and `fetch` defaults to omitting cookies cross-origin. Without the cookie, the hub-side auto-approve path (parachute-hub#199, the companion change) can't recognize the signed-in operator and DCR falls through to the "App not yet approved" interstitial — the failure shape Aaron hit on 2026-05-08 when clicking a Notes link (paraclaw#138 cache-staleness was the underlying trigger). One-line opt-in on the SPA side: add `credentials: 'include'` to the registration fetch. No-op until hub#199 ships; harmless when it does. Sibling fix on the Notes SPA at parachute-notes#106. New unit test pins the field so a future edit can't silently regress it.
+
 ## [0.1.3-rc.1] - 2026-05-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.3-rc.1",
+  "version": "0.1.3-rc.2",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -237,6 +237,30 @@ describe('ensureClient — /oauth/register body', () => {
     expect(body.token_endpoint_auth_method).toBe('none');
   });
 
+  /**
+   * `credentials: 'include'` is load-bearing for the hub-side auto-approve
+   * path (parachute-hub#199). Without it, the browser omits the
+   * `parachute_hub_session` cookie on the cross-origin POST (SPA's
+   * container-deployed origin vs operator's hub origin), the hub can't
+   * recognize the signed-in operator, and DCR falls through to the
+   * "App not yet approved" interstitial — the failure mode Aaron hit on
+   * 2026-05-08. Pin the field so a future edit can't silently regress.
+   * (parachute-agent#140)
+   */
+  it("sends credentials: 'include' so the hub session cookie travels with DCR", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ client_id: 'returned-client-id' }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await ensureClient('http://hub.test');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.credentials).toBe('include');
+  });
+
   it('reuses the cached client_id when redirect_uri matches the current bootstrap', async () => {
     // Pre-seed a record whose redirect_uri matches what getRedirectUri()
     // computes in this test environment (same logic as the prod helper:

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -181,6 +181,12 @@ export async function ensureClient(hubOrigin: string): Promise<string> {
   const res = await fetch(`${hubOrigin}/oauth/register`, {
     method: "POST",
     headers: { "content-type": "application/json", accept: "application/json" },
+    // Send the `parachute_hub_session` cookie so the hub can auto-approve
+    // DCR for an already-signed-in operator (parachute-hub#199). Cross-origin
+    // by default omits cookies — the SPA's container-deployed origin differs
+    // from the operator's hub origin, so this opt-in is required. No-op until
+    // hub#199 ships; harmless when it does. (parachute-agent#140)
+    credentials: "include",
     body: JSON.stringify({
       redirect_uris: [redirectUri],
       scope: REQUESTED_SCOPES,


### PR DESCRIPTION
## Summary

- `web/ui/src/lib/auth.ts:ensureClient` now sends `credentials: 'include'` on the cross-origin POST to `<hub>/oauth/register`. Without it, the browser omits the `parachute_hub_session` cookie (cross-origin default), the hub can't recognize the signed-in operator, and DCR falls through to the "App not yet approved" interstitial — the failure shape Aaron hit on 2026-05-08 when clicking a Notes link (paraclaw#138 cache-staleness was the underlying trigger).
- New unit test pins `init.credentials === 'include'` so a future edit can't silently regress it.
- Version bump `0.1.3-rc.1 → 0.1.3-rc.2` + CHANGELOG entry.

## Companions

- **parachute-hub#199** — hub-side auto-approve via session cookie (the actual auto-approve logic). This SPA change is a **no-op until hub#199 ships**, and harmless when it does.
- **parachute-notes#106** — same one-line shape on the Notes SPA's `ensureClient` (sibling tentacle).

## Why now

Aaron clicked a Notes link on 2026-05-08 and hit "App not yet approved" — the consent screen for an unrecognized DCR client. The proximate trigger was paraclaw#138's redirect_uri-cache-staleness path forcing a re-registration; the root cause is that DCR has no path to auto-approve for an operator who is *already signed into the hub*. The hub-side fix (parachute-hub#199) reads `parachute_hub_session` and, when present, marks the new DCR row as auto-approved so the consent screen never shows. The browser only sends that cookie if the SPA opts in — hence this one-liner.

## Diff shape

```diff
   const res = await fetch(`${hubOrigin}/oauth/register`, {
     method: "POST",
     headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "include",
     body: JSON.stringify({ ... }),
   });
```

`grep -rn 'oauth/register' web/ src/` confirms `ensureClient` is the only registration call site in the repo, so no other DCR fetches need the same opt-in.

## Test plan

- [x] `pnpm exec vitest run src/lib/auth.test.ts` — 18/18 pass (was 17 + new positive assertion for `credentials: 'include'`).
- [x] Full UI suite: 66/66 pass.
- [x] `pnpm exec tsc --noEmit` clean in `web/ui/`.
- [ ] End-to-end: verified once parachute-hub#199 lands and the hub session cookie travels with the registration POST in DevTools.