### PR TITLE
docs(agent): deprecation notice — README banner + DEPRECATED.md

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -24,12 +24,12 @@ Don't install parachute-agent. Instead:
    token = os.environ["PARACHUTE_VAULT_TOKEN"]
    hub = os.environ["PARACHUTE_HUB_URL"]
    # Fetch your job notes via vault REST
-   # For each one, spawn: claude -p --mcp-config "$(parachute-vault mcp-config <name>)" ...
+   # For each one, spawn: claude -p --mcp-config '<json>' ...  # construct the JSON manually, or use 'parachute-vault mcp-config <name>' (vault 0.4.6+)
    # Write outputs back via vault REST
    ```
 4. `crontab -e` to schedule it.
 
-The `parachute-vault mcp-config <name>` CLI (vault 0.4.6-rc.5+) gives you the inline MCP config JSON, eliminating boilerplate.
+Vault 0.4.6 ships a `parachute-vault mcp-config <name>` CLI that emits the MCP config JSON for you, eliminating boilerplate — until it's on `@latest`, you can construct the JSON manually.
 
 ### If you're running a hosted multi-tenant scenario (untrusted prompts, sandbox isolation)
 
@@ -38,8 +38,15 @@ The container-isolation architecture is genuinely valuable here. parachute-cloud
 ## Status
 
 - No new features. Bugfixes only.
-- npm deprecate warning on install (after Aaron runs `npm deprecate ...`).
+- npm deprecate warning on install (after Aaron runs the command below).
 - Existing installs continue working. Nothing has been unpublished. Roll back to a specific version if needed.
+
+The deprecation command (for Aaron — copy-paste, kept under 80 chars so npm install doesn't wrap awkwardly):
+
+```bash
+npm deprecate @openparachute/agent "Deprecated 2026-05-20. Use cron + claude -p instead. See repo DEPRECATED.md"
+```
+
 - `@latest` and `@rc` tags maintained for now.
 - Retirement timeline: when `parachute-jobs` (TBD module) ships AND has been stable for 1-2 months, parachute-agent moves out of the committed-core list entirely. This is expected in Q3 2026.
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,59 @@
+# parachute-agent — deprecated 2026-05-20
+
+## Why this module is deprecated
+
+parachute-agent shipped a "Claude in containers" architecture: each agent task runs in an isolated container, with image-per-project, supervisor-managed lifecycle, network policy. The intent was a safe runtime for arbitrary Claude work against a vault.
+
+In practice, that architecture solves problems most operators don't have:
+
+- **The container isolation matters when you don't trust the prompts.** For owner-operated vaults where the operator wrote the prompts AND owns the vault, the trust gradient is flat — there's nothing to isolate from.
+- **The complexity cost is real.** Docker images, container lifecycle, slug-keyed image names, supervisor coordination — all of this is operational surface that owner-operators don't want to manage.
+- **A simpler primitive does the job.** A ~200-line Python runner that spawns `claude -p` with `--mcp-config '<json>'` against the vault, scheduled by cron, handles the common case completely. The Gitcoin Brain (2026-05) prototype proves this.
+
+## Migration
+
+### If you're running an owner-operated automation use case
+
+Don't install parachute-agent. Instead:
+
+1. Install `@openparachute/vault` and `@openparachute/hub` per the [main install guide](https://parachute.computer/install/).
+2. Mint an operator token: `parachute-vault tokens create --scope vault:<name>:write`.
+3. Write a small runner script. Pattern:
+   ```python
+   import subprocess, json, requests
+   token = os.environ["PARACHUTE_VAULT_TOKEN"]
+   hub = os.environ["PARACHUTE_HUB_URL"]
+   # Fetch your job notes via vault REST
+   # For each one, spawn: claude -p --mcp-config "$(parachute-vault mcp-config <name>)" ...
+   # Write outputs back via vault REST
+   ```
+4. `crontab -e` to schedule it.
+
+The `parachute-vault mcp-config <name>` CLI (vault 0.4.6-rc.5+) gives you the inline MCP config JSON, eliminating boilerplate.
+
+### If you're running a hosted multi-tenant scenario (untrusted prompts, sandbox isolation)
+
+The container-isolation architecture is genuinely valuable here. parachute-cloud (TBD) will provide this as a hosted service. Until parachute-cloud ships, you can continue using parachute-agent — but expect no new features.
+
+## Status
+
+- No new features. Bugfixes only.
+- npm deprecate warning on install (after Aaron runs `npm deprecate ...`).
+- Existing installs continue working. Nothing has been unpublished. Roll back to a specific version if needed.
+- `@latest` and `@rc` tags maintained for now.
+- Retirement timeline: when `parachute-jobs` (TBD module) ships AND has been stable for 1-2 months, parachute-agent moves out of the committed-core list entirely. This is expected in Q3 2026.
+
+## What replaces it
+
+`parachute-jobs` (TBD module) will provide the lightweight runner pattern with:
+
+- Vault notes tagged `job` as the unit of work
+- Cron / launchd / systemd integration for scheduling
+- Light sandboxing via subprocess isolation + env scrubbing + restricted PATH (NOT containers)
+- Subscription-funded inference (claude CLI), not API-billed per request
+
+Design doc: TBD at `parachute.computer/design/2026-xx-parachute-jobs.md` once Gitcoin Brain pattern has run long enough to inform the spec.
+
+## Questions / issues
+
+File at https://github.com/ParachuteComputer/parachute-agent/issues — Aaron will respond.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # parachute-agent
 
+> [!CAUTION]
+> **`@openparachute/agent` is deprecated as of 2026-05-20.**
+>
+> Most users should NOT install this module. The "Claude in containers" architecture proved too heavy for the owner-operated, trusted-vault use case it was built for. A simpler primitive — a cron-scheduled Python runner that spawns `claude -p` with inline MCP config against your vault — handles 90% of the actual use cases at a fraction of the complexity.
+>
+> **What to use instead:**
+> - **For owner-operated automation**: write a small runner script. See the [Gitcoin Brain pattern](https://github.com/unforced-dev/gitcoin-brain) (TBD link — may not be public) or roll your own ~200-line Python+cron equivalent. The new `parachute-vault mcp-config <name>` CLI gives you the inline MCP config JSON for free.
+> - **For hosted multi-tenant or untrusted prompts**: parachute-agent's container isolation IS the right shape — but this scenario will be served by `parachute-cloud` (TBD), not by self-hosting `@openparachute/agent` directly.
+> - **For experimentation**: this repo and module remain installable; nothing's been removed. Read [DEPRECATED.md](./DEPRECATED.md) for the full rationale.
+
+(The rest of the README is below for historical reference.)
+
+---
+
 <p align="center">
   An AI assistant that runs agents securely in their own containers. Lightweight, built to be easily understood and completely customized for your needs. A [Parachute](https://parachute.computer) module.
 </p>

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 > Most users should NOT install this module. The "Claude in containers" architecture proved too heavy for the owner-operated, trusted-vault use case it was built for. A simpler primitive — a cron-scheduled Python runner that spawns `claude -p` with inline MCP config against your vault — handles 90% of the actual use cases at a fraction of the complexity.
 >
 > **What to use instead:**
-> - **For owner-operated automation**: write a small runner script. See the [Gitcoin Brain pattern](https://github.com/unforced-dev/gitcoin-brain) (TBD link — may not be public) or roll your own ~200-line Python+cron equivalent. The new `parachute-vault mcp-config <name>` CLI gives you the inline MCP config JSON for free.
+> - **For owner-operated automation**: write a small runner script. See the Gitcoin Brain (2026-05) pattern — a small Python+cron runner that proves the lightweight model. The `parachute-vault mcp-config <name>` CLI (vault 0.4.6+) gives you the inline MCP config JSON for free; until it's on `@latest`, you can construct the JSON manually.
 > - **For hosted multi-tenant or untrusted prompts**: parachute-agent's container isolation IS the right shape — but this scenario will be served by `parachute-cloud` (TBD), not by self-hosting `@openparachute/agent` directly.
 > - **For experimentation**: this repo and module remain installable; nothing's been removed. Read [DEPRECATED.md](./DEPRECATED.md) for the full rationale.
 
-(The rest of the README is below for historical reference.)
+(The original README follows.)
 
 ---
 


### PR DESCRIPTION
## Summary

Aaron is phasing out parachute-agent in favor of a future lightweight `parachute-jobs` module. The Gitcoin Brain prototype (2026-05) proved that for owner-operated, trusted-vault use cases, a ~200-line Python runner spawning `claude -p` with inline MCP config handles 90% of what people actually want at a fraction of parachute-agent's complexity. Container isolation only pays off when prompts aren't trusted (hosted multi-tenant) — and that scenario will be served by parachute-cloud (TBD), not by self-hosting.

This PR is the first step in a staged retirement. It surfaces the deprecation publicly (README banner + dedicated `DEPRECATED.md`) without removing anything. Subsequent steps (Aaron's hand): `npm deprecate @openparachute/agent "..."`, then eventually moving out of committed-core once parachute-jobs has been stable 1-2 months.

## What this PR does

- **README.md**: Adds a GitHub `CAUTION` admonition banner at the very top of the file. Surfaces the deprecation, what to use instead (owner-operated runner pattern citing the new `parachute-vault mcp-config <name>` CLI; parachute-cloud for multi-tenant), and links to `DEPRECATED.md`. Existing README content preserved verbatim below an `---`.
- **DEPRECATED.md**: New file at repo root. Full rationale (trust gradient is flat for owner-operators; complexity cost is real; simpler primitive does the job). Migration paths for both owner-operated and hosted multi-tenant scenarios, with a Python runner stub showing the pattern. Status (no new features, bugfixes only, existing installs keep working, npm tags maintained). Retirement timeline tied to parachute-jobs maturity (~Q3 2026).

## What this PR does NOT do

- No code changes — module stays fully installable. \`parachute install parachute-agent\` still works.
- No version bump — doc-only, per the doc-only-skip-rc rule (governance rule 2).
- No CHANGELOG entry — the README banner IS the announcement.
- No \`npm deprecate\` — Aaron runs that from his shell after merge (npm publishes are Aaron's job; this just falls under that).
- No GitHub repo archive — keep the repo open for any final commenters and for ongoing bugfixes.

## Cross-references

- Gitcoin Brain pattern design: \`~/Gitcoin/mirrormirror/gitcoin_brain_design/for_parachute_round_4.md\` (Aaron's local notes; not yet upstreamed)
- vault#345 — \`parachute-vault mcp-config <name>\` CLI that the new runner pattern depends on
- parachute-jobs design doc: TBD at \`parachute.computer/design/2026-xx-parachute-jobs.md\`, written after Gitcoin Brain pattern has run long enough to inform the spec

## Test plan

- [x] \`pnpm run build\` (tsc) passes
- [x] No source files modified — \`git diff --stat main\` shows only README.md + new DEPRECATED.md
- [ ] Reviewer checks the README banner renders correctly on the GitHub web UI (CAUTION admonition syntax)
- [ ] Reviewer confirms migration steps in DEPRECATED.md make sense for someone landing fresh on the repo