### PR TITLE
docs(module.json): declare uiUrl: "/agent" (parachute-patterns#52)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -6,6 +6,7 @@
   "kind": "frontend",
   "port": 1944,
   "paths": ["/agent"],
+  "uiUrl": "/agent",
   "health": "/api/health",
   "startCmd": ["bun", "src/index.ts"],
   "scopes": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to parachute-agent will be documented in this file.
 
+## [0.1.4-rc.2] - 2026-05-10
+
+### Added
+
+- **`uiUrl: "/agent"` in `.parachute/module.json` (parachute-patterns#52).** Adopt the [`module-ui-declaration`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md) convention — services declare their user-facing UI URL in `module.json`, and hub's discovery page renders one tile per declaring service. Agent's UI (combining run + config + admin) lives at `/agent`, so the field mirrors the existing `paths[0]`. Pairs with `parachute-notes` (already declares `uiUrl: "/notes"`); vault and scribe stay absent until each grows a UI surface. Step 2 of the cross-repo adoption sequence (patterns convention defined → modules declare → hub consumer-side reads). Backwards-compatible: hub before its consumer-side update simply ignores the new field; nothing else in the agent repo reads it today.
+
 ## [0.1.4-rc.1] - 2026-05-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.4-rc.1",
+  "version": "0.1.4-rc.2",
   "description": "Parachute Agent — per-session containerized AI agent companion.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Declares `uiUrl: "/agent"` in `.parachute/module.json`, adopting the [`module-ui-declaration`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md) pattern just merged at parachute-patterns#52.
- Step 2 of the cross-repo adoption sequence: patterns convention defined → modules declare → hub consumer-side reads. Pairs with `parachute-notes` (already declares `uiUrl: "/notes"`).
- Bumps to `0.1.4-rc.2` per RC-versioning convention.

## Why

Hub's discovery page today hardcodes which services have UIs in a `SERVICE_LABELS` map at the top of `parachute-hub/src/hub.ts`. The pattern retires that hardcoding by having services declare their own UI URLs; hub renders one tile per declaring service. Agent's UI (run + config + admin combined) lives at `/agent`, so the field mirrors the existing `paths[0]`.

## Backwards-compatibility

Hub before its consumer-side update simply ignores the new field. Nothing else in the agent repo reads `uiUrl` today — the well-known passthrough in `src/web/server.ts` does not currently forward it; that's a follow-up question for whichever side (agent vs. hub) ends up reading the canonical source. The team-lead's scope here was deliberately tight: declare the field, ship, sequence the consumer wiring separately.

## Test plan

- [x] Existing test suite (642 tests across 65 files) still passes — no module.json validation tests, but server.ts well-known-emit code path is covered by `services-manifest.test.ts` and `server-version.test.ts`.
- [ ] Hub follow-up: well-known passthrough + discovery-page consumer (separate PR, both repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)